### PR TITLE
Removing unused lifetimes

### DIFF
--- a/src/ptr_util.rs
+++ b/src/ptr_util.rs
@@ -150,7 +150,7 @@ impl<T: ?Sized> Clone for WeakPtr<T> {
 #[macro_export]
 macro_rules! downgrade_as {
     ($owned:expr, $new_type:ty) => {
-        crate::upcast_weak_as!($owned.downgrade(), $new_type)
+        $crate::upcast_weak_as!($owned.downgrade(), $new_type)
     };
 }
 


### PR DESCRIPTION
This PR resolves some Clippy warnings involving unused lifetimes. It also fixes the formatting of those touched files.