### PR TITLE
'ErrorReporter::print_errors should be consuming.

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
-use crate::slice_file::{Location, SliceFile};
-use std::collections::HashMap;
+use crate::slice_file::Location;
 
 #[derive(Debug)]
 pub struct ErrorReporter {
@@ -44,9 +43,9 @@ impl ErrorReporter {
         (self.error_count, self.warning_count)
     }
 
-    /// Returns a slice of the errors that have been reported.
-    pub fn errors(&self) -> &[Error] {
-        &self.errors
+    /// Consumes the error reporter, returning all the errors that have been reported with it.
+    pub fn into_errors(self) -> Vec<Error> {
+        self.errors
     }
 
     /// Adds a new error to the error reporter. The warning count and error count are also incremented.
@@ -87,39 +86,6 @@ impl ErrorReporter {
             location: location.cloned(),
             severity: ErrorLevel::Error,
         });
-    }
-
-    /// Writes the errors stored to stderr, along with any locations and snippets.
-    pub fn emit_errors(self, slice_files: &HashMap<String, SliceFile>) {
-        for error in self.errors.into_iter() {
-            let prefix = match error.severity {
-                ErrorLevel::Note => "note",
-                ErrorLevel::Warning => "warning",
-                ErrorLevel::Error => "error",
-            };
-
-            // Insert the prefix at the start of the message.
-            let mut message = prefix.to_owned() + ": " + &error.message;
-
-            if let Some(location) = &error.location {
-                // Specify the location where the error starts on its own line after the message.
-                message = format!(
-                    "{}\n@ '{}' ({},{})",
-                    message, &location.file, location.start.0, location.start.1
-                );
-
-                // If the location spans between two positions, add a snippet from the slice file.
-                if location.start != location.end {
-                    message += ":\n";
-                    let file = slice_files.get(&location.file).expect("Slice file not in file map!");
-                    message += &file.get_snippet(location.start, location.end);
-                } else {
-                    message += "\n";
-                }
-            }
-            // Print the message to stderr.
-            eprintln!("{}", message);
-        }
     }
 }
 

--- a/src/parse_result.rs
+++ b/src/parse_result.rs
@@ -1,7 +1,7 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
 use crate::ast::Ast;
-use crate::error::ErrorReporter;
+use crate::error::{ErrorLevel, ErrorReporter};
 use crate::slice_file::SliceFile;
 use std::collections::HashMap;
 
@@ -12,8 +12,53 @@ pub struct ParsedData {
 }
 
 impl ParsedData {
+    pub fn into_exit_code(self) -> i32 {
+        if self.has_errors() {
+            Self::emit_errors(self.error_reporter, &self.files);
+            1
+        } else {
+            0
+        }
+    }
+
     pub fn has_errors(&self) -> bool {
         self.error_reporter.has_errors()
+    }
+
+    fn emit_errors(error_reporter: ErrorReporter, files: &HashMap<String, SliceFile>) {
+        let counts = error_reporter.get_totals();
+
+        for error in error_reporter.into_errors() {
+            let prefix = match error.severity {
+                ErrorLevel::Note => "note",
+                ErrorLevel::Warning => "warning",
+                ErrorLevel::Error => "error",
+            };
+
+            // Insert the prefix at the start of the message.
+            let mut message = prefix.to_owned() + ": " + &error.message;
+
+            if let Some(location) = error.location {
+                // Specify the location where the error starts on its own line after the message.
+                message = format!(
+                    "{}\n@ '{}' ({},{})",
+                    message, &location.file, location.start.0, location.start.1
+                );
+
+                // If the location spans between two positions, add a snippet from the slice file.
+                if location.start != location.end {
+                    message += ":\n";
+                    let file = files.get(&location.file).expect("Slice file not in file map!");
+                    message += &file.get_snippet(location.start, location.end);
+                } else {
+                    message += "\n";
+                }
+            }
+            // Print the message to stderr.
+            eprintln!("{}", message);
+        }
+
+        println!("Compilation failed with {} error(s) and {} warning(s).\n", counts.0, counts.1);
     }
 }
 

--- a/tests/enums/container.rs
+++ b/tests/enums/container.rs
@@ -212,9 +212,7 @@ fn automatically_assigned_values_will_not_overflow() {
 
     let error_reporter = parse_for_errors(&slice);
 
-    assert!(error_reporter.errors()[0]
-        .message
-        .ends_with("Enumerator value out of range: B"));
+    assert_errors!(error_reporter, [" --> 5:17\n  |\n5 |                 B,␊\n  |                 ^\n  |\n  = Enumerator value out of range: B"]);
 }
 
 #[test_case("unchecked enum", true ; "unchecked")]

--- a/tests/helpers/macros.rs
+++ b/tests/helpers/macros.rs
@@ -7,24 +7,26 @@
 #[macro_export]
 macro_rules! assert_errors {
     ($error_reporter:expr) => {
+        let errors = $error_reporter.into_errors();
         assert!(
-            !$error_reporter.has_errors(),
+            errors.is_empty(),
             "Expected no errors, got {}.\n{:?}",
-            $error_reporter.errors().len(),
-            $error_reporter.errors(),
+            errors.len(),
+            errors,
         );
     };
 
     ($error_reporter:expr, $expected_errors:expr) => {
+        let errors = $error_reporter.into_errors();
         assert_eq!(
-            $error_reporter.errors().len(),
+            errors.len(),
             $expected_errors.len(),
             "Expected {} errors, got {}.\n{:?}",
             $expected_errors.len(),
-            $error_reporter.errors().len(),
-            $error_reporter.errors(),
+            errors.len(),
+            errors,
         );
-        for (i, error) in $error_reporter.errors().iter().enumerate() {
+        for (i, error) in errors.iter().enumerate() {
             assert_eq!(error.message, $expected_errors[i]);
         }
     };


### PR DESCRIPTION
This nano-scopic PR is a companion to: https://github.com/zeroc-ice/icerpc-csharp/pull/1451

Currently, `print_errors` is `&self`, meaning the function can be called multiple times.
In reality, this should never happen; doing so means we're emitting duplicate errors.
`print_errors` should only be called once, at the very end before the compiler exits.
Changing the signature to `self` conveys (and guarantees) that the function can only be called once, which is closer to the true semantics of `print_errors`. And this can only happen at the end, since everything else takes `&mut ErrorReporter`s and not owned copies.