### PR TITLE
Formatting with rustfmt +nightly

### DIFF
--- a/src/grammar/traits.rs
+++ b/src/grammar/traits.rs
@@ -52,9 +52,8 @@ pub trait Attributable: Symbol {
     }
 
     fn get_attribute(&self, directive: &str, recurse: bool) -> Option<&Vec<String>> {
-        self.get_raw_attribute(directive, recurse).map(
-            |attribute| &attribute.arguments
-        )
+        self.get_raw_attribute(directive, recurse)
+            .map(|attribute| &attribute.arguments)
     }
 
     fn get_deprecated_attribute(&self, check_parent: bool) -> Option<&Vec<String>> {
@@ -160,7 +159,7 @@ macro_rules! implement_Attributable_for {
 
                 match self.parent() {
                     Some(parent) if recurse => parent.get_raw_attribute(directive, recurse),
-                    _ => None
+                    _ => None,
                 }
             }
         }
@@ -223,13 +222,8 @@ macro_rules! implement_Member_for {
     };
 }
 
-pub(crate) use implement_Element_for;
-pub(crate) use implement_Symbol_for;
-pub(crate) use implement_Named_Symbol_for;
-pub(crate) use implement_Scoped_Symbol_for;
-pub(crate) use implement_Attributable_for;
-pub(crate) use implement_Commentable_for;
-pub(crate) use implement_Entity_for;
-pub(crate) use implement_Container_for;
-pub(crate) use implement_Contained_for;
-pub(crate) use implement_Member_for;
+pub(crate) use {
+    implement_Attributable_for, implement_Commentable_for, implement_Contained_for,
+    implement_Container_for, implement_Element_for, implement_Entity_for, implement_Member_for,
+    implement_Named_Symbol_for, implement_Scoped_Symbol_for, implement_Symbol_for,
+};

--- a/src/grammar/util.rs
+++ b/src/grammar/util.rs
@@ -18,11 +18,7 @@ impl Scope {
             .map(|s| s.to_owned())
             .collect::<Vec<_>>();
 
-        let module_scope = if is_module {
-            parser_scope.clone()
-        } else {
-            Vec::new()
-        };
+        let module_scope = if is_module { parser_scope.clone() } else { Vec::new() };
 
         Scope {
             raw_module_scope: module_scope.join("::"),
@@ -57,7 +53,8 @@ impl Scope {
 /// These encodings identity the format used to convert Slice types to and from byte streams.
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub enum Encoding {
-    /// Version 1 of the Slice encoding, supported by IceRPC, and compatible with Ice 3.5 or greater.
+    /// Version 1 of the Slice encoding, supported by IceRPC, and compatible with Ice 3.5 or
+    /// greater.
     ///
     /// It is primarily for interoperability between Ice and IceRPC.
     Slice1,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,9 @@ use crate::slice_file::SliceFile;
 use crate::validator::Validator;
 use std::collections::HashMap;
 
-pub fn parse_from_options(options: &SliceOptions) -> Result<(Ast, ErrorReporter, HashMap<String, SliceFile>), Error> {
+pub fn parse_from_options(
+    options: &SliceOptions,
+) -> Result<(Ast, ErrorReporter, HashMap<String, SliceFile>), Error> {
     let mut ast = Ast::new();
     let mut error_reporter = ErrorReporter::default();
 
@@ -67,11 +69,7 @@ pub fn handle_errors(
         );
 
         println!("{}", &message);
-        Err(Error{
-            message,
-            location: None,
-            severity: ErrorLevel::Critical,
-        })
+        Err(Error { message, location: None, severity: ErrorLevel::Critical })
     } else {
         Ok(())
     }

--- a/src/parser/cycle_detection.rs
+++ b/src/parser/cycle_detection.rs
@@ -6,11 +6,11 @@ use crate::slice_file::SliceFile;
 use crate::visitor::Visitor;
 use std::collections::HashMap;
 
-pub(super) fn detect_cycles(slice_files: &HashMap<String, SliceFile>, error_reporter: &mut ErrorReporter) {
-    let mut cycle_detector = CycleDetector {
-        dependency_stack: Vec::new(),
-        error_reporter,
-    };
+pub(super) fn detect_cycles(
+    slice_files: &HashMap<String, SliceFile>,
+    error_reporter: &mut ErrorReporter,
+) {
+    let mut cycle_detector = CycleDetector { dependency_stack: Vec::new(), error_reporter };
 
     // First, visit everything immutably to check for cycles and compute the supported encodings.
     for slice_file in slice_files.values() {
@@ -34,7 +34,8 @@ impl<'a> CycleDetector<'a> {
                 type_id = &type_id,
                 cycle_string = &self.dependency_stack[i..].join(" -> "),
             );
-            self.error_reporter.report_error(message, Some(type_def.location()));
+            self.error_reporter
+                .report_error(message, Some(type_def.location()));
 
             true
         } else {

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -16,13 +16,13 @@ use crate::command_line::SliceOptions;
 use crate::error::{Error, ErrorReporter};
 use crate::slice_file::SliceFile;
 use std::collections::HashMap;
-use std::fs;
-use std::io;
 use std::path::PathBuf;
+use std::{fs, io};
 
 // NOTE! it is NOT safe to call any methods on any of the slice entities during parsing.
-// Slice entities are NOT considered fully constructed until AFTER parsing is finished (including patching).
-// Accessing ANY data, or calling ANY methods before this point may result in panics or undefined behavior.
+// Slice entities are NOT considered fully constructed until AFTER parsing is finished (including
+// patching). Accessing ANY data, or calling ANY methods before this point may result in panics or
+// undefined behavior.
 
 // TODO This module is a mess.
 
@@ -65,7 +65,11 @@ pub fn parse_files(
     Ok(slice_files)
 }
 
-pub fn parse_string(input: &str, ast: &mut Ast, error_reporter: &mut ErrorReporter) -> Result<HashMap<String,SliceFile>, Error> {
+pub fn parse_string(
+    input: &str,
+    ast: &mut Ast,
+    error_reporter: &mut ErrorReporter,
+) -> Result<HashMap<String, SliceFile>, Error> {
     let mut parser = slice::SliceParser { error_reporter };
 
     let identifier = "in-memory-file";
@@ -92,7 +96,8 @@ fn find_slice_files(paths: &[String]) -> Vec<String> {
         }
     }
 
-    let mut string_paths = slice_paths.into_iter()
+    let mut string_paths = slice_paths
+        .into_iter()
         .map(|path| path.to_str().unwrap().to_owned())
         .collect::<Vec<_>>();
 
@@ -107,7 +112,11 @@ fn find_slice_files_in_path(path: PathBuf) -> io::Result<Vec<PathBuf>> {
         find_slice_files_in_directory(path.read_dir()?)
     }
     // If the path is not a directory, check if it ends with 'slice'.
-    else if path.extension().filter(|ext| ext.to_str() == Some("slice")).is_some() {
+    else if path
+        .extension()
+        .filter(|ext| ext.to_str() == Some("slice"))
+        .is_some()
+    {
         Ok(vec![path])
     } else {
         Ok(vec![])

--- a/src/parser/parent_patcher.rs
+++ b/src/parser/parent_patcher.rs
@@ -10,7 +10,9 @@ pub(super) fn patch_parents(ast: &mut Ast) {
     let mut patcher = ParentPatcher;
 
     for module in &mut ast.ast {
-        unsafe { module.visit_ptr_with(&mut patcher); }
+        unsafe {
+            module.visit_ptr_with(&mut patcher);
+        }
     }
 }
 
@@ -21,15 +23,15 @@ impl PtrVisitor for ParentPatcher {
         let parent_ptr = module_ptr.downgrade();
         for definition in &mut module_ptr.borrow_mut().contents {
             match definition {
-                Definition::Module(x)     => x.borrow_mut().parent = Some(parent_ptr.clone()),
-                Definition::Struct(x)     => x.borrow_mut().parent = parent_ptr.clone(),
-                Definition::Class(x)      => x.borrow_mut().parent = parent_ptr.clone(),
-                Definition::Exception(x)  => x.borrow_mut().parent = parent_ptr.clone(),
-                Definition::Interface(x)  => x.borrow_mut().parent = parent_ptr.clone(),
-                Definition::Enum(x)       => x.borrow_mut().parent = parent_ptr.clone(),
-                Definition::Trait(x)      => x.borrow_mut().parent = parent_ptr.clone(),
+                Definition::Module(x) => x.borrow_mut().parent = Some(parent_ptr.clone()),
+                Definition::Struct(x) => x.borrow_mut().parent = parent_ptr.clone(),
+                Definition::Class(x) => x.borrow_mut().parent = parent_ptr.clone(),
+                Definition::Exception(x) => x.borrow_mut().parent = parent_ptr.clone(),
+                Definition::Interface(x) => x.borrow_mut().parent = parent_ptr.clone(),
+                Definition::Enum(x) => x.borrow_mut().parent = parent_ptr.clone(),
+                Definition::Trait(x) => x.borrow_mut().parent = parent_ptr.clone(),
                 Definition::CustomType(x) => x.borrow_mut().parent = parent_ptr.clone(),
-                Definition::TypeAlias(x)  => x.borrow_mut().parent = parent_ptr.clone(),
+                Definition::TypeAlias(x) => x.borrow_mut().parent = parent_ptr.clone(),
             }
         }
     }

--- a/src/parser/preprocessor.rs
+++ b/src/parser/preprocessor.rs
@@ -1,3 +1,3 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-//TODO
+// TODO

--- a/src/parser/slice.rs
+++ b/src/parser/slice.rs
@@ -2,8 +2,8 @@
 
 use super::comments::CommentParser;
 use crate::ast::Ast;
-use crate::grammar::*;
 use crate::error::{Error, ErrorLevel, ErrorReporter};
+use crate::grammar::*;
 use crate::ptr_util::{OwnedPtr, WeakPtr};
 use crate::slice_file::{Location, SliceFile};
 use crate::upcast_weak_as;
@@ -57,12 +57,14 @@ pub(super) struct SliceParser<'a> {
 }
 
 impl<'a> SliceParser<'a> {
-
-    pub fn try_parse_file(&mut self, file: &str, is_source: bool, ast: &mut Ast) -> Option<SliceFile> {
+    pub fn try_parse_file(
+        &mut self,
+        file: &str,
+        is_source: bool,
+        ast: &mut Ast,
+    ) -> Option<SliceFile> {
         match self.parse_file(file, is_source, ast) {
-            Ok(slice_file) => {
-                Some(slice_file)
-            }
+            Ok(slice_file) => Some(slice_file),
             Err(message) => {
                 self.error_reporter.report_error(message, None);
                 None
@@ -70,7 +72,12 @@ impl<'a> SliceParser<'a> {
         }
     }
 
-    fn parse_file(&mut self, file: &str, is_source: bool, ast: &mut Ast) -> Result<SliceFile, String> {
+    fn parse_file(
+        &mut self,
+        file: &str,
+        is_source: bool,
+        ast: &mut Ast,
+    ) -> Result<SliceFile, String> {
         let user_data = RefCell::new(ParserData {
             ast,
             current_file: file.to_owned(),
@@ -90,9 +97,10 @@ impl<'a> SliceParser<'a> {
         let (file_attributes, file_contents, file_encoding) =
             SliceParser::main(raw_ast).map_err(|e| e.to_string())?;
 
-        let top_level_modules = file_contents.into_iter().map(|module_def| {
-            ast.add_module(module_def)
-        }).collect::<Vec<_>>();
+        let top_level_modules = file_contents
+            .into_iter()
+            .map(|module_def| ast.add_module(module_def))
+            .collect::<Vec<_>>();
 
         Ok(SliceFile::new(
             file.to_owned(),
@@ -154,7 +162,6 @@ impl<'a> SliceParser<'a> {
 
         Ok(slice_file)
     }
-
 }
 
 #[pest_consume::parser]
@@ -261,7 +268,9 @@ impl<'a> SliceParser<'a> {
     }
 
     #[allow(clippy::type_complexity)]
-    fn class_start(input: PestNode) -> PestResult<(Identifier, Option<u32>, Location, Option<TypeRef<Class>>)> {
+    fn class_start(
+        input: PestNode,
+    ) -> PestResult<(Identifier, Option<u32>, Location, Option<TypeRef<Class>>)> {
         let location = from_span(&input);
         Ok(match_nodes!(input.children();
             [_, identifier(identifier), compact_id(compact_id)] => {
@@ -301,7 +310,9 @@ impl<'a> SliceParser<'a> {
         ))
     }
 
-    fn exception_start(input: PestNode) -> PestResult<(Identifier, Location, Option<TypeRef<Exception>>)> {
+    fn exception_start(
+        input: PestNode,
+    ) -> PestResult<(Identifier, Location, Option<TypeRef<Exception>>)> {
         let location = from_span(&input);
         Ok(match_nodes!(input.children();
             [_, identifier(identifier)] => {
@@ -341,7 +352,9 @@ impl<'a> SliceParser<'a> {
         ))
     }
 
-    fn interface_start(input: PestNode) -> PestResult<(Identifier, Location, Vec<TypeRef<Interface>>)> {
+    fn interface_start(
+        input: PestNode,
+    ) -> PestResult<(Identifier, Location, Vec<TypeRef<Interface>>)> {
         let location = from_span(&input);
         Ok(match_nodes!(input.children();
             [_, identifier(identifier)] => {
@@ -382,7 +395,9 @@ impl<'a> SliceParser<'a> {
         ))
     }
 
-    fn enum_start(input: PestNode) -> PestResult<(bool, Identifier, Location, Option<TypeRef<Primitive>>)> {
+    fn enum_start(
+        input: PestNode,
+    ) -> PestResult<(bool, Identifier, Location, Option<TypeRef<Primitive>>)> {
         // Reset the current enumerator value back to 0.
         input.user_data().borrow_mut().current_enum_value = 0;
 
@@ -767,19 +782,33 @@ impl<'a> SliceParser<'a> {
 
     fn primitive(input: PestNode) -> PestResult<WeakPtr<Primitive>> {
         // Look the primitive up in the AST's primitive cache.
-        Ok(input.user_data().borrow().ast.lookup_primitive(input.as_str()).downgrade())
+        Ok(input
+            .user_data()
+            .borrow()
+            .ast
+            .lookup_primitive(input.as_str())
+            .downgrade())
     }
 
     fn identifier(input: PestNode) -> PestResult<Identifier> {
-        Ok(Identifier::new(input.as_str().to_owned(), from_span(&input)))
+        Ok(Identifier::new(
+            input.as_str().to_owned(),
+            from_span(&input),
+        ))
     }
 
     fn scoped_identifier(input: PestNode) -> PestResult<Identifier> {
-        Ok(Identifier::new(input.as_str().to_owned(), from_span(&input)))
+        Ok(Identifier::new(
+            input.as_str().to_owned(),
+            from_span(&input),
+        ))
     }
 
     fn global_identifier(input: PestNode) -> PestResult<Identifier> {
-        Ok(Identifier::new(input.as_str().to_owned(), from_span(&input)))
+        Ok(Identifier::new(
+            input.as_str().to_owned(),
+            from_span(&input),
+        ))
     }
 
     fn prelude(input: PestNode) -> PestResult<(Vec<Attribute>, Option<DocComment>)> {

--- a/src/ptr_visitor.rs
+++ b/src/ptr_visitor.rs
@@ -5,9 +5,9 @@ use crate::ptr_util::OwnedPtr;
 
 /// The `PtrVisitor` trait is used to recursively visit through a tree of slice elements.
 ///
-/// It automatically traverses through the tree, calling the various `visit_x` methods as applicable.
-/// Elements that implement [Container] have 2 corresponding methods, `visit_x_start` and `visit_x_end`.
-/// Non-container elements only have a single method: `visit_x`.
+/// It automatically traverses through the tree, calling the various `visit_x` methods as
+/// applicable. Elements that implement [Container] have 2 corresponding methods, `visit_x_start`
+/// and `visit_x_end`. Non-container elements only have a single method: `visit_x`.
 ///
 /// These methods are default implemented as no-ops, so implementors are free to only implement the
 /// methods they need. Implementors also don't need to implement the tree traversal or recursive
@@ -223,7 +223,8 @@ pub trait PtrVisitor {
 
     /// This function is called by the visitor when it visits a [CustomType].
     ///
-    /// This shouldn't be called by users. To visit a custom type, use `custom_type_ptr.visit_ptr_with`.
+    /// This shouldn't be called by users. To visit a custom type, use
+    /// `custom_type_ptr.visit_ptr_with`.
     ///
     /// # Safety
     ///
@@ -234,7 +235,8 @@ pub trait PtrVisitor {
 
     /// This function is called by the visitor when it visits a [TypeAlias].
     ///
-    /// This shouldn't be called by users. To visit a type alias, use `type_alias_ptr.visit_ptr_with`.
+    /// This shouldn't be called by users. To visit a type alias, use
+    /// `type_alias_ptr.visit_ptr_with`.
     ///
     /// # Safety
     ///
@@ -267,18 +269,20 @@ pub trait PtrVisitor {
 
     /// This function is called by the visitor when it visits a [return member](Parameter).
     ///
-    /// This shouldn't be called by users. To visit a return member, use `member_ptr.visit_ptr_with`.
+    /// This shouldn't be called by users. To visit a return member, use
+    /// `member_ptr.visit_ptr_with`.
     ///
     /// # Safety
     ///
     /// Implementors of this function must be able to safely borrow the return member being visited,
-    /// mutably and immutably. Hence, this function is only safe to call when the return member isn't
-    /// borrowed elsewhere. Violating this **will** lead to undefined behavior.
+    /// mutably and immutably. Hence, this function is only safe to call when the return member
+    /// isn't borrowed elsewhere. Violating this **will** lead to undefined behavior.
     unsafe fn visit_return_member(&mut self, parameter_ptr: &mut OwnedPtr<Parameter>) {}
 
     /// This function is called by the visitor when it visits an [Enumerator].
     ///
-    /// This shouldn't be called by users. To visit a enumerator, use `type_alias_ptr.visit_ptr_with`.
+    /// This shouldn't be called by users. To visit a enumerator, use
+    /// `type_alias_ptr.visit_ptr_with`.
     ///
     /// # Safety
     ///
@@ -306,15 +310,15 @@ impl OwnedPtr<Module> {
         visitor.visit_module_start(self);
         for definition in &mut self.borrow_mut().contents {
             match definition {
-                Definition::Module(module_ptr)          => module_ptr.visit_ptr_with(visitor),
-                Definition::Struct(struct_ptr)          => struct_ptr.visit_ptr_with(visitor),
-                Definition::Class(class_ptr)            => class_ptr.visit_ptr_with(visitor),
-                Definition::Exception(exception_ptr)    => exception_ptr.visit_ptr_with(visitor),
-                Definition::Interface(interface_ptr)    => interface_ptr.visit_ptr_with(visitor),
-                Definition::Enum(enum_ptr)              => enum_ptr.visit_ptr_with(visitor),
-                Definition::Trait(trait_ptr)            => trait_ptr.visit_ptr_with(visitor),
+                Definition::Module(module_ptr) => module_ptr.visit_ptr_with(visitor),
+                Definition::Struct(struct_ptr) => struct_ptr.visit_ptr_with(visitor),
+                Definition::Class(class_ptr) => class_ptr.visit_ptr_with(visitor),
+                Definition::Exception(exception_ptr) => exception_ptr.visit_ptr_with(visitor),
+                Definition::Interface(interface_ptr) => interface_ptr.visit_ptr_with(visitor),
+                Definition::Enum(enum_ptr) => enum_ptr.visit_ptr_with(visitor),
+                Definition::Trait(trait_ptr) => trait_ptr.visit_ptr_with(visitor),
                 Definition::CustomType(custom_type_ptr) => custom_type_ptr.visit_ptr_with(visitor),
-                Definition::TypeAlias(type_alias_ptr)   => type_alias_ptr.visit_ptr_with(visitor),
+                Definition::TypeAlias(type_alias_ptr) => type_alias_ptr.visit_ptr_with(visitor),
             }
         }
         visitor.visit_module_end(self);
@@ -374,7 +378,8 @@ impl OwnedPtr<Exception> {
     /// the contents of the exception, and finally calls `visitor.visit_exception_end`.
     ///
     /// It takes a mutable borrow of the pointer, to allow the visitor to modify the pointer and its
-    /// contents. If you don't need mutability or pointer access, use [Exception::visit_with] instead.
+    /// contents. If you don't need mutability or pointer access, use [Exception::visit_with]
+    /// instead.
     ///
     /// # Safety
     ///
@@ -397,7 +402,8 @@ impl OwnedPtr<Interface> {
     /// the contents of the interface, and finally calls `visitor.visit_interface_end`.
     ///
     /// It takes a mutable borrow of the pointer, to allow the visitor to modify the pointer and its
-    /// contents. If you don't need mutability or pointer access, use [Interface::visit_with] instead.
+    /// contents. If you don't need mutability or pointer access, use [Interface::visit_with]
+    /// instead.
     ///
     /// # Safety
     ///
@@ -443,7 +449,8 @@ impl OwnedPtr<Operation> {
     /// the contents of the operation, and finally calls `visitor.visit_operation_end`.
     ///
     /// It takes a mutable borrow of the pointer, to allow the visitor to modify the pointer and its
-    /// contents. If you don't need mutability or pointer access, use [Operation::visit_with] instead.
+    /// contents. If you don't need mutability or pointer access, use [Operation::visit_with]
+    /// instead.
     ///
     /// # Safety
     ///
@@ -486,7 +493,8 @@ impl OwnedPtr<CustomType> {
     /// This function delegates to `visitor.visit_custom_type`.
     ///
     /// It takes a mutable borrow of the pointer, to allow the visitor to modify the pointer and its
-    /// contents. If you don't need mutability or pointer access, use [CustomType::visit_with] instead.
+    /// contents. If you don't need mutability or pointer access, use [CustomType::visit_with]
+    /// instead.
     ///
     /// # Safety
     ///
@@ -504,7 +512,8 @@ impl OwnedPtr<TypeAlias> {
     /// This function delegates to `visitor.visit_type_alias`.
     ///
     /// It takes a mutable borrow of the pointer, to allow the visitor to modify the pointer and its
-    /// contents. If you don't need mutability or pointer access, use [TypeAlias::visit_with] instead.
+    /// contents. If you don't need mutability or pointer access, use [TypeAlias::visit_with]
+    /// instead.
     ///
     /// # Safety
     ///
@@ -522,7 +531,8 @@ impl OwnedPtr<DataMember> {
     /// This function delegates to `visitor.visit_data_member`.
     ///
     /// It takes a mutable borrow of the pointer, to allow the visitor to modify the pointer and its
-    /// contents. If you don't need mutability or pointer access, use [DataMember::visit_with] instead.
+    /// contents. If you don't need mutability or pointer access, use [DataMember::visit_with]
+    /// instead.
     ///
     /// # Safety
     ///
@@ -542,7 +552,8 @@ impl OwnedPtr<Parameter> {
     /// cases because both semantic types are implemented by the [Parameter] struct.
     ///
     /// It takes a mutable borrow of the pointer, to allow the visitor to modify the pointer and its
-    /// contents. If you don't need mutability or pointer access, use [Parameter::visit_with] instead.
+    /// contents. If you don't need mutability or pointer access, use [Parameter::visit_with]
+    /// instead.
     ///
     /// # Safety
     ///
@@ -564,7 +575,8 @@ impl OwnedPtr<Enumerator> {
     /// This function delegates to `visitor.visit_enumerator`.
     ///
     /// It takes a mutable borrow of the pointer, to allow the visitor to modify the pointer and its
-    /// contents. If you don't need mutability or pointer access, use [Enumerator::visit_with] instead.
+    /// contents. If you don't need mutability or pointer access, use [Enumerator::visit_with]
+    /// instead.
     ///
     /// # Safety
     ///

--- a/src/slice_file.rs
+++ b/src/slice_file.rs
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-use crate::grammar::{Attribute, FileEncoding, Module, Encoding};
+use crate::grammar::{Attribute, Encoding, FileEncoding, Module};
 use crate::ptr_util::WeakPtr;
 
 #[derive(Clone, Debug)]

--- a/src/supported_encodings.rs
+++ b/src/supported_encodings.rs
@@ -68,7 +68,7 @@ impl SupportedEncodings {
 /// match supported_encodings[..] {
 ///     [] => println!("No supported encodings"),
 ///     [e] => println!("Only supports {}", e),
-///     _ => println!("Supports multiple encodings")
+///     _ => println!("Supports multiple encodings"),
 /// }
 /// ```
 impl<I: std::slice::SliceIndex<[Encoding]>> std::ops::Index<I> for SupportedEncodings {

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -5,9 +5,9 @@ use crate::slice_file::SliceFile;
 
 /// The `Visitor` trait is used to recursively visit through a tree of slice elements.
 ///
-/// It automatically traverses through the tree, calling the various `visit_x` methods as applicable.
-/// Elements that implement [Container] have 2 corresponding methods, `visit_x_start` and `visit_x_end`.
-/// Non-container elements only have a single method: `visit_x`.
+/// It automatically traverses through the tree, calling the various `visit_x` methods as
+/// applicable. Elements that implement [Container] have 2 corresponding methods, `visit_x_start`
+/// and `visit_x_end`. Non-container elements only have a single method: `visit_x`.
 ///
 /// These methods are default implemented as no-ops, so implementors are free to only implement the
 /// methods they need. Implementors also don't need to implement the tree traversal or recursive
@@ -187,15 +187,15 @@ impl Module {
         visitor.visit_module_start(self);
         for definition in &self.contents {
             match definition {
-                Definition::Module(module_def)       => module_def.borrow().visit_with(visitor),
-                Definition::Struct(struct_def)       => struct_def.borrow().visit_with(visitor),
-                Definition::Class(class_def)         => class_def.borrow().visit_with(visitor),
+                Definition::Module(module_def) => module_def.borrow().visit_with(visitor),
+                Definition::Struct(struct_def) => struct_def.borrow().visit_with(visitor),
+                Definition::Class(class_def) => class_def.borrow().visit_with(visitor),
                 Definition::Exception(exception_def) => exception_def.borrow().visit_with(visitor),
                 Definition::Interface(interface_def) => interface_def.borrow().visit_with(visitor),
-                Definition::Enum(enum_def)           => enum_def.borrow().visit_with(visitor),
-                Definition::Trait(trait_def)         => trait_def.borrow().visit_with(visitor),
-                Definition::CustomType(custom_type)  => custom_type.borrow().visit_with(visitor),
-                Definition::TypeAlias(type_alias)    => type_alias.borrow().visit_with(visitor),
+                Definition::Enum(enum_def) => enum_def.borrow().visit_with(visitor),
+                Definition::Trait(trait_def) => trait_def.borrow().visit_with(visitor),
+                Definition::CustomType(custom_type) => custom_type.borrow().visit_with(visitor),
+                Definition::TypeAlias(type_alias) => type_alias.borrow().visit_with(visitor),
             }
         }
         visitor.visit_module_end(self);


### PR DESCRIPTION
This is a PR that runs `rustfmt +nightly` over the `src` directory. This is the defacto style that rust encourages. As such, let's use it.

If there are things that we decide don't work for us,  we can always add a rustfmt configuration to exclude those rules in the future.