### PR TITLE
Error reporting takes location by reference now.

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -30,7 +30,7 @@ impl ErrorReporter {
 
     pub fn report_error(&mut self,
         message: String,
-        location: Option<Location>,
+        location: Option<&Location>,
         severity: ErrorLevel)
     {
         match severity {
@@ -41,7 +41,7 @@ impl ErrorReporter {
                 //TODO:  Report the error and exit immediately.
             }
         };
-        self.errors.push(Error { message, location, severity })
+        self.errors.push(Error { message, location: location.cloned(), severity })
     }
 
     /// Writes the errors stored in the handler to stderr, along with any locations and snippets.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,23 +39,23 @@ pub unsafe fn borrow_mut_ast() -> &'static mut Ast {
     &mut *global_state::AST.get().unwrap().get()
 }
 
-pub fn report_note(message: String, location: Option<Location>) {
+pub fn report_note(message: String, location: Option<&Location>) {
     report_error_impl(message, location, ErrorLevel::Note);
 }
 
-pub fn report_warning(message: String, location: Option<Location>) {
+pub fn report_warning(message: String, location: Option<&Location>) {
     report_error_impl(message, location, ErrorLevel::Warning);
 }
 
-pub fn report_error(message: String, location: Option<Location>) {
+pub fn report_error(message: String, location: Option<&Location>) {
     report_error_impl(message, location, ErrorLevel::Error);
 }
 
-pub fn report_critical(message: String, location: Option<Location>) {
+pub fn report_critical(message: String, location: Option<&Location>) {
     report_error_impl(message, location, ErrorLevel::Critical);
 }
 
-fn report_error_impl(message: String, location: Option<Location>, severity: ErrorLevel) {
+fn report_error_impl(message: String, location: Option<&Location>, severity: ErrorLevel) {
     let error_reporter = unsafe { &mut *global_state::ERROR_REPORTER.get().unwrap().get() };
     error_reporter.report_error(message, location, severity);
 }

--- a/src/parser/type_patcher.rs
+++ b/src/parser/type_patcher.rs
@@ -124,7 +124,7 @@ impl<'ast> TypePatcher<'ast> {
         crate::report_error(format!(
             "No entity with the identifier '{}' could be found in this scope.",
             &type_ref.type_string,
-        ), Some(type_ref.location().clone())); //TODO make it take a location by reference.
+        ), Some(type_ref.location()));
     }
 
     fn resolve_typed_definition<T: Element + 'static>(&self, type_ref: &mut TypeRef<T>) {
@@ -145,13 +145,13 @@ impl<'ast> TypePatcher<'ast> {
                 crate::report_error(format!(
                     "The Entity '{}' is not a valid type for this definition.",
                     &type_ref.type_string,
-                ), Some(type_ref.location().clone())); //TODO make it take a location by reference.
+                ), Some(type_ref.location()));
             }
         } else {
             crate::report_error(format!(
                 "No entity with the identifier '{}' could be found in this scope.",
                 &type_ref.type_string,
-            ), Some(type_ref.location().clone())); //TODO make it take a location by reference.
+            ), Some(type_ref.location()));
         }
     }
 }


### PR DESCRIPTION
This tiny PR changes the error reporting to take `Location`s by reference, so we don't always need to `.clone()` them.
I'll open a PR for slicec-cs to take advantage of this in a little.