### PR TITLE
Renamed Slice primitive integers

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -74,8 +74,8 @@ impl Ast {
             ("uint64", OwnedPtr::new(Primitive::UInt64)),
             ("varint62", OwnedPtr::new(Primitive::VarInt62)),
             ("varuint62", OwnedPtr::new(Primitive::VarUInt62)),
-            ("float", OwnedPtr::new(Primitive::Float)),
-            ("double", OwnedPtr::new(Primitive::Double)),
+            ("float32", OwnedPtr::new(Primitive::Float32)),
+            ("float64", OwnedPtr::new(Primitive::Float64)),
             ("string", OwnedPtr::new(Primitive::String)),
             ("AnyClass", OwnedPtr::new(Primitive::AnyClass)),
         ]);

--- a/src/grammar/slice.rs
+++ b/src/grammar/slice.rs
@@ -1208,8 +1208,8 @@ pub enum Primitive {
     UInt64,
     VarInt62,
     VarUInt62,
-    Float,
-    Double,
+    Float32,
+    Float64,
     String,
     AnyClass,
 }
@@ -1219,7 +1219,7 @@ impl Primitive {
         matches!(self,
             Self::UInt8 | Self::Int16 | Self::UInt16 | Self::Int32 | Self::UInt32 | Self::VarInt32 |
             Self::VarUInt32 | Self::Int64 | Self::UInt64 | Self::VarInt62 | Self::VarUInt62 |
-            Self::Float | Self::Double
+            Self::Float32 | Self::Float64
         )
     }
 
@@ -1239,7 +1239,7 @@ impl Type for Primitive {
     fn is_fixed_size(&self) -> bool {
         matches!(self,
             Self::Bool | Self::UInt8 | Self::Int16 | Self::UInt16 | Self::Int32 | Self::UInt32 |
-            Self::Int64 | Self::UInt64 | Self::Float | Self::Double
+            Self::Int64 | Self::UInt64 | Self::Float32 | Self::Float64
         )
     }
 
@@ -1257,8 +1257,8 @@ impl Type for Primitive {
             Self::UInt64 => 8,
             Self::VarInt62 => 1,
             Self::VarUInt62 => 1,
-            Self::Float => 4,
-            Self::Double => 8,
+            Self::Float32 => 4,
+            Self::Float64 => 8,
             Self::String => 1, // At least 1 byte for the empty string.
             Self::AnyClass => 1, // At least 1 byte to encode an index (instead of an instance).
         }
@@ -1286,8 +1286,8 @@ impl Type for Primitive {
             Self::UInt64    => TagFormat::F8,
             Self::VarInt62  => TagFormat::VInt,
             Self::VarUInt62 => TagFormat::VInt,
-            Self::Float     => TagFormat::F4,
-            Self::Double    => TagFormat::F8,
+            Self::Float32   => TagFormat::F4,
+            Self::Float64   => TagFormat::F8,
             Self::String    => TagFormat::OVSize,
             Self::AnyClass  => TagFormat::Class,
         }
@@ -1307,8 +1307,8 @@ impl Type for Primitive {
             Self::UInt64    => vec![Encoding::Slice2],
             Self::VarInt62  => vec![Encoding::Slice2],
             Self::VarUInt62 => vec![Encoding::Slice2],
-            Self::Float     => vec![Encoding::Slice1, Encoding::Slice2],
-            Self::Double    => vec![Encoding::Slice1, Encoding::Slice2],
+            Self::Float32   => vec![Encoding::Slice1, Encoding::Slice2],
+            Self::Float64   => vec![Encoding::Slice1, Encoding::Slice2],
             Self::String    => vec![Encoding::Slice1, Encoding::Slice2],
             Self::AnyClass  => vec![Encoding::Slice1],
         })
@@ -1330,8 +1330,8 @@ impl Element for Primitive {
             Self::UInt64 => "uint64",
             Self::VarInt62 => "varint62",
             Self::VarUInt62 => "varuint62",
-            Self::Float => "float",
-            Self::Double => "double",
+            Self::Float32 => "float32",
+            Self::Float64 => "float64",
             Self::String => "string",
             Self::AnyClass => "any class",
         }

--- a/src/grammar/util.rs
+++ b/src/grammar/util.rs
@@ -94,10 +94,10 @@ pub enum TagFormat {
     /// A fixed size numeric encoded on 2 bytes such as int16.
     F2,
 
-    /// A fixed size numeric encoded on 4 bytes such as int32 or float.
+    /// A fixed size numeric encoded on 4 bytes such as int32 or float32.
     F4,
 
-    /// A fixed size numeric encoded on 8 bytes such as int64 or double.
+    /// A fixed size numeric encoded on 8 bytes such as int64 or float64.
     F8,
 
     /// A variable-length size encoded on 1 or 5 bytes.

--- a/src/parser/slice.pest
+++ b/src/parser/slice.pest
@@ -71,8 +71,8 @@ primitive = {
     uint64_kw    |
     varint62_kw  |
     varuint62_kw |
-    float_kw     |
-    double_kw    |
+    float32_kw   |
+    float64_kw   |
     string_kw    |
     any_class_kw
 }
@@ -139,8 +139,8 @@ int64_kw = { "int64" ~ !ASCII_ALPHA }
 uint64_kw = { "uint64" ~ !ASCII_ALPHA }
 varint62_kw = { "varint62" ~ !ASCII_ALPHA }
 varuint62_kw = { "varuint62" ~ !ASCII_ALPHA }
-float_kw = { "float" ~ !ASCII_ALPHA }
-double_kw = { "double" ~ !ASCII_ALPHA }
+float32_kw = { "float32" ~ !ASCII_ALPHA }
+float64_kw = { "float64" ~ !ASCII_ALPHA }
 string_kw = { "string" ~ !ASCII_ALPHA }
 any_class_kw = { "AnyClass" ~ !ASCII_ALPHA }
 

--- a/src/parser/slice.rs
+++ b/src/parser/slice.rs
@@ -978,11 +978,11 @@ impl SliceParser {
         Ok(())
     }
 
-    fn float_kw(input: PestNode) -> PestResult<()> {
+    fn float32_kw(input: PestNode) -> PestResult<()> {
         Ok(())
     }
 
-    fn double_kw(input: PestNode) -> PestResult<()> {
+    fn float64_kw(input: PestNode) -> PestResult<()> {
         Ok(())
     }
 


### PR DESCRIPTION
This PR renames the integer primitive types as follows (per https://github.com/zeroc-ice/icerpc/issues/92):
`byte` -> `uint8`
`short` -> `int16`
`ushort` -> `uint16`

`int` -> `int32`
`uint` -> `uint32`
`varint` -> `varint32`
`varuint` -> `varuint32`

`long` -> `int64`
`ulong` -> `uint64`
`varlong` -> `varint62`
`varulong` -> `varuint62`

`float` -> `float32`
`double` -> `float64`

This doesn't add a new `int8` type. I plan to add that in my next PR. But that will be more involved.