### PR TITLE
Removing deprecate_reason from DocComment

### DIFF
--- a/src/grammar/comments.rs
+++ b/src/grammar/comments.rs
@@ -11,7 +11,6 @@ pub struct DocComment {
     pub params: Vec<(String, String)>,
     pub returns: Option<String>,
     pub throws: Vec<(String, String)>,
-    pub deprecate_reason: Option<String>,
     pub location: Location,
 }
 
@@ -26,7 +25,6 @@ impl DocComment {
             .collect();
 
         self.returns = self.returns.as_ref().map(|s| s.trim().to_owned());
-        self.deprecate_reason = self.deprecate_reason.as_ref().map(|s| s.trim().to_owned());
         self.throws = self
             .throws
             .iter()

--- a/src/parser/comments.rs
+++ b/src/parser/comments.rs
@@ -21,7 +21,6 @@ impl CommentParser {
             params: Vec::new(),
             returns: None,
             throws: Vec::new(),
-            deprecate_reason: None,
             location,
         };
 


### PR DESCRIPTION
This PR removes some dead code related to DocComment. In PR #184 I wired up this dead code so that doc comments with the `@deprecated` flag would be correctly added to `DocComment`. This would allow us notify the users if they indicated in a doc comment that something was deprecated but did not actually have a deprecated attribute. However, it does not make much sense to have both a doc comment and attribute with the same name doing the same thing.

As such, I have removed the dead code related to adding a `deprecated` doc comment flag.