### PR TITLE
Added parser support for metadata directives.

### DIFF
--- a/slicec/src/slice.pest
+++ b/slicec/src/slice.pest
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-main = { SOI ~ file_metadata ~ module_def* ~ EOI }
+main = { SOI ~ file_attributes ~ module_def* ~ EOI }
 
 definition = { module_def | struct_def | interface_def | enum_def }
 
@@ -61,18 +61,18 @@ primitive = {
     string_kw
 }
 
-prelude = { local_metadata ~ doc_comment ~ local_metadata }
+prelude = { local_attributes ~ doc_comment ~ local_attributes }
 
-file_metadata = { ("[[" ~ metadata ~ "]]")* }
-local_metadata = { ("[" ~ metadata ~ "]")* }
-metadata = { metadata_directive ~ ( "(" ~ metadata_arguments? ~ ")" )? }
-metadata_directive = { metadata_identifier ~ (":" ~ metadata_identifier)? }
-metadata_identifier = { (ASCII_ALPHANUMERIC | "_" | "-")+ }
-metadata_argument = {
+file_attributes = { ("[[" ~ attribute ~ "]]")* }
+local_attributes = { ("[" ~ attribute ~ "]")* }
+attribute = { attribute_directive ~ ( "(" ~ attribute_arguments? ~ ")" )? }
+attribute_directive = { attribute_identifier ~ (":" ~ attribute_identifier)? }
+attribute_identifier = { (ASCII_ALPHANUMERIC | "_" | "-")+ }
+attribute_argument = {
     "\"" ~ (!"\"" ~ ANY)* ~ "\"" |          // Add support for escaped characters in the future.
     (ASCII_ALPHANUMERIC | "_" | "-" | ":" | "<" | ">")+
 }
-metadata_arguments = { ( metadata_argument ~ "," ~ metadata_arguments) | ( metadata_argument ~ ","? ) }
+attribute_arguments = { ( attribute_argument ~ "," ~ attribute_arguments) | ( attribute_argument ~ ","? ) }
 
 // "WHITESPACE" and "COMMENT" are special rules that Pest will implicitely allow to appear in between any other rules.
 WHITESPACE = _{ " " | "\t" | NEWLINE }

--- a/slicec/src/util.rs
+++ b/slicec/src/util.rs
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-use crate::grammar::Metadata;
+use crate::grammar::Attribute;
 use std::path::Path;
 
 /// Describes a single position, or a span over two positions in a slice file.
@@ -27,8 +27,8 @@ pub struct SliceFile {
     /// The AST indices of all the top-level definitions contained in the slice file,
     /// in the order they were defined.
     pub contents: Vec<usize>,
-    /// Stores any file metadata defined in the file.
-    pub metadata: Vec<Metadata>,
+    /// Stores any file attribute defined on the file.
+    pub attributes: Vec<Attribute>,
     /// True if the slice file is a source file (which code should be generated for),
     /// or false if it's a reference file.
     pub is_source: bool,
@@ -43,7 +43,7 @@ impl SliceFile {
         relative_path: String,
         raw_text: String,
         contents: Vec<usize>,
-        metadata: Vec<Metadata>,
+        attributes: Vec<Attribute>,
         is_source: bool,
     ) -> Self {
         // Store the starting position of each line the file.
@@ -72,7 +72,7 @@ impl SliceFile {
         // Extract the name of the slice file without its extension.
         let filename = Path::new(&relative_path).file_stem().unwrap().to_os_string().into_string().unwrap();
 
-        SliceFile { filename, relative_path, raw_text, contents, metadata, is_source, line_positions }
+        SliceFile { filename, relative_path, raw_text, contents, attributes, is_source, line_positions }
     }
 
     /// Retrieves a formatted snippet from the slice file. This method expects `start < end`.


### PR DESCRIPTION
This adds support for 3.7-style metadata directives (both local and file level) to the new compiler.

Due to `pest_consume`'s limited functionality, there's no way to arbitrarily mix local metadata and doc comments:
```
/// this will
[cs:namespace(foo)]
/// be a syntax error
module something { ... }
```
This can be fixed when we switch from using `pest_consume` to the low-level API built in to Pest.