### PR TITLE
Add support for Slice primitives.

### DIFF
--- a/slicec-cs/src/cs_util.rs
+++ b/slicec-cs/src/cs_util.rs
@@ -1,7 +1,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 use slice::ast::Node;
-use slice::grammar::Builtin;
+use slice::grammar::Primitive;
 
 pub fn type_to_string(node: &Node) -> String {
     match node {
@@ -13,10 +13,23 @@ pub fn type_to_string(node: &Node) -> String {
             let mut identifier = interface_def.scope.as_ref().unwrap().clone() + "::" + interface_def.identifier();
             identifier.drain(2..).collect::<String>().replace("::", ".")
         },
-        Node::Builtin(_, builtin) => {
-            match builtin {
-                Builtin::Int => { "int" },
-                Builtin::String => { "string" },
+        Node::Primitive(_, primitive) => {
+            match primitive {
+                Primitive::Bool     => "bool",
+                Primitive::Byte     => "byte",
+                Primitive::Short    => "short",
+                Primitive::UShort   => "ushort",
+                Primitive::Int      => "int",
+                Primitive::UInt     => "uint",
+                Primitive::VarInt   => "int",
+                Primitive::VarUInt  => "uint",
+                Primitive::Long     => "long",
+                Primitive::ULong    => "ulong",
+                Primitive::VarLong  => "long",
+                Primitive::VarULong => "ulong",
+                Primitive::Float    => "float",
+                Primitive::Double   => "double",
+                Primitive::String   => "string",
             }.to_owned()
         },
         _ => {

--- a/slicec-cs/src/cs_writer.rs
+++ b/slicec-cs/src/cs_writer.rs
@@ -41,7 +41,7 @@ impl Visitor for CsWriter {
 
     fn visit_module_end(&mut self, _: &Module, _: usize, _: &Ast) {
         self.output.indent_by(-4);
-        let content = "}}\n\n".to_owned();
+        let content = "}\n\n".to_owned();
         self.output.write_all(content.as_bytes());
     }
 
@@ -54,7 +54,7 @@ impl Visitor for CsWriter {
 
     fn visit_struct_end(&mut self, _: &Struct, _: usize, _: &Ast) {
         self.output.indent_by(-4);
-        let content = "}}\n\n".to_owned();
+        let content = "}\n\n".to_owned();
         self.output.write_all(content.as_bytes());
     }
 
@@ -67,7 +67,7 @@ impl Visitor for CsWriter {
 
     fn visit_interface_end(&mut self, _: &Interface, _: usize, _: &Ast) {
         self.output.indent_by(-4);
-        let content = "}}\n\n".to_owned();
+        let content = "}\n\n".to_owned();
         self.output.write_all(content.as_bytes());
     }
 

--- a/slicec/src/ast.rs
+++ b/slicec/src/ast.rs
@@ -12,7 +12,7 @@ pub enum Node {
     Struct(usize, Struct),
     Interface(usize, Interface),
     DataMember(usize, DataMember),
-    Builtin(usize, Builtin),
+    Primitive(usize, Primitive),
 }
 
 impl Node {
@@ -34,7 +34,7 @@ impl Node {
         match self {
             Self::Struct(_, struct_def)       => Some(struct_def),
             Self::Interface(_, interface_def) => Some(interface_def),
-            Self::Builtin(_, builtin)         => Some(builtin),
+            Self::Primitive(_, primitive)     => Some(primitive),
             _ => None,
         }
     }
@@ -47,7 +47,7 @@ impl Node {
             Self::Struct(_, _)     => std::any::TypeId::of::<Struct>(),
             Self::Interface(_, _)  => std::any::TypeId::of::<Interface>(),
             Self::DataMember(_, _) => std::any::TypeId::of::<DataMember>(),
-            Self::Builtin(_, _)    => std::any::TypeId::of::<Builtin>(),
+            Self::Primitive(_, _)  => std::any::TypeId::of::<Primitive>(),
         }
     }
 }
@@ -74,7 +74,7 @@ implement_into_node_for!(Module, Node::Module);
 implement_into_node_for!(Struct, Node::Struct);
 implement_into_node_for!(Interface, Node::Interface);
 implement_into_node_for!(DataMember, Node::DataMember);
-implement_into_node_for!(Builtin, Node::Builtin);
+implement_into_node_for!(Primitive, Node::Primitive);
 
 /// The Abstract Syntax Tree is where all slice grammar elements are stored, directly or indirectly.
 ///

--- a/slicec/src/grammar.rs
+++ b/slicec/src/grammar.rs
@@ -151,17 +151,43 @@ impl TypeRef {
 }
 
 #[derive(Clone, Eq, Hash, PartialEq, Debug)]
-pub enum Builtin {
+pub enum Primitive {
+    Bool,
+    Byte,
+    Short,
+    UShort,
     Int,
+    UInt,
+    VarInt,
+    VarUInt,
+    Long,
+    ULong,
+    VarLong,
+    VarULong,
+    Float,
+    Double,
     String,
 }
 
-impl Type for Builtin {}
+impl Type for Primitive {}
 
-impl From<&str> for Builtin {
+impl From<&str> for Primitive {
     fn from(s: &str) -> Self {
         match s {
+            "bool" => Self::Bool,
+            "byte" => Self::Byte,
+            "short" => Self::Short,
+            "ushort" => Self::UShort,
             "int" => Self::Int,
+            "uint" => Self::UInt,
+            "varint" => Self::VarInt,
+            "varuint" => Self::VarUInt,
+            "long" => Self::Long,
+            "ulong" => Self::ULong,
+            "varlong" => Self::VarLong,
+            "varulong" => Self::VarULong,
+            "float" => Self::Float,
+            "double" => Self::Double,
             "string" => Self::String,
             _ => panic!("`{}` is not a valid builtin type!", s),
         }

--- a/slicec/src/parser.rs
+++ b/slicec/src/parser.rs
@@ -243,15 +243,15 @@ impl SliceParser {
             [global_identifier(identifier)] => {
                 // Nothing to do, we wait until after we've generated a lookup table to patch user defined types.
             },
-            [builtin_type(builtin)] => {
+            [primitive_type(primitive)] => {
                 let user_data = &mut input.user_data().borrow_mut();
-                type_use.definition = Some(construct_type::<Builtin>(user_data, &type_use.type_name));
+                type_use.definition = Some(construct_type::<Primitive>(user_data, &type_use.type_name));
             }
         );
         Ok(type_use)
     }
 
-    fn builtin_type(input: PestNode) -> PestResult<()> {
+    fn primitive_type(input: PestNode) -> PestResult<()> {
         Ok(())
     }
 
@@ -267,7 +267,59 @@ impl SliceParser {
         Ok(())
     }
 
+    fn bool_kw(input: PestNode) -> PestResult<()> {
+        Ok(())
+    }
+
+    fn byte_kw(input: PestNode) -> PestResult<()> {
+        Ok(())
+    }
+
+    fn short_kw(input: PestNode) -> PestResult<()> {
+        Ok(())
+    }
+
+    fn ushort_kw(input: PestNode) -> PestResult<()> {
+        Ok(())
+    }
+
     fn int_kw(input: PestNode) -> PestResult<()> {
+        Ok(())
+    }
+
+    fn uint_kw(input: PestNode) -> PestResult<()> {
+        Ok(())
+    }
+
+    fn varint_kw(input: PestNode) -> PestResult<()> {
+        Ok(())
+    }
+
+    fn varuint_kw(input: PestNode) -> PestResult<()> {
+        Ok(())
+    }
+
+    fn long_kw(input: PestNode) -> PestResult<()> {
+        Ok(())
+    }
+
+    fn ulong_kw(input: PestNode) -> PestResult<()> {
+        Ok(())
+    }
+
+    fn varlong_kw(input: PestNode) -> PestResult<()> {
+        Ok(())
+    }
+
+    fn varulong_kw(input: PestNode) -> PestResult<()> {
+        Ok(())
+    }
+
+    fn float_kw(input: PestNode) -> PestResult<()> {
+        Ok(())
+    }
+
+    fn double_kw(input: PestNode) -> PestResult<()> {
         Ok(())
     }
 

--- a/slicec/src/slice.pest
+++ b/slicec/src/slice.pest
@@ -20,13 +20,26 @@ scoped_identifier = @{ identifier ~ ( "::" ~ identifier )* }
 global_identifier = @{ ( "::" ~ identifier )+ }
 
 typename = {
-    builtin_type      |
+    primitive_type      |
     scoped_identifier |
     global_identifier
 }
 
-builtin_type = {
-    int_kw    |
+primitive_type = {
+    bool_kw     |
+    byte_kw     |
+    short_kw    |
+    ushort_kw   |
+    int_kw      |
+    uint_kw     |
+    varint_kw   |
+    varuint_kw  |
+    long_kw     |
+    ulong_kw    |
+    varlong_kw  |
+    varulong_kw |
+    float_kw    |
+    double_kw   |
     string_kw
 }
 
@@ -35,5 +48,19 @@ WHITESPACE = _{ " " | "\t" | NEWLINE }
 module_kw = { "module" }
 struct_kw = { "struct" }
 interface_kw = { "interface" }
+
+bool_kw = { "bool" }
+byte_kw = { "byte" }
+short_kw = { "short" }
+ushort_kw = { "ushort" }
 int_kw = { "int" }
+uint_kw = { "uint" }
+varint_kw = { "varint" }
+varuint_kw = { "varuint" }
+long_kw = { "long" }
+ulong_kw = { "ulong" }
+varlong_kw = { "varlong" }
+varulong_kw = { "varulong" }
+float_kw = { "float" }
+double_kw = { "double" }
 string_kw = { "string" }


### PR DESCRIPTION
This small PR adds supports for all the remaining Slice primitives `(bool, short, ushort, uint, varint, varuint, long, ulong, varlong, varulong, float, and double`), `int` and `string` were already implemented.