### PR TITLE
Make interface bit sequence encodable

### DIFF
--- a/src/grammar/slice.rs
+++ b/src/grammar/slice.rs
@@ -890,8 +890,9 @@ impl<T: Type + ?Sized> TypeRef<T> {
     pub fn min_wire_size(&self) -> u32 {
         if self.is_optional {
             match self.definition().concrete_type() {
-                // TODO explain why classes and interfaces still take up 1 byte.
-                Types::Class(_) | Types::Interface(_) => 1,
+                // TODO explain why still take up 1 byte.
+                // TODO this is not totally correct the min_wire_size of a optional interface depends on the encoding
+                Types::Class(_) => 1,
                 Types::Primitive(primitive) if matches!(primitive, Primitive::AnyClass) => 1,
                 _ => 0,
             }


### PR DESCRIPTION
This PR changes interface/proxy to use a bit sequence for the optional, like other 2.0 encoded optional. See https://github.com/zeroc-ice/icerpc-csharp/pull/781