### PR TITLE
Exact versioning of Pest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,9 @@ edition = "2018"
 
 [dependencies]
 convert_case = "0.5.0"
-pest = "2.0"
-pest_derive = "2.0"
-pest_consume = "1.0.6"
+pest = "=2.1.3"
+pest_derive = "=2.1.0"
+pest_consume = "=1.1.1"
 structopt = "0.3.13"
 
 [dev-dependencies]


### PR DESCRIPTION
Today Pest released a new version [2.2.0](https://releasealert.dev/github/pest-parser/pest). 

While this version should maintain compatibility, it is causing breaking changes to  this repo. Since we are in the process of migrating away from Pest, it is not worth making the fixes required to use this new version. As such, I have locked the version of Pest to the last version that was used by `icerpc-csharp`.
