### PR TITLE
Removed underlying_type method from Enum

### DIFF
--- a/src/grammar/elements/enum.rs
+++ b/src/grammar/elements/enum.rs
@@ -58,18 +58,6 @@ impl Enum {
             .collect()
     }
 
-    /// Computes the underlying type of the enum. The default underlying type is dependent on the
-    /// encoding. For Slice1 the default is int32, for Slice2 the default is varint32.
-    pub fn underlying_type(&self, encoding: Encoding) -> &Primitive {
-        let default_underlying = match encoding {
-            Encoding::Slice1 => &Primitive::Int32,
-            Encoding::Slice2 => &Primitive::VarInt32,
-        };
-        self.underlying
-            .as_ref()
-            .map_or(default_underlying, |data_type| data_type.definition())
-    }
-
     pub fn get_min_max_values(&self) -> Option<(i64, i64)> {
         let values = self
             .enumerators

--- a/tests/enums/container.rs
+++ b/tests/enums/container.rs
@@ -381,7 +381,7 @@ mod slice2 {
         assert_eq!(enumerators[2].value, 3);
 
         assert!(matches!(
-            *enum_def.underlying_type(Encoding::Slice2),
+            enum_def.underlying.as_ref().unwrap().definition(),
             Primitive::Int16,
         ));
     }


### PR DESCRIPTION
Per @bernardnormier in [this PR](https://github.com/zeroc-ice/icerpc-csharp/pull/1268#discussion_r882010437), the `underlying_type` method seemed redundant. We don't use it for anything other than validation and tests in this repo either so it has been removed.