### PR TITLE
Add Support for Compact Structs

### DIFF
--- a/src/grammar/slice.rs
+++ b/src/grammar/slice.rs
@@ -66,6 +66,7 @@ implement_Container_for!(Module, Definition, contents);
 pub struct Struct {
     pub identifier: Identifier,
     pub members: Vec<OwnedPtr<DataMember>>,
+    pub is_compact: bool,
     pub parent: WeakPtr<Module>,
     pub scope: Scope,
     pub attributes: Vec<Attribute>,
@@ -76,6 +77,7 @@ pub struct Struct {
 impl Struct {
     pub(crate) fn new(
         identifier: Identifier,
+        is_compact: bool,
         scope: Scope,
         attributes: Vec<Attribute>,
         comment: Option<DocComment>,
@@ -83,7 +85,7 @@ impl Struct {
     ) -> Self {
         let members = Vec::new();
         let parent = WeakPtr::create_uninitialized();
-        Struct { identifier, members, parent, scope, attributes, comment, location }
+        Struct { identifier, members, is_compact, parent, scope, attributes, comment, location }
     }
 
     pub(crate) fn add_member(&mut self, member: DataMember) {
@@ -443,7 +445,7 @@ impl Operation {
     ) -> Self {
         let parameters = Vec::new();
         let parent = WeakPtr::create_uninitialized();
-        Operation { identifier, return_type, is_idempotent, parameters, parent, scope, attributes, comment, location }
+        Operation { identifier, return_type, parameters, is_idempotent, parent, scope, attributes, comment, location }
     }
 
     pub(crate) fn add_parameter(&mut self, parameter: Parameter) {

--- a/src/parser/slice.pest
+++ b/src/parser/slice.pest
@@ -9,7 +9,7 @@ definition = { module_def | struct_def | class_def | exception_def | interface_d
 module_start = ${ module_kw ~ ws+ ~ scoped_identifier }
 module_def = !{ prelude ~ module_start ~ "{" ~ definition* ~ "}" }
 
-struct_start = ${ struct_kw ~ ws+ ~ identifier }
+struct_start = ${ compact_modifier ~ struct_kw ~ ws+ ~ identifier }
 struct_def = !{ prelude ~ struct_start ~ "{" ~ data_member_list ~ "}" }
 
 class_start = ${ class_kw ~ ws+ ~ identifier ~ compact_id ~ ( ws* ~ extends_kw ~ ws* ~ inheritance_list)? }
@@ -103,6 +103,7 @@ integer = @{ "-"? ~ ASCII_DIGIT+ }
 
 compact_id = { ("(" ~ integer ~ ")")? }
 stream_modifier = ${ (stream_kw ~ ws+)? }
+compact_modifier = { (compact_kw ~ ws+)? }
 idempotent_modifier = { (idempotent_kw ~ ws+)? }
 unchecked_modifier = { (unchecked_kw ~ ws+)? }
 
@@ -137,5 +138,6 @@ any_class_kw = { "AnyClass" ~ !ASCII_ALPHA }
 tag_kw = { "tag" ~ !ASCII_ALPHA }
 stream_kw = { "stream" ~ !ASCII_ALPHA }
 extends_kw = { ":" }
+compact_kw = { "compact" ~ !ASCII_ALPHA }
 idempotent_kw = { "idempotent" ~ !ASCII_ALPHA }
 unchecked_kw = { "unchecked" ~ !ASCII_ALPHA }


### PR DESCRIPTION
This PR adds support for compact structs to the grammar and parser.
Code-gen support will need to be added after it's acceptance.

The syntax for compact structs is:
```
compact struct Foo { ... }
```
vs declaring a normal struct:
```
struct Foo { ... }
```