### PR TITLE
Remove rustfmt license template

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,1 @@
 * text=auto
-
-# On Windows, files are checked out with CRLF. Line endings are normalized as LF during commit. We checkout the license
-# with LF so that when rustfmt runs in the pre-commit hook the license template matches the commited files.
-.rustfmt-license-template text eol=lf

--- a/.rustfmt-license-template
+++ b/.rustfmt-license-template
@@ -1,1 +1,0 @@
-// Copyright (c) ZeroC, Inc. All rights reserved.

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -5,7 +5,6 @@
 # enum_discrim_align_threshold (https://github.com/rust-lang/rustfmt/issues/3372)
 # format_code_in_doc_comments (https://github.com/rust-lang/rustfmt/issues/3348)
 # format_macro_matchers (https://github.com/rust-lang/rustfmt/issues/3354)
-# license_template_path (https://github.com/rust-lang/rustfmt/issues/3352)
 # normalize_doc_attributes (https://github.com/rust-lang/rustfmt/issues/3351)
 # overflow_delimited_expression (https://github.com/rust-lang/rustfmt/issues/3370)
 # wrap_comments (https://github.com/rust-lang/rustfmt/issues/3347)
@@ -16,8 +15,6 @@ comment_width = 120
 
 format_code_in_doc_comments = true
 format_macro_matchers = true
-
-license_template_path = ".rustfmt-license-template"
 
 merge_derives = true
 


### PR DESCRIPTION
This feature has been removed from `rustfmt`. See https://github.com/rust-lang/rustfmt/issues/5103
