### PR TITLE
Modified primitives/encoding.rs to use test-case crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ pest_derive = "2.0"
 pest_consume = "1.0.6"
 structopt = "0.3.13"
 
+[dev-dependencies]
+test-case = "2.0.2"
+
 [lib]
 name = "slice"
 path = "src/lib.rs"

--- a/tests/primitives/encoding.rs
+++ b/tests/primitives/encoding.rs
@@ -5,179 +5,187 @@ use crate::helpers::parsing_helpers::parse_for_errors;
 mod slice1 {
 
     use super::*;
+    use test_case::test_case;
     const ENCODING: &str = "1";
 
     /// Verifies that if Slice 1 is used with unsupported types (int8, uint16, uint32, varint32,
     /// varuint32, uint64, varint62, and varuint62) that the compiler will produce the relevant not
     /// supported errors.
-    #[test]
-    fn unsupported_types_fail() {
+    #[test_case("int8")]
+    #[test_case("uint16")]
+    #[test_case("uint32")]
+    #[test_case("varint32")]
+    #[test_case("varuint32")]
+    #[test_case("uint64")]
+    #[test_case("varint62")]
+    #[test_case("varuint62")]
+    fn unsupported_types_fail(value: &str) {
         // Test setup
-        let type_cases = vec![
-            "int8",
-            "uint16",
-            "uint32",
-            "varint32",
-            "varuint32",
-            "uint64",
-            "varint62",
-            "varuint62",
+        let slice = &format!(
+            "
+            encoding = {encoding};
+            module Test;
+            compact struct S
+            {{
+                v: {value},
+            }}",
+            encoding = ENCODING,
+            value = value,
+        );
+
+        let expected_errors: &[&str] = &[
+            &format!("'{}' is not supported by the Slice 1 encoding", value),
+            "file encoding was set to the Slice 1 encoding here:",
         ];
 
-        for value in type_cases.iter() {
-            let errors: &[&str] = &[
-                &format!("'{}' is not supported by the Slice 1 encoding", value),
-                "file encoding was set to the Slice 1 encoding here:",
-            ];
-            test(value, errors)
-        }
+        // Act
+        let error_reporter = parse_for_errors(slice);
 
-        fn test(value: &str, expected: &[&str]) {
-            // Arrange
-            let slice = &format!(
-                "
-                encoding = {encoding};
-                module Test;
-                compact struct S
-                {{
-                    v: {value},
-                }}",
-                encoding = ENCODING,
-                value = value,
-            );
-
-            // Act
-            let error_reporter = parse_for_errors(slice);
-
-            // Assert
-            error_reporter.assert_errors(expected);
-        }
+        // Assert
+        error_reporter.assert_errors(expected_errors);
     }
 
     /// Verifies that valid Slice 1 types (bool, uint8, int16, int32, int64, float32, float64,
     /// string, and  AnyClass) will not produce any compiler errors.
-    #[test]
-    fn supported_types_succeed() {
-        // Test setup
-        let type_cases = vec![
-            "bool", "uint8", "int16", "int32", "int64", "float32", "float64", "string", "AnyClass",
-        ];
+    #[test_case("bool")]
+    #[test_case("uint8")]
+    #[test_case("int16")]
+    #[test_case("int32")]
+    #[test_case("int64")]
+    #[test_case("float32")]
+    #[test_case("float64")]
+    #[test_case("string")]
+    #[test_case("AnyClass")]
+    fn supported_types_succeed(value: &str) {
+        // Arrange
+        let slice = &format!(
+            "
+            encoding = {encoding};
+            module Test;
+            compact struct S
+            {{
+                v: {value},
+            }}",
+            encoding = ENCODING,
+            value = value,
+        );
 
-        for value in type_cases.iter() {
-            test(value)
-        }
+        // Act
+        let error_reporter = parse_for_errors(slice);
 
-        fn test(value: &str) {
-            // Arrange
-            let slice = &format!(
-                "
-                encoding = {encoding};
-                module Test;
-                compact struct S
-                {{
-                    v: {value},
-                }}",
-                encoding = ENCODING,
-                value = value,
-            );
-
-            // Act
-            let error_reporter = parse_for_errors(slice);
-
-            // Assert
-            assert!(!error_reporter.has_errors(true));
-        }
+        // Assert
+        assert!(!error_reporter.has_errors(true));
     }
 }
 
 mod slice2 {
 
     use super::*;
+    use test_case::test_case;
     const ENCODING: &str = "2";
 
     /// Verifies that if Slice 2 is used with unsupported types (AnyClass) that the compiler will
     /// produce the relevant not supported errors.
     #[test]
     fn unsupported_types_fail() {
-        // Test setup
-        let type_cases = vec!["AnyClass"];
-        for value in type_cases.iter() {
-            let errors: &[&str] = &[
-                &format!("'{}' is not supported by the Slice 2 encoding", value),
-                "file encoding was set to the Slice 2 encoding here:",
-            ];
-            test(value, errors)
-        }
+        // Arrange
+        let slice = &format!(
+            "
+            encoding = {encoding};
+            module Test;
+            compact struct S
+            {{
+                v: AnyClass,
+            }}",
+            encoding = ENCODING,
+        );
+        let expected_errors: &[&str] = &[
+            "'AnyClass' is not supported by the Slice 2 encoding",
+            "file encoding was set to the Slice 2 encoding here:",
+        ];
 
-        fn test(value: &str, expected: &[&str]) {
-            // Arrange
-            let slice = &format!(
-                "
-                encoding = {encoding};
-                module Test;
-                compact struct S
-                {{
-                    v: {value},
-                }}",
-                encoding = ENCODING,
-                value = value,
-            );
+        // Act
+        let error_reporter = parse_for_errors(slice);
 
-            // Act
-            let error_reporter = parse_for_errors(slice);
-
-            // Assert
-            error_reporter.assert_errors(expected);
-        }
+        // Assert
+        error_reporter.assert_errors(expected_errors);
     }
 
     /// Verifies that valid Slice 2 types (bool, int8, uint8, int16, uint16, int32, uint32,
     /// varint32, varuint32, int64, uint64, varint62, varuint62, float32, float64, and string) will
     /// not produce any compiler errors.
-    #[test]
-    fn supported_types_succeed() {
-        // Test setup
-        let type_cases = vec![
-            "bool",
-            "int8",
-            "uint8",
-            "int16",
-            "uint16",
-            "int32",
-            "uint32",
-            "varint32",
-            "varuint32",
-            "int64",
-            "uint64",
-            "varint62",
-            "varuint62",
-            "float32",
-            "float64",
-            "string",
-        ];
-        for value in type_cases.iter() {
-            test(value)
-        }
+    #[test_case("bool")]
+    #[test_case("int8")]
+    #[test_case("uint8")]
+    #[test_case("int16")]
+    #[test_case("uint16")]
+    #[test_case("int32")]
+    #[test_case("uint32")]
+    #[test_case("varint32")]
+    #[test_case("varuint32")]
+    #[test_case("int64")]
+    #[test_case("uint64")]
+    #[test_case("varint62")]
+    #[test_case("varuint62")]
+    #[test_case("float32")]
+    #[test_case("float64")]
+    #[test_case("string")]
+    fn supported_types_succeed(value: &str) {
+        // Arrange
+        let slice = &format!(
+            "
+            encoding = {encoding};
+            module Test;
+            compact struct S
+            {{
+                v: {value},
+            }}",
+            encoding = ENCODING,
+            value = value,
+        );
 
-        fn test(value: &str) {
-            // Arrange
-            let slice = &format!(
-                "
-                encoding = {encoding};
-                module Test;
-                compact struct S
-                {{
-                    v: {value},
-                }}",
-                encoding = ENCODING,
-                value = value,
-            );
+        // Act
+        let error_reporter = parse_for_errors(slice);
 
-            // Act
-            let error_reporter = parse_for_errors(slice);
+        // Assert
+        assert!(!error_reporter.has_errors(true));
+    }
 
-            // Assert
-            assert!(!error_reporter.has_errors(true));
-        }
+    #[test_case("uint8?")]
+    #[test_case("uint16?")]
+    #[test_case("uint32?")]
+    #[test_case("uint64?")]
+    #[test_case("int8?")]
+    #[test_case("int16?")]
+    #[test_case("int32?")]
+    #[test_case("int64?")]
+    #[test_case("varint32?")]
+    #[test_case("varuint32?")]
+    #[test_case("varint62?")]
+    #[test_case("varuint62?")]
+    #[test_case("string?")]
+    #[test_case("bool?")]
+    #[test_case("sequence<int32>?")]
+    #[test_case("float32?")]
+    #[test_case("float64?")]
+    fn supported_optional_types_succeed(value: &str) {
+        // Arrange
+        let slice = &format!(
+            "
+            encoding = {encoding};
+            module Test;
+            struct MyStruct {{
+                myVar: {value},
+            }}
+            ",
+            encoding = ENCODING,
+            value = value,
+        );
+
+        // Act
+        let error_reporter = parse_for_errors(slice);
+
+        // Assert
+        assert!(!error_reporter.has_errors(true));
     }
 }


### PR DESCRIPTION
I think using the test-case crate could lead to easier to read and more consistent tests. I have modified `primitives/encoding.rs` test to use the test-case crate. If we like it I will convert the rest of the tests done so far to this new style.