### PR TITLE
Added deprecated parsing

### DIFF
--- a/src/parser/comments.pest
+++ b/src/parser/comments.pest
@@ -9,13 +9,14 @@ message = { (!newline ~ ANY)+ }
 // Match any characters other than separators at least once.
 identifier = { (!separator ~ ANY)+ }
 
-field = _{ param_field | return_field | throws_field | see_field | invalid_field }
+field = _{ deprecated_field | param_field | return_field | see_field | throws_field | invalid_field }
 // `identifier`s always end at a whitespace character, so we don't need to explicitly match a space
 // in between `identifier`s and `message`s. Not having the extra token simplifies parsing later on.
+deprecated_field = { "@deprecated" ~ space? ~ message? }
 param_field = { "@param" ~ space? ~ identifier? ~ message? }
 return_field = { "@return" ~ space? ~ message? }
-throws_field = { "@throws" ~ space? ~ identifier? ~ message? }
 see_field = { "@see" ~ space? ~ identifier? ~ message? }
+throws_field = { "@throws" ~ space? ~ identifier? ~ message? }
 invalid_field = { "@" ~ identifier? ~ message? }
 
 // We don't ignore `space`, since it DOES have a syntactic meaning: delimiting tokens.

--- a/tests/comment_tests.rs
+++ b/tests/comment_tests.rs
@@ -183,6 +183,32 @@ mod comments {
         assert_eq!(op_doc_comment.see_also, expected);
     }
 
+    #[test]
+    fn doc_comments_deprecated() {
+        // Arrange
+        let slice = "
+            module tests;
+
+            interface TestInterface {
+                /// @deprecated A reason for deprecation.
+                testOp(testParam: string) -> bool;
+            }
+            ";
+        let expected = Some("A reason for deprecation.".to_owned());
+
+        // Act
+        let ast = parse_for_ast(slice);
+
+        // Assert
+        let op_ptr = ast
+            .find_typed_entity::<Operation>("tests::TestInterface::testOp")
+            .unwrap();
+        let op_def = op_ptr.borrow();
+        let op_doc_comment = op_def.comment().unwrap();
+
+        assert_eq!(op_doc_comment.deprecate_reason, expected);
+    }
+
     #[test_case("/// This is a doc comment.", (4, 13), (5, 13); "doc comment")]
     #[test_case("/**\n* This is a multi line doc comment.\n*/", (4, 13), (6, 3); "multi-line doc comment")]
     fn doc_comments_location(comment: &str, expected_start: (usize, usize), expected_end: (usize, usize)) {


### PR DESCRIPTION
Looks like we never added support for parsing the `@deprecated` tag in doc comments despite having a `deprecation_reason` field on `DocComment`.

This PR adds deprecation parsing and a test to verify that it works.