### PR TITLE
Moved patchers into 'ast' module.

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -2,6 +2,8 @@
 
 // TODO this file needs some cleanup now.
 
+pub mod patchers;
+
 use crate::{downgrade_as, upcast_owned_as, upcast_weak_as};
 
 use crate::grammar::*;

--- a/src/ast/patchers/encoding_patcher.rs
+++ b/src/ast/patchers/encoding_patcher.rs
@@ -10,7 +10,7 @@ use crate::supported_encodings::SupportedEncodings;
 use crate::visitor::Visitor;
 use std::collections::HashMap;
 
-pub(super) fn patch_encodings(
+pub fn patch_encodings(
     slice_files: &HashMap<String, SliceFile>,
     ast: &mut Ast,
     error_reporter: &mut ErrorReporter,

--- a/src/ast/patchers/mod.rs
+++ b/src/ast/patchers/mod.rs
@@ -1,0 +1,5 @@
+// Copyright (c) ZeroC, Inc. All rights reserved.
+
+pub mod encoding_patcher;
+pub mod parent_patcher;
+pub mod type_patcher;

--- a/src/ast/patchers/parent_patcher.rs
+++ b/src/ast/patchers/parent_patcher.rs
@@ -6,7 +6,7 @@ use crate::grammar::*;
 use crate::ptr_util::{OwnedPtr, WeakPtr};
 use crate::ptr_visitor::PtrVisitor;
 
-pub(super) fn patch_parents(ast: &mut Ast) {
+pub fn patch_parents(ast: &mut Ast) {
     let mut patcher = ParentPatcher;
 
     for module in &mut ast.ast {

--- a/src/ast/patchers/type_patcher.rs
+++ b/src/ast/patchers/type_patcher.rs
@@ -9,7 +9,7 @@ use crate::ptr_util::{OwnedPtr, WeakPtr};
 use crate::ptr_visitor::PtrVisitor;
 use std::collections::HashMap;
 
-pub(super) fn patch_types(ast: &mut Ast, error_reporter: &mut ErrorReporter) {
+pub fn patch_types(ast: &mut Ast, error_reporter: &mut ErrorReporter) {
     let mut patcher = TypePatcher {
         primitive_cache: &ast.primitive_cache,
         lookup_table: &ast.lookup_table,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -5,11 +5,8 @@
 
 mod comments;
 mod cycle_detection;
-mod encoding_patcher;
-mod parent_patcher;
 mod preprocessor;
 mod slice;
-mod type_patcher;
 
 use crate::ast::Ast;
 use crate::command_line::SliceOptions;
@@ -119,11 +116,11 @@ pub fn parse_strings(inputs: &[&str]) -> ParserResult {
 
 fn patch_ast(parsed_data: &mut ParsedData) {
     if !parsed_data.has_errors() {
-        parent_patcher::patch_parents(&mut parsed_data.ast);
+        crate::ast::patchers::parent_patcher::patch_parents(&mut parsed_data.ast);
     }
 
     if !parsed_data.has_errors() {
-        type_patcher::patch_types(&mut parsed_data.ast, &mut parsed_data.error_reporter);
+        crate::ast::patchers::type_patcher::patch_types(&mut parsed_data.ast, &mut parsed_data.error_reporter);
     }
 
     if !parsed_data.has_errors() {
@@ -131,7 +128,7 @@ fn patch_ast(parsed_data: &mut ParsedData) {
     }
 
     if !parsed_data.has_errors() {
-        encoding_patcher::patch_encodings(
+        crate::ast::patchers::encoding_patcher::patch_encodings(
             &parsed_data.files,
             &mut parsed_data.ast,
             &mut parsed_data.error_reporter,


### PR DESCRIPTION
This small PR creates a new `ast` module, and `patchers` submodule inside of it.
The `ast` module just holds the contents of the `ast.rs` file, and the patchers are moved into the `patchers` submodule.

`ast.rs` -> `ast/mod.rs`
`encoding_patcher.rs` -> `ast/patchers/encoding_patcher.rs`
... same for `type_patcher` and `parent_patcher`

This seems more logical to me, because the patchers are all about patching an AST. Currently they're in the `parsing` module, but they have nothing to do with parsing.
