### PR TITLE
Remove VInt

### DIFF
--- a/src/grammar/util.rs
+++ b/src/grammar/util.rs
@@ -112,9 +112,6 @@ pub enum TagFormat {
     /// Represents a class, but is no longer encoded or decoded.
     Class,
 
-    /// Pseudo non-encoded format that means one of F1, F2, F4 or F8.
-    VInt,
-
     /// Pseudo non-encoded format: like VSize but the size is optimized out.
     OVSize,
 }
@@ -130,7 +127,6 @@ impl fmt::Display for TagFormat {
             TagFormat::VSize => write!(f, "VSize"),
             TagFormat::FSize => write!(f, "FSize"),
             TagFormat::Class => write!(f, "Class"),
-            TagFormat::VInt => write!(f, "VInt"),
             TagFormat::OVSize => write!(f, "OVSize"),
         }
     }


### PR DESCRIPTION
This PR removes the VInt enumerator from TagFormat.