### PR TITLE
Expected errors in the arrange section removed

### DIFF
--- a/tests/attribute_tests.rs
+++ b/tests/attribute_tests.rs
@@ -70,13 +70,13 @@ mod attributes {
                 ",
                 arg.unwrap_or(""),
             );
-            let error: ErrorKind = LogicKind::CannotBeEmpty("format attribute").into();
 
             // Act
             let error_reporter = parse_for_errors(slice);
 
             // Assert
-            assert_errors_new!(error_reporter, [&error]);
+            let expected: ErrorKind = LogicKind::CannotBeEmpty("format attribute").into();
+            assert_errors_new!(error_reporter, [&expected]);
         }
 
         #[test]
@@ -90,14 +90,14 @@ mod attributes {
                     op(s: string) -> string;
                 }
             ";
-            let expected = [
-                LogicKind::ArgumentNotSupported("Foo".to_owned(), "format attribute".to_owned()).into(),
-                ErrorKind::new_note("The valid arguments for the format attribute are `Compact` and `Sliced`"),
-            ];
             // Act
             let error_reporter = parse_for_errors(slice);
 
             // Assert
+            let expected = [
+                LogicKind::ArgumentNotSupported("Foo".to_owned(), "format attribute".to_owned()).into(),
+                ErrorKind::new_note("The valid arguments for the format attribute are `Compact` and `Sliced`"),
+            ];
             assert_errors_new!(error_reporter, expected);
         }
 
@@ -131,12 +131,12 @@ mod attributes {
                     op([deprecated] s: string) -> string;
                 }
             ";
-            let expected: ErrorKind = LogicKind::DeprecatedAttributeCannotBeApplied("parameter(s)".to_owned()).into();
 
             // Act
             let error_reporter = parse_for_errors(slice);
 
             // Assert
+            let expected: ErrorKind = LogicKind::DeprecatedAttributeCannotBeApplied("parameter(s)".to_owned()).into();
             assert_errors_new!(error_reporter, [&expected]);
         }
 
@@ -151,12 +151,12 @@ mod attributes {
                     s: string,
                 }
             ";
-            let expected: ErrorKind = LogicKind::DeprecatedAttributeCannotBeApplied("data member(s)".to_owned()).into();
 
             // Act
             let error_reporter = parse_for_errors(slice);
 
             // Assert
+            let expected: ErrorKind = LogicKind::DeprecatedAttributeCannotBeApplied("data member(s)".to_owned()).into();
             assert_errors_new!(error_reporter, [&expected]);
         }
 
@@ -177,6 +177,7 @@ mod attributes {
 
             // Assert
             let operation = ast.find_element::<Operation>("Test::I::op").unwrap();
+
             assert!(operation.get_deprecated_attribute(false).is_some());
             assert_eq!(
                 operation.get_deprecated_attribute(false).unwrap()[0],
@@ -201,6 +202,7 @@ mod attributes {
 
             // Assert
             let operation = ast.find_element::<Operation>("Test::I::op").unwrap();
+
             assert!(operation.compress_arguments());
             assert!(operation.compress_return());
         }
@@ -216,15 +218,15 @@ mod attributes {
                     op(s: string) -> string;
                 }
             ";
-            let expected = [
-                LogicKind::ArgumentNotSupported("Foo".to_owned(), "compress attribute".to_owned()).into(),
-                ErrorKind::new_note("The valid argument(s) for the compress attribute are `Args` and `Return`"),
-            ];
 
             // Act
             let error_reporter = parse_for_errors(slice);
 
             // Assert
+            let expected = [
+                LogicKind::ArgumentNotSupported("Foo".to_owned(), "compress attribute".to_owned()).into(),
+                ErrorKind::new_note("The valid argument(s) for the compress attribute are `Args` and `Return`"),
+            ];
             assert_errors_new!(error_reporter, expected);
         }
 
@@ -239,12 +241,12 @@ mod attributes {
                     s: string,
                 }
             ";
-            let expected: ErrorKind = LogicKind::CompressAttributeCannotBeApplied.into();
 
             // Act
             let error_reporter = parse_for_errors(slice);
 
             // Assert
+            let expected: ErrorKind = LogicKind::CompressAttributeCannotBeApplied.into();
             assert_errors_new!(error_reporter, [&expected]);
         }
 
@@ -265,6 +267,7 @@ mod attributes {
 
             // Assert
             let operation = ast.find_element::<Operation>("Test::I::op").unwrap();
+
             assert!(!operation.compress_arguments());
             assert!(!operation.compress_return());
         }
@@ -297,7 +300,6 @@ mod attributes {
             let operation = ast.find_element::<Operation>("Test::I::op").unwrap();
 
             assert!(operation.has_attribute("foo::bar", true));
-
             assert_eq!(operation.attributes[0].directive, "bar");
             assert_eq!(operation.attributes[0].prefixed_directive, "foo::bar");
             assert_eq!(operation.attributes[0].prefix, Some("foo".to_owned()));
@@ -323,7 +325,6 @@ mod attributes {
             let operation = ast.find_element::<Operation>("Test::I::op").unwrap();
 
             assert!(operation.has_attribute("foo::bar", true));
-
             assert_eq!(operation.attributes[0].directive, "bar");
             assert_eq!(operation.attributes[0].prefixed_directive, "foo::bar");
             assert_eq!(operation.attributes[0].prefix, Some("foo".to_owned()));

--- a/tests/classes/container.rs
+++ b/tests/classes/container.rs
@@ -31,7 +31,6 @@ fn can_contain_data_members() {
     assert!(matches!(data_members[0].identifier(), "i"));
     assert!(matches!(data_members[1].identifier(), "s"));
     assert!(matches!(data_members[2].identifier(), "b"));
-
     assert!(matches!(
         data_members[0].data_type.concrete_type(),
         Types::Primitive(Primitive::Int32),
@@ -52,8 +51,7 @@ fn can_contain_data_members() {
         {
             c: C,
         }
-    ";
-    "single class circular reference"
+    "; "single class circular reference"
 )]
 #[test_case(
     "
@@ -65,8 +63,7 @@ fn can_contain_data_members() {
         {
             c1: C1,
         }
-    ";
-    "multi class circular reference"
+    "; "multi class circular reference"
 )]
 fn cycles_are_allowed(cycle_string: &str) {
     let slice = format!(
@@ -113,14 +110,14 @@ fn cannot_redefine_data_members() {
             a: string,
         }
     ";
-    let expected = [
-        LogicKind::Redefinition("a".to_string()).into(),
-        ErrorKind::new_note("`a` was previously defined here".to_owned()),
-    ];
 
     // Act
     let error_reporter = parse_for_errors(slice);
 
     // Assert
+    let expected = [
+        LogicKind::Redefinition("a".to_string()).into(),
+        ErrorKind::new_note("`a` was previously defined here".to_owned()),
+    ];
     assert_errors_new!(error_reporter, &expected);
 }

--- a/tests/classes/encoding.rs
+++ b/tests/classes/encoding.rs
@@ -9,10 +9,16 @@ mod slice2 {
 
     #[test]
     fn unsupported_error() {
+        // Arrange
         let slice = "
             module Test;
             class C {}
         ";
+
+        // Act
+        let error_reporter = parse_for_errors(slice);
+
+        // Assert
         let expected = [
             LogicKind::NotSupportedWithEncoding("class".to_owned(), "C".to_owned(), Encoding::Slice2).into(),
             ErrorKind::new_note("file is using the Slice2 encoding by default".to_owned()),
@@ -21,9 +27,6 @@ mod slice2 {
             ),
             ErrorKind::new_note("classes are only supported by the Slice1 encoding".to_owned()),
         ];
-
-        let error_reporter = parse_for_errors(slice);
-
         assert_errors_new!(error_reporter, expected);
     }
 }

--- a/tests/classes/inheritance.rs
+++ b/tests/classes/inheritance.rs
@@ -24,7 +24,6 @@ fn supports_single_inheritance() {
 
     assert!(class_i_def.base_class().is_none());
     assert!(class_j_def.base_class().is_some());
-
     assert_eq!(
         class_j_def.base_class().unwrap().module_scoped_identifier(),
         class_i_def.module_scoped_identifier(),
@@ -33,6 +32,7 @@ fn supports_single_inheritance() {
 
 #[test]
 fn does_not_support_multiple_inheritance() {
+    // Arrange
     let slice = "
         encoding = 1;
         module Test;
@@ -41,13 +41,16 @@ fn does_not_support_multiple_inheritance() {
         class K : I, J {}
     ";
 
+    // Act
     let error_reporter = parse_for_errors(slice);
 
+    // Assert
     assert_errors!(error_reporter, ["classes can only inherit from a single base class",]);
 }
 
 #[test]
 fn data_member_shadowing_is_disallowed() {
+    // Arrange
     let slice = "
         encoding = 1;
         module Test;
@@ -60,14 +63,15 @@ fn data_member_shadowing_is_disallowed() {
             i: int32
         }
     ";
-    let expected = [
-        LogicKind::Shadows("i".to_owned()).into(),
-        ErrorKind::new_note("`i` was previously defined here".to_owned()),
-    ];
 
     // Act
     let error_reporter = parse_for_errors(slice);
 
+    // Assert
+    let expected = [
+        LogicKind::Shadows("i".to_owned()).into(),
+        ErrorKind::new_note("`i` was previously defined here".to_owned()),
+    ];
     assert_errors_new!(error_reporter, expected);
 }
 

--- a/tests/classes/mod.rs
+++ b/tests/classes/mod.rs
@@ -10,14 +10,17 @@ use slice::grammar::*;
 
 #[test]
 fn support_compact_type_id() {
+    // Arrange
     let slice = "
         encoding = 1;
         module Test;
         class C(42) {}
     ";
 
+    // Act
     let ast = parse_for_ast(slice);
 
+    // Assert
     let class_def = ast.find_element::<Class>("Test::C").unwrap();
     assert_eq!(class_def.compact_id, Some(42));
 }

--- a/tests/classes/tags.rs
+++ b/tests/classes/tags.rs
@@ -15,6 +15,8 @@ fn can_contain_tags() {
             b: tag(10) bool?,
         }
     ";
+
+    // Act
     let ast = parse_for_ast(slice);
 
     // Assert

--- a/tests/comment_tests.rs
+++ b/tests/comment_tests.rs
@@ -51,12 +51,12 @@ mod comments {
                 testOp(testParam: string);
             }
         ";
-        let expected = vec![("testParam".to_owned(), "My test param".to_owned())];
 
         // Act
         let ast = parse_for_ast(slice);
 
         // Assert
+        let expected = vec![("testParam".to_owned(), "My test param".to_owned())];
         let operation = ast.find_element::<Operation>("tests::TestInterface::testOp").unwrap();
         let op_doc_comment = operation.comment().unwrap();
 
@@ -74,12 +74,12 @@ mod comments {
                 testOp(testParam: string) -> bool;
             }
         ";
-        let expected = Some("bool".to_owned());
 
         // Act
         let ast = parse_for_ast(slice);
 
         // Assert
+        let expected = Some("bool".to_owned());
         let operation = ast.find_element::<Operation>("tests::TestInterface::testOp").unwrap();
         let op_doc_comment = operation.comment().unwrap();
 
@@ -165,15 +165,15 @@ mod comments {
                 testOp(testParam: string) -> bool;
             }
         ";
-        let expected_throws = vec![(
-            "MyThrownThing".to_owned(),
-            "Message about my thrown thing.\nMore about the thrown thing.".to_owned(),
-        )];
 
         // Act
         let ast = parse_for_ast(slice);
 
         // Assert
+        let expected_throws = vec![(
+            "MyThrownThing".to_owned(),
+            "Message about my thrown thing.\nMore about the thrown thing.".to_owned(),
+        )];
         let operation = ast.find_element::<Operation>("tests::TestInterface::testOp").unwrap();
         let op_doc_comment = operation.comment().unwrap();
 
@@ -192,12 +192,12 @@ mod comments {
                 testOp(testParam: string) -> bool;
             }
         ";
-        let expected = vec![("MyThrownThing".to_owned(), "Message about my thrown thing.".to_owned())];
 
         // Act
         let ast = parse_for_ast(slice);
 
         // Assert
+        let expected = vec![("MyThrownThing".to_owned(), "Message about my thrown thing.".to_owned())];
         let operation = ast.find_element::<Operation>("tests::TestInterface::testOp").unwrap();
         let op_doc_comment = operation.comment().unwrap();
 
@@ -235,12 +235,12 @@ mod comments {
                 testOp(testParam: string) -> bool;
             }
         ";
-        let expected = vec!["MySee".to_owned()];
 
         // Act
         let ast = parse_for_ast(slice);
 
         // Assert
+        let expected = vec!["MySee".to_owned()];
         let operation = ast.find_element::<Operation>("tests::TestInterface::testOp").unwrap();
         let op_doc_comment = operation.comment().unwrap();
 

--- a/tests/dictionaries/key_type.rs
+++ b/tests/dictionaries/key_type.rs
@@ -12,12 +12,12 @@ fn optionals_are_disallowed() {
         module Test;
         typealias Dict = dictionary<int32?, int8>;
     ";
-    let expected: ErrorKind = LogicKind::CannotUseOptionalAsKey.into();
 
     // Act
     let error_reporter = parse_for_errors(slice);
 
     // Assert
+    let expected: ErrorKind = LogicKind::CannotUseOptionalAsKey.into();
     assert_errors_new!(error_reporter, [&expected]);
 }
 
@@ -64,12 +64,12 @@ fn disallowed_primitive_types(key_type: &str) {
         ",
         key_type,
     );
-    let expected: ErrorKind = LogicKind::TypeCannotBeUsedAsAKey(key_type.to_owned()).into();
 
     // Act
     let error_reporter = parse_for_errors(slice);
 
     // Assert
+    let expected: ErrorKind = LogicKind::TypeCannotBeUsedAsAKey(key_type.to_owned()).into();
     assert_errors_new!(error_reporter, [&expected]);
 }
 
@@ -84,12 +84,12 @@ fn collections_are_disallowed(key_type: &str, key_kind: &str) {
         ",
         key_type,
     );
-    let expected: ErrorKind = LogicKind::TypeCannotBeUsedAsAKey(key_kind.to_owned()).into();
 
     // Act
     let error_reporter = parse_for_errors(slice);
 
     // Assert
+    let expected: ErrorKind = LogicKind::TypeCannotBeUsedAsAKey(key_kind.to_owned()).into();
     assert_errors_new!(error_reporter, [&expected]);
 }
 
@@ -130,15 +130,15 @@ fn disallowed_constructed_types(key_type: &str, key_type_def: &str, key_kind: &s
         key_type_definition = key_type_def,
         key_type = key_type,
     );
-    let expected: [ErrorKind; 2] = [
-        LogicKind::TypeCannotBeUsedAsAKey(pluralize_kind(key_kind)).into(),
-        ErrorKind::new_note(format!("{} '{}' is defined here:", key_kind, key_type)),
-    ];
 
     // Act
     let error_reporter = parse_for_errors(slice);
 
     // Assert
+    let expected: [ErrorKind; 2] = [
+        LogicKind::TypeCannotBeUsedAsAKey(pluralize_kind(key_kind)).into(),
+        ErrorKind::new_note(format!("{} '{}' is defined here:", key_kind, key_type)),
+    ];
     assert_errors_new!(error_reporter, expected);
 }
 
@@ -150,15 +150,15 @@ fn non_compact_structs_are_disallowed() {
         struct MyStruct {}
         typealias Dict = dictionary<MyStruct, int8>;
     ";
-    let expected: [ErrorKind; 2] = [
-        LogicKind::StructsMustBeCompactToBeAKey.into(),
-        ErrorKind::new_note("struct 'MyStruct' is defined here:".to_owned()),
-    ];
 
     // Act
     let error_reporter = parse_for_errors(slice);
 
     // Assert
+    let expected: [ErrorKind; 2] = [
+        LogicKind::StructsMustBeCompactToBeAKey.into(),
+        ErrorKind::new_note("struct 'MyStruct' is defined here:".to_owned()),
+    ];
     assert_errors_new!(error_reporter, expected);
 }
 
@@ -210,6 +210,11 @@ fn compact_struct_with_disallowed_members_is_disallowed() {
 
         typealias Dict = dictionary<Outer, int8>;
     ";
+
+    // Act
+    let error_reporter = parse_for_errors(slice);
+
+    // Assert
     let expected: [ErrorKind; 9] = [
         LogicKind::TypeCannotBeUsedAsAKey("sequences".to_owned()).into(),
         LogicKind::TypeCannotBeUsedAsAKey("seq".to_owned()).into(),
@@ -221,10 +226,5 @@ fn compact_struct_with_disallowed_members_is_disallowed() {
         LogicKind::StructContainsDisallowedType("Outer".to_owned()).into(),
         ErrorKind::new_note("struct 'Outer' is defined here:".to_owned()),
     ];
-
-    // Act
-    let error_reporter = parse_for_errors(slice);
-
-    // Assert
     assert_errors_new!(error_reporter, expected);
 }

--- a/tests/enums/container.rs
+++ b/tests/enums/container.rs
@@ -80,12 +80,12 @@ fn validate_backing_type_out_of_bounds() {
         ",
         out_of_bounds_value = out_of_bounds_value,
     );
-    let expected: ErrorKind = LogicKind::MustBeBounded(out_of_bounds_value as i64, -32768_i64, 32767_i64).into();
 
     // Act
     let error_reporter = parse_for_errors(slice);
 
     // Assert
+    let expected: ErrorKind = LogicKind::MustBeBounded(out_of_bounds_value as i64, -32768_i64, 32767_i64).into();
     assert_errors_new!(error_reporter, [&expected]);
 }
 
@@ -126,12 +126,12 @@ fn invalid_underlying_type(underlying_type: &str) {
         ",
         underlying_type,
     );
-    let expected: ErrorKind = LogicKind::UnderlyingTypeMustBeIntegral(underlying_type.to_owned()).into();
 
     // Act
     let error_reporter = parse_for_errors(slice);
 
     // Assert
+    let expected: ErrorKind = LogicKind::UnderlyingTypeMustBeIntegral(underlying_type.to_owned()).into();
     assert_errors_new!(error_reporter, [&expected]);
 }
 
@@ -197,6 +197,7 @@ fn enumerators_must_be_unique() {
 
 #[test]
 fn automatically_assigned_values_will_not_overflow() {
+    // Arrange
     let slice = format!(
         "
             module Test;
@@ -208,8 +209,10 @@ fn automatically_assigned_values_will_not_overflow() {
         max_value = i64::MAX,
     );
 
+    // Act
     let error_reporter = parse_for_errors(&slice);
 
+    // Assert
     assert_errors!(error_reporter, [
         " --> 5:17\n  |\n5 |                 B,\n  |                 ^\n  |\n  = Enumerator value out of range: B"
     ]);
@@ -218,6 +221,7 @@ fn automatically_assigned_values_will_not_overflow() {
 #[test_case("unchecked enum", true ; "unchecked")]
 #[test_case("enum", false ; "checked")]
 fn can_be_unchecked(enum_definition: &str, expected_result: bool) {
+    // Arrange
     let slice = format!(
         "
             module Test;
@@ -229,8 +233,10 @@ fn can_be_unchecked(enum_definition: &str, expected_result: bool) {
         enum_definition = enum_definition,
     );
 
+    // Act
     let ast = parse_for_ast(slice);
 
+    // Assert
     let enum_def = ast.find_element::<Enum>("Test::E").unwrap();
     assert_eq!(enum_def.is_unchecked, expected_result);
 }
@@ -250,13 +256,16 @@ fn checked_enums_can_not_be_empty() {
 
 #[test]
 fn unchecked_enums_can_be_empty() {
+    // Arrange
     let slice = "
         module Test;
         unchecked enum E {}
     ";
 
+    // Act
     let ast = parse_for_ast(slice);
 
+    // Assert
     let enum_def = ast.find_element::<Enum>("Test::E").unwrap();
     assert_eq!(enum_def.enumerators.len(), 0);
 }
@@ -279,16 +288,16 @@ mod slice1 {
                 C = -3,
             }
         ";
-        let expected_errors: [ErrorKind; 3] = [
-            LogicKind::MustBePositive("enumerator values".to_owned()).into(),
-            LogicKind::MustBePositive("enumerator values".to_owned()).into(),
-            LogicKind::MustBePositive("enumerator values".to_owned()).into(),
-        ];
 
         // Act
         let error_reporter = parse_for_errors(slice);
 
         // Assert
+        let expected_errors: [ErrorKind; 3] = [
+            LogicKind::MustBePositive("enumerator values".to_owned()).into(),
+            LogicKind::MustBePositive("enumerator values".to_owned()).into(),
+            LogicKind::MustBePositive("enumerator values".to_owned()).into(),
+        ];
         assert_errors_new!(error_reporter, expected_errors);
     }
 
@@ -305,12 +314,12 @@ mod slice1 {
             ",
             value = i32::MAX as i64 + 1
         );
-        let expected: ErrorKind = LogicKind::MustBeBounded(i32::MAX as i64 + 1, 0_i64, i32::MAX as i64).into();
 
         // Act
         let error_reporter = parse_for_errors(slice);
 
         // Assert
+        let expected: ErrorKind = LogicKind::MustBeBounded(i32::MAX as i64 + 1, 0_i64, i32::MAX as i64).into();
         assert_errors_new!(error_reporter, [&expected]);
     }
 }
@@ -360,15 +369,12 @@ mod slice2 {
         let enumerators = enum_def.enumerators();
 
         assert_eq!(enumerators.len(), 3);
-
         assert_eq!(enumerators[0].identifier(), "A");
         assert_eq!(enumerators[1].identifier(), "B");
         assert_eq!(enumerators[2].identifier(), "C");
-
         assert_eq!(enumerators[0].value, 1);
         assert_eq!(enumerators[1].value, 2);
         assert_eq!(enumerators[2].value, 3);
-
         assert!(matches!(
             enum_def.underlying.as_ref().unwrap().definition(),
             Primitive::Int16,

--- a/tests/enums/encoding.rs
+++ b/tests/enums/encoding.rs
@@ -18,16 +18,16 @@ mod slice1 {
             module Test;
             unchecked enum E : int32 {}
         ";
-        let expected_errors = [
-            LogicKind::NotSupportedWithEncoding("enum".to_owned(), "E".to_owned(), Encoding::Slice1).into(),
-            ErrorKind::new_note("file encoding was set to Slice1 here:".to_owned()),
-            ErrorKind::new_note("enums with underlying types are not supported by the Slice1 encoding".to_owned()),
-        ];
 
         // Act
         let error_reporter = parse_for_errors(slice);
 
         // Assert
+        let expected_errors = [
+            LogicKind::NotSupportedWithEncoding("enum".to_owned(), "E".to_owned(), Encoding::Slice1).into(),
+            ErrorKind::new_note("file encoding was set to Slice1 here:".to_owned()),
+            ErrorKind::new_note("enums with underlying types are not supported by the Slice1 encoding".to_owned()),
+        ];
         assert_errors_new!(error_reporter, expected_errors);
     }
 }

--- a/tests/enums/tags.rs
+++ b/tests/enums/tags.rs
@@ -16,6 +16,9 @@ fn cannot_contain_tags() {
         }
     ";
 
+    // Act
+    let error_reporter = parse_for_errors(slice);
+
     // Act & Assert
-    assert_errors!(parse_for_errors(slice));
+    assert_errors!(error_reporter);
 }

--- a/tests/exceptions/container.rs
+++ b/tests/exceptions/container.rs
@@ -29,7 +29,6 @@ fn can_contain_data_members() {
     assert!(matches!(data_members[0].identifier(), "i"));
     assert!(matches!(data_members[1].identifier(), "s"));
     assert!(matches!(data_members[2].identifier(), "b"));
-
     assert!(matches!(
         data_members[0].data_type.concrete_type(),
         Types::Primitive(Primitive::Int32),
@@ -63,6 +62,7 @@ fn can_be_empty() {
 
 #[test]
 fn cannot_redefine_data_members() {
+    // Arrange
     let slice = "
         encoding = 1;
         module Test;
@@ -72,12 +72,14 @@ fn cannot_redefine_data_members() {
             a: string,
         }
     ";
+
+    // Act
+    let error_reporter = parse_for_errors(slice);
+
+    // Assert
     let expected = [
         LogicKind::Redefinition("a".to_owned()).into(),
         ErrorKind::new_note("`a` was previously defined here".to_owned()),
     ];
-
-    let error_reporter = parse_for_errors(slice);
-
     assert_errors_new!(error_reporter, expected);
 }

--- a/tests/exceptions/encoding.rs
+++ b/tests/exceptions/encoding.rs
@@ -22,15 +22,15 @@ mod slice1 {
                 e: E,
             }
         ";
-        let expected = [
-            LogicKind::ExceptionNotSupported(Encoding::Slice1).into(),
-            ErrorKind::new_note("file encoding was set to Slice1 here:".to_owned()),
-        ];
 
         // Act
         let error_reporter = parse_for_errors(slice);
 
         // Assert
+        let expected = [
+            LogicKind::ExceptionNotSupported(Encoding::Slice1).into(),
+            ErrorKind::new_note("file encoding was set to Slice1 here:".to_owned()),
+        ];
         assert_errors_new!(error_reporter, expected);
     }
 }
@@ -52,6 +52,11 @@ mod slice2 {
             exception A {}
             exception B : A {}
         ";
+
+        // Act
+        let error_reporter = parse_for_errors(slice);
+
+        // Assert
         let expected = [
             LogicKind::NotSupportedWithEncoding("exception".to_owned(), "B".to_owned(), Encoding::Slice2).into(),
             ErrorKind::new_note("file is using the Slice2 encoding by default".to_owned()),
@@ -60,11 +65,6 @@ mod slice2 {
             ),
             ErrorKind::new_note("exception inheritance is only supported by the Slice1 encoding".to_owned()),
         ];
-
-        // Act
-        let error_reporter = parse_for_errors(slice);
-
-        // Assert
         assert_errors_new!(error_reporter, expected);
     }
 

--- a/tests/exceptions/inheritance.rs
+++ b/tests/exceptions/inheritance.rs
@@ -7,6 +7,7 @@ use slice::grammar::*;
 
 #[test]
 fn supports_single_inheritance() {
+    // Arrange
     let slice = "
         encoding = 1;
         module Test;
@@ -14,8 +15,10 @@ fn supports_single_inheritance() {
         exception E2 : E1 {}
     ";
 
+    // Act
     let ast = parse_for_ast(slice);
 
+    // Assert
     let e2_def = ast.find_element::<Exception>("Test::E2").unwrap();
     assert_eq!(e2_def.base_exception().unwrap().module_scoped_identifier(), "Test::E1");
 }
@@ -31,18 +34,19 @@ fn does_not_support_multiple_inheritance() {
         exception E2 {}
         exception E3 : E1, E2 {}
     ";
-    let expected: ErrorKind = LogicKind::CanOnlyInheritFromSingleBase.into();
 
     // Act
     let error_reporter = parse_for_errors(slice);
 
     // Assert
+    let expected: ErrorKind = LogicKind::CanOnlyInheritFromSingleBase.into();
     assert_errors_new!(error_reporter, [&expected]);
 }
 
 #[test]
 #[ignore = "reason: TODO Need to update AST Error emission"]
 fn must_inherit_from_exception() {
+    // Arrange
     let slice = "
         encoding = 1;
         module Test;
@@ -50,8 +54,10 @@ fn must_inherit_from_exception() {
         exception E : C {}
     ";
 
+    // Act
     let error_reporter = parse_for_errors(slice);
 
+    // Assert
     assert_errors!(error_reporter, [
         "type mismatch: expected an exception but found a class",
     ]);
@@ -59,6 +65,7 @@ fn must_inherit_from_exception() {
 
 #[test]
 fn data_member_shadowing_is_disallowed() {
+    // Arrange
     let slice = "
         encoding = 1;
         module Test;
@@ -71,18 +78,21 @@ fn data_member_shadowing_is_disallowed() {
             i: int32
         }
     ";
+
+    // Act
+    let error_reporter = parse_for_errors(slice);
+
+    // Assert
     let expected = [
         LogicKind::Shadows("i".to_owned()).into(),
         ErrorKind::new_note("`i` was previously defined here".to_owned()),
     ];
-
-    let error_reporter = parse_for_errors(slice);
-
     assert_errors_new!(error_reporter, expected);
 }
 
 #[test]
 fn inherits_correct_data_members() {
+    // Arrange
     let slice = "
         encoding = 1;
         module Test;
@@ -100,7 +110,10 @@ fn inherits_correct_data_members() {
         }
     ";
 
+    // Act
     let ast = parse_for_ast(slice);
+
+    // Assert
     let exception_a_def = ast.find_element::<Exception>("Test::A").unwrap();
     let exception_b_def = ast.find_element::<Exception>("Test::B").unwrap();
     let exception_c_def = ast.find_element::<Exception>("Test::C").unwrap();

--- a/tests/exceptions/tags.rs
+++ b/tests/exceptions/tags.rs
@@ -14,6 +14,8 @@ fn can_contain_tags() {
             b: tag(10) bool?,
         }
     ";
+
+    // Act
     let ast = parse_for_ast(slice);
 
     // Assert

--- a/tests/interfaces/encoding.rs
+++ b/tests/interfaces/encoding.rs
@@ -7,6 +7,7 @@ use slice::parse_from_strings;
 
 #[test]
 fn operation_members_are_compatible_with_encoding() {
+    // Arrange
     let slice1 = "
         encoding = 1;
         module Test;
@@ -19,12 +20,14 @@ fn operation_members_are_compatible_with_encoding() {
             op(c: C);
         }
     ";
+
+    // Act
+    let result = parse_from_strings(&[slice1, slice2]).err().unwrap();
+
+    // Assert
     let expected = [
         LogicKind::UnsupportedType("C".to_owned(), Encoding::Slice2).into(),
         ErrorKind::new_note("file encoding was set to Slice2 here:".to_owned()),
     ];
-
-    let result = parse_from_strings(&[slice1, slice2]).err().unwrap();
-
     assert_errors_new!(result.error_reporter, expected);
 }

--- a/tests/interfaces/inheritance.rs
+++ b/tests/interfaces/inheritance.rs
@@ -7,13 +7,17 @@ use slice::grammar::*;
 
 #[test]
 fn supports_single_inheritance() {
+    // Arrange
     let slice = "
         module Test;
         interface I {}
         interface J : I {}
     ";
 
+    // Act
     let ast = parse_for_ast(slice);
+
+    // Assert
     let interface_i_def = ast.find_element::<Interface>("Test::I").unwrap();
     let interface_j_def = ast.find_element::<Interface>("Test::J").unwrap();
     let interface_j_bases = interface_j_def.base_interfaces();
@@ -28,6 +32,7 @@ fn supports_single_inheritance() {
 
 #[test]
 fn supports_multiple_inheritance() {
+    // Arrange
     let slice = "
         module Test;
         interface I {}
@@ -35,22 +40,22 @@ fn supports_multiple_inheritance() {
         interface K : I, J {}
     ";
 
+    // Act
     let ast = parse_for_ast(slice);
+
+    // Assert
     let interface_i_def = ast.find_element::<Interface>("Test::I").unwrap();
     let interface_j_def = ast.find_element::<Interface>("Test::J").unwrap();
     let interface_k_def = ast.find_element::<Interface>("Test::K").unwrap();
-
     let interface_k_bases = interface_k_def.base_interfaces();
 
     assert!(interface_i_def.base_interfaces().is_empty());
     assert!(interface_j_def.base_interfaces().is_empty());
     assert_eq!(interface_k_bases.len(), 2);
-
     assert_eq!(
         interface_k_bases[0].module_scoped_identifier(),
         interface_i_def.module_scoped_identifier(),
     );
-
     assert_eq!(
         interface_k_bases[1].module_scoped_identifier(),
         interface_j_def.module_scoped_identifier(),
@@ -60,6 +65,7 @@ fn supports_multiple_inheritance() {
 #[test]
 #[ignore = "reason: TODO Need to update AST Error emission"]
 fn must_inherit_from_interface() {
+    // Arrange
     let slice = "
         encoding = 1;
         module Test;
@@ -67,8 +73,10 @@ fn must_inherit_from_interface() {
         interface I : C {}
     ";
 
+    // Act
     let error_reporter = parse_for_errors(slice);
 
+    // Assert
     assert_errors!(error_reporter, [
         "type mismatch: expected an interface but found a class",
     ]);
@@ -76,6 +84,7 @@ fn must_inherit_from_interface() {
 
 #[test]
 fn operation_shadowing_is_disallowed() {
+    // Arrange
     let slice = "
         module Test;
         interface I
@@ -92,13 +101,16 @@ fn operation_shadowing_is_disallowed() {
         ErrorKind::new_note("`op` was previously defined here".to_owned()),
     ];
 
+    // Act
     let error_reporter = parse_for_errors(slice);
 
+    // Assert
     assert_errors_new!(error_reporter, expected);
 }
 
 #[test]
 fn inherits_correct_operations() {
+    // Arrange
     let slice = "
         module Test;
         interface A
@@ -118,7 +130,10 @@ fn inherits_correct_operations() {
         }
     ";
 
+    // Act
     let ast = parse_for_ast(slice);
+
+    // Assert
     let interface_a_def = ast.find_element::<Interface>("Test::A").unwrap();
     let interface_b_def = ast.find_element::<Interface>("Test::B").unwrap();
     let interface_d_def = ast.find_element::<Interface>("Test::D").unwrap();

--- a/tests/interfaces/mod.rs
+++ b/tests/interfaces/mod.rs
@@ -12,13 +12,16 @@ use slice::parse_from_string;
 
 #[test]
 fn can_have_no_operations() {
+    // Arrange
     let slice = "
         module Test;
         interface I {}
     ";
 
+    // Act
     let ast = parse_for_ast(slice);
 
+    // Assert
     let interface_def = ast.find_element::<Interface>("Test::I").unwrap();
     assert_eq!(interface_def.identifier(), "I");
     assert_eq!(interface_def.operations().len(), 0);
@@ -26,6 +29,7 @@ fn can_have_no_operations() {
 
 #[test]
 fn can_have_self_referencing_operations() {
+    // Arrange
     let slice = "
         module Test;
         interface I {
@@ -42,6 +46,7 @@ fn can_have_self_referencing_operations() {
 
 #[test]
 fn can_have_one_operation() {
+    // Arrange
     let slice = "
         module Test;
         interface I
@@ -50,14 +55,17 @@ fn can_have_one_operation() {
         }
     ";
 
+    // Act
     let ast = parse_for_ast(slice);
 
+    // Assert
     let interface_def = ast.find_element::<Interface>("Test::I").unwrap();
     assert_eq!(interface_def.operations().len(), 1);
 }
 
 #[test]
 fn can_have_multiple_operation() {
+    // Arrange
     let slice = "
         module Test;
         interface I
@@ -68,14 +76,17 @@ fn can_have_multiple_operation() {
         }
     ";
 
+    // Act
     let ast = parse_for_ast(slice);
 
+    // Assert
     let interface_def = ast.find_element::<Interface>("Test::I").unwrap();
     assert_eq!(interface_def.operations().len(), 3);
 }
 
 #[test]
 fn cannot_redefine_operations() {
+    // Arrange
     let slice = "
         encoding = 1;
         module Test;
@@ -85,12 +96,14 @@ fn cannot_redefine_operations() {
             op();
         }
     ";
+
+    // Act
+    let error_reporter = parse_for_errors(slice);
+
+    // Assert
     let expected: [ErrorKind; 2] = [
         LogicKind::Redefinition("op".to_owned()).into(),
         ErrorKind::new_note("`op` was previously defined here".to_owned()),
     ];
-
-    let error_reporter = parse_for_errors(slice);
-
     assert_errors_new!(error_reporter, expected);
 }

--- a/tests/interfaces/operations.rs
+++ b/tests/interfaces/operations.rs
@@ -7,6 +7,7 @@ use slice::grammar::*;
 
 #[test]
 fn can_have_no_parameters() {
+    // Arrange
     let slice = "
         module Test;
         interface I
@@ -15,14 +16,17 @@ fn can_have_no_parameters() {
         }
     ";
 
+    // Act
     let ast = parse_for_ast(slice);
 
+    // Assert
     let operation = ast.find_element::<Operation>("Test::I::op").unwrap();
     assert!(operation.parameters().is_empty());
 }
 
 #[test]
 fn can_have_no_return_type() {
+    // Arrange
     let slice = "
         module Test;
         interface I
@@ -31,8 +35,10 @@ fn can_have_no_return_type() {
         }
     ";
 
+    // Act
     let ast = parse_for_ast(slice);
 
+    // Assert
     let operation = ast.find_element::<Operation>("Test::I::op").unwrap();
     assert!(operation.return_members().is_empty());
 }
@@ -81,6 +87,7 @@ fn parameter_and_return_can_have_the_same_tag() {
 
 #[test]
 fn can_have_parameters() {
+    // Arrange
     let slice = "
         module Test;
         interface I
@@ -89,8 +96,10 @@ fn can_have_parameters() {
         }
     ";
 
+    // Act
     let ast = parse_for_ast(slice);
 
+    // Assert
     let operation = ast.find_element::<Operation>("Test::I::op").unwrap();
     let parameters = operation.parameters();
 
@@ -98,7 +107,6 @@ fn can_have_parameters() {
     assert_eq!(parameters[0].identifier(), "a");
     assert_eq!(parameters[1].identifier(), "b");
     assert_eq!(parameters[2].identifier(), "c");
-
     assert!(matches!(
         parameters[0].data_type.concrete_type(),
         Types::Primitive(Primitive::Int32),
@@ -115,6 +123,7 @@ fn can_have_parameters() {
 
 #[test]
 fn can_have_return_value() {
+    // Arrange
     let slice = "
         module Test;
         interface I
@@ -123,14 +132,15 @@ fn can_have_return_value() {
         }
     ";
 
+    // Act
     let ast = parse_for_ast(slice);
 
+    // Assert
     let operation = ast.find_element::<Operation>("Test::I::op").unwrap();
     let returns = operation.return_members();
 
     assert_eq!(returns.len(), 1);
     assert_eq!(returns[0].identifier(), "returnValue");
-
     assert!(matches!(
         returns[0].data_type.concrete_type(),
         Types::Primitive(Primitive::String),
@@ -139,6 +149,7 @@ fn can_have_return_value() {
 
 #[test]
 fn can_have_return_tuple() {
+    // Arrange
     let slice = "
         module Test;
         interface I
@@ -147,15 +158,16 @@ fn can_have_return_tuple() {
         }
     ";
 
+    // Act
     let ast = parse_for_ast(slice);
 
+    // Assert
     let operation = ast.find_element::<Operation>("Test::I::op").unwrap();
     let returns = operation.return_members();
 
     assert_eq!(returns.len(), 2);
     assert_eq!(returns[0].identifier(), "r1");
     assert_eq!(returns[1].identifier(), "r2");
-
     assert!(matches!(
         returns[0].data_type.concrete_type(),
         Types::Primitive(Primitive::String),
@@ -168,6 +180,7 @@ fn can_have_return_tuple() {
 
 #[test]
 fn return_tuple_must_contain_two_or_more_elements() {
+    // Arrange
     let slice = "
         module Test;
         interface I
@@ -175,10 +188,12 @@ fn return_tuple_must_contain_two_or_more_elements() {
             op() -> ();
         }
     ";
-    let expected: ErrorKind = LogicKind::ReturnTuplesMustContainAtLeastTwoElements.into();
 
+    // Act
     let error_reporter = parse_for_errors(slice);
 
+    // Assert
+    let expected: ErrorKind = LogicKind::ReturnTuplesMustContainAtLeastTwoElements.into();
     assert_errors_new!(error_reporter, [&expected]);
 }
 
@@ -190,6 +205,7 @@ mod streams {
 
     #[test]
     fn can_have_streamed_parameter_and_return() {
+        // Arrange
         let slice = "
             module Test;
             interface I
@@ -198,8 +214,10 @@ mod streams {
             }
         ";
 
+        // Act
         let ast = parse_for_ast(slice);
 
+        // Assert
         let operation = ast.find_element::<Operation>("Test::I::op").unwrap();
         let parameters = operation.parameters();
         let returns = operation.return_members();
@@ -210,6 +228,7 @@ mod streams {
 
     #[test]
     fn operation_can_have_at_most_one_streamed_parameter() {
+        // Arrange
         let slice = "
             module Test;
             interface I
@@ -217,14 +236,18 @@ mod streams {
                 op(s: stream varuint62, s2: stream string);
             }
         ";
-        let expected: ErrorKind = LogicKind::StreamsMustBeLast.into();
 
+        // Act
         let error_reporter = parse_for_errors(slice);
+
+        // Assert
+        let expected: ErrorKind = LogicKind::StreamsMustBeLast.into();
         assert_errors_new!(error_reporter, [&expected]);
     }
 
     #[test]
     fn stream_parameter_must_be_last() {
+        // Arrange
         let slice = "
             module Test;
             interface I
@@ -232,8 +255,11 @@ mod streams {
                 op(s: stream varuint62, i: int32);
             }
         ";
+
+        // Act
         let expected: ErrorKind = LogicKind::StreamsMustBeLast.into();
 
+        // Assert
         let error_reporter = parse_for_errors(slice);
         assert_errors_new!(error_reporter, [&expected]);
     }

--- a/tests/mixed_encoding_tests.rs
+++ b/tests/mixed_encoding_tests.rs
@@ -7,6 +7,7 @@ use slice::parse_from_strings;
 
 #[test]
 fn valid_mixed_encoding_works() {
+    // Arrange
     let encoding1_slice = "
         encoding = 1;
         module Test;
@@ -32,7 +33,6 @@ fn valid_mixed_encoding_works() {
             message: string,
         }
     ";
-
     let encoding2_slice = "
         encoding = 2;
         module Test;
@@ -45,11 +45,16 @@ fn valid_mixed_encoding_works() {
         }
     ";
 
-    assert!(parse_from_strings(&[encoding2_slice, encoding1_slice]).ok().is_some());
+    // Act
+    let parser_result = parse_from_strings(&[encoding2_slice, encoding1_slice]);
+
+    // Assert
+    assert!(parser_result.ok().is_some());
 }
 
 #[test]
 fn invalid_mixed_encoding_fails() {
+    // Arrange
     let encoding2_slice = "
         encoding = 2;
         module Test;
@@ -70,17 +75,19 @@ fn invalid_mixed_encoding_fails() {
             s: ACompactStruct,
         }
     ";
+
+    // Act
+    let parser_result = parse_from_strings(&[encoding1_slice, encoding2_slice]);
+
+    // Assert
+    // TODO: we should provide a better error message to the user here
+    let error_reporter = parser_result.err().unwrap().error_reporter;
     let expected = [
         LogicKind::UnsupportedType("ACustomType".to_owned(), Encoding::Slice1).into(),
         ErrorKind::new_note("file encoding was set to Slice1 here:"),
         LogicKind::UnsupportedType("ACompactStruct".to_owned(), Encoding::Slice1).into(),
         ErrorKind::new_note("file encoding was set to Slice1 here:"),
     ];
-    let error_reporter = parse_from_strings(&[encoding1_slice, encoding2_slice])
-        .err()
-        .unwrap()
-        .error_reporter;
 
-    // TODO: we should provide a better error message to the user here
     assert_errors_new!(error_reporter, expected);
 }

--- a/tests/module_tests.rs
+++ b/tests/module_tests.rs
@@ -10,6 +10,7 @@ mod module {
 
     #[test]
     fn can_be_reopened() {
+        // Arrange
         let slice = "
             module Test
             {
@@ -22,14 +23,17 @@ mod module {
             }
         ";
 
+        // Act
         let ast = parse_for_ast(slice);
 
+        // Assert
         assert!(ast.find_element::<Struct>("Test::S1").is_ok());
         assert!(ast.find_element::<Struct>("Test::S2").is_ok());
     }
 
     #[test]
     fn can_be_nested() {
+        // Arrange
         let slice = "
             module A
             {
@@ -37,30 +41,39 @@ mod module {
             }
         ";
 
+        // Act
         let ast = parse_for_ast(slice);
 
+        // Assert
         assert!(ast.find_element::<Module>("A::B").is_ok());
     }
 
     #[test]
     fn can_use_nested_syntax() {
+        // Arrange
         let slice = "
             module A::B::C::D {}
         ";
 
+        // Act
         let ast = parse_for_ast(slice);
 
+        // Assert
         assert!(ast.find_element::<Module>("A::B::C::D").is_ok());
     }
 
     #[test]
-    #[ignore = "Reece"]
     fn is_required() {
-        // TODO: better error message once we replace the parser
+        // Arrange
         let slice = "
             custom C;
         ";
+
+        // Act
         let err = parse_from_string(slice).err();
+
+        // Assert
+        // TODO: better error message once we replace the parser
         assert!(err.is_some());
     }
 }

--- a/tests/primitives/encoding.rs
+++ b/tests/primitives/encoding.rs
@@ -32,15 +32,15 @@ mod slice1 {
             ",
             value = value,
         );
-        let expected = [
-            LogicKind::UnsupportedType(value.to_owned(), Encoding::Slice1).into(),
-            ErrorKind::new_note("file encoding was set to Slice1 here:"),
-        ];
 
         // Act
         let error_reporter = parse_for_errors(slice);
 
         // Assert
+        let expected = [
+            LogicKind::UnsupportedType(value.to_owned(), Encoding::Slice1).into(),
+            ErrorKind::new_note("file encoding was set to Slice1 here:"),
+        ];
         assert_errors_new!(error_reporter, expected);
     }
 
@@ -97,6 +97,11 @@ mod slice2 {
                 v: AnyClass,
             }
         ";
+
+        // Act
+        let error_reporter = parse_for_errors(slice);
+
+        // Assert
         let expected = [
             LogicKind::UnsupportedType("AnyClass".to_owned(), Encoding::Slice2).into(),
             ErrorKind::new_note("file is using the Slice2 encoding by default"),
@@ -104,11 +109,6 @@ mod slice2 {
                 "to use a different encoding, specify it at the top of the slice file\nex: 'encoding = 1;'",
             ),
         ];
-
-        // Act
-        let error_reporter = parse_for_errors(slice);
-
-        // Assert
         assert_errors_new!(error_reporter, expected);
     }
 

--- a/tests/primitives/mod.rs
+++ b/tests/primitives/mod.rs
@@ -24,6 +24,7 @@ use test_case::test_case;
 #[test_case("string", Primitive::String, None; "string")]
 #[test_case("AnyClass", Primitive::AnyClass, Some("encoding = 1;"); "AnyClass")]
 fn type_parses(slice_component: &str, expected: Primitive, encoding: Option<&str>) {
+    // Arrange
     let slice = format!(
         "
             {encoding}
@@ -34,8 +35,10 @@ fn type_parses(slice_component: &str, expected: Primitive, encoding: Option<&str
         slice_component = slice_component,
     );
 
+    // Act
     let ast = parse_for_ast(slice);
 
+    // Assert
     let primitive_ptr = ast
         .find_element::<TypeAlias>("Test::P")
         .unwrap()

--- a/tests/scope_resolution_tests.rs
+++ b/tests/scope_resolution_tests.rs
@@ -11,12 +11,16 @@ mod scope_resolution {
 
     #[test]
     fn file_level_modules_can_not_contain_sub_modules() {
+        // Arrange
         let slice = "
             module T;
             module S {}
         ";
+
+        // Act
         let error_reporter = parse_for_errors(slice);
 
+        // Assert
         assert_errors!(error_reporter, [
             "file level modules cannot contain sub-modules",
             "file level module 'T' declared here",
@@ -25,6 +29,7 @@ mod scope_resolution {
 
     #[test]
     fn identifier_exists_in_module_and_submodule() {
+        // Arrange
         let slice = "
             module A
             {
@@ -48,8 +53,10 @@ mod scope_resolution {
             }
         ";
 
+        // Act
         let ast = parse_for_ast(slice);
 
+        // Assert
         let s1_type = ast.find_element::<DataMember>("A::C::s1").unwrap().data_type();
         let s2_type = ast.find_element::<DataMember>("A::C::s2").unwrap().data_type();
         let s3_type = ast.find_element::<DataMember>("A::C::s3").unwrap().data_type();
@@ -63,6 +70,7 @@ mod scope_resolution {
 
     #[test]
     fn identifier_exists_in_module_and_parent_module() {
+        // Arrange
         let slice = "
             module A
             {
@@ -83,8 +91,10 @@ mod scope_resolution {
             }
         ";
 
+        // Act
         let ast = parse_for_ast(slice);
 
+        // Assert
         let s1_type = ast.find_element::<DataMember>("A::B::C::s1").unwrap().data_type();
         let s2_type = ast.find_element::<DataMember>("A::B::C::s2").unwrap().data_type();
         let s3_type = ast.find_element::<DataMember>("A::B::C::s3").unwrap().data_type();
@@ -98,6 +108,7 @@ mod scope_resolution {
 
     #[test]
     fn identifier_exists_in_multiple_parent_modules() {
+        // Arrange
         let slice = "
             module A
             {
@@ -125,8 +136,10 @@ mod scope_resolution {
             }
         ";
 
+        // Act
         let ast = parse_for_ast(slice);
 
+        // Assert
         let s1_type = ast.find_element::<DataMember>("A::B::B::C::s1").unwrap().data_type();
         let s2_type = ast.find_element::<DataMember>("A::B::B::C::s2").unwrap().data_type();
         let s3_type = ast.find_element::<DataMember>("A::B::B::C::s3").unwrap().data_type();
@@ -138,6 +151,7 @@ mod scope_resolution {
 
     #[test]
     fn identifier_exists_in_multiple_modules_with_common_partial_scope() {
+        // Arrange
         let slice = "
             module A
             {
@@ -168,8 +182,10 @@ mod scope_resolution {
             }
         ";
 
+        // Act
         let ast = parse_for_ast(slice);
 
+        // Assert
         let nested_s1_type = ast.find_element::<DataMember>("A::B::A::B::C::s1").unwrap().data_type();
         let nested_s2_type = ast.find_element::<DataMember>("A::B::A::B::C::s2").unwrap().data_type();
         let s1_type = ast.find_element::<DataMember>("A::C::s1").unwrap().data_type();
@@ -183,7 +199,6 @@ mod scope_resolution {
             nested_s2_type.concrete_type(),
             Types::Primitive(Primitive::String),
         ));
-
         assert!(matches!(s1_type.concrete_type(), Types::Primitive(Primitive::String)));
         assert!(matches!(s2_type.concrete_type(), Types::Primitive(Primitive::String)));
     }
@@ -208,15 +223,15 @@ mod scope_resolution {
                 }
             }
         ";
-        let expected = [
-            LogicKind::Redefinition("B".to_string()).into(),
-            ErrorKind::new_note("`B` was previously defined here"),
-        ];
 
         // Act
         let error_reporter = parse_for_errors(slice);
 
         // Assert
+        let expected = [
+            LogicKind::Redefinition("B".to_string()).into(),
+            ErrorKind::new_note("`B` was previously defined here"),
+        ];
         assert_errors_new!(error_reporter, expected);
     }
 

--- a/tests/sequence_tests.rs
+++ b/tests/sequence_tests.rs
@@ -11,8 +11,8 @@ mod sequences {
     fn can_contain_primitive_types() {
         // Arrange
         let slice = "
-        module Test;
-        typealias Seq = sequence<int8>;
+            module Test;
+            typealias Seq = sequence<int8>;
         ";
 
         // Act
@@ -22,6 +22,7 @@ mod sequences {
         let seq_def = ast.find_element::<TypeAlias>("Test::Seq").unwrap();
         let seq_type = seq_def.underlying.concrete_typeref();
 
+        // TODO: Remove if check from test
         if let TypeRefs::Sequence(seq) = seq_type {
             matches!(&seq.element_type.concrete_type(), Types::Primitive(Primitive::Int8));
         } else {

--- a/tests/structs/container.rs
+++ b/tests/structs/container.rs
@@ -28,11 +28,9 @@ mod structs {
         let data_members = ast.find_element::<Struct>("Test::S").unwrap().members();
 
         assert_eq!(data_members.len(), 3);
-
         assert_eq!(data_members[0].identifier(), "i");
         assert_eq!(data_members[1].identifier(), "s");
         assert_eq!(data_members[2].identifier(), "b");
-
         assert!(matches!(
             data_members[0].data_type.concrete_type(),
             Types::Primitive(Primitive::Int32),
@@ -66,6 +64,7 @@ mod structs {
 
     #[test]
     fn cannot_redefine_data_members() {
+        // Arrange
         let slice = "
             module Test;
             struct S
@@ -74,13 +73,15 @@ mod structs {
                 a: string,
             }
         ";
+
+        // Act
+        let error_reporter = parse_for_errors(slice);
+
+        // Assert
         let expected = [
             LogicKind::Redefinition("a".to_owned()).into(),
             ErrorKind::new_note("`a` was previously defined here".to_owned()),
         ];
-
-        let error_reporter = parse_for_errors(slice);
-
         assert_errors_new!(error_reporter, expected);
     }
 }
@@ -98,12 +99,12 @@ mod compact_structs {
             module Test;
             compact struct S {}
         ";
-        let expected: ErrorKind = LogicKind::CompactStructIsEmpty.into();
 
         // Act
         let error_reporter = parse_for_errors(slice);
 
         // Assert
+        let expected: ErrorKind = LogicKind::CompactStructIsEmpty.into();
         assert_errors_new!(error_reporter, [&expected]);
     }
 }

--- a/tests/structs/encoding.rs
+++ b/tests/structs/encoding.rs
@@ -17,16 +17,16 @@ mod slice1 {
             module Test;
             struct A {}
         ";
-        let expected = [
-            LogicKind::NotSupportedWithEncoding("struct".to_owned(), "A".to_owned(), Encoding::Slice1).into(),
-            ErrorKind::new_note("file encoding was set to Slice1 here:"),
-            ErrorKind::new_note("structs must be `compact` to be supported by the Slice1 encoding"),
-        ];
 
         // Act
         let error_reporter = parse_for_errors(slice);
 
         // Assert
+        let expected = [
+            LogicKind::NotSupportedWithEncoding("struct".to_owned(), "A".to_owned(), Encoding::Slice1).into(),
+            ErrorKind::new_note("file encoding was set to Slice1 here:"),
+            ErrorKind::new_note("structs must be `compact` to be supported by the Slice1 encoding"),
+        ];
         assert_errors_new!(error_reporter, expected);
     }
 }
@@ -50,6 +50,11 @@ mod slice2 {
                 c: AnyClass,
             }
         ";
+
+        // Act
+        let error_reporter = parse_for_errors(slice);
+
+        // Assert
         let expected: [ErrorKind; 3] = [
             LogicKind::UnsupportedType("AnyClass".to_owned(), Encoding::Slice2).into(),
             ErrorKind::new_note("file is using the Slice2 encoding by default"),
@@ -57,11 +62,6 @@ mod slice2 {
                 "to use a different encoding, specify it at the top of the slice file\nex: 'encoding = 1;'",
             ),
         ];
-
-        // Act
-        let error_reporter = parse_for_errors(slice);
-
-        // Assert
         assert_errors_new!(error_reporter, expected);
     }
 
@@ -88,5 +88,3 @@ mod slice2 {
         assert_errors!(error_reporter);
     }
 }
-
-mod compact_structs {}

--- a/tests/structs/tags.rs
+++ b/tests/structs/tags.rs
@@ -16,6 +16,8 @@ mod structs {
                 b: tag(10) bool?,
             }
         ";
+
+        // Act
         let ast = parse_for_ast(slice);
 
         // Assert
@@ -26,10 +28,9 @@ mod structs {
 
 mod compact_structs {
 
-    use slice::errors::{ErrorKind, LogicKind};
-
     use crate::assert_errors_new;
     use crate::helpers::parsing_helpers::*;
+    use slice::errors::{ErrorKind, LogicKind};
 
     #[test]
     fn cannot_contain_tags() {
@@ -42,15 +43,15 @@ mod compact_structs {
                 b: tag(10) bool?,
             }
         ";
-        let expected = [
-            LogicKind::NotSupportedInCompactStructs.into(),
-            ErrorKind::new_note("struct 'S' is declared compact here"),
-        ];
 
         // Act
         let error_reporter = parse_for_errors(slice);
 
         // Assert
+        let expected = [
+            LogicKind::NotSupportedInCompactStructs.into(),
+            ErrorKind::new_note("struct 'S' is declared compact here"),
+        ];
         assert_errors_new!(error_reporter, expected);
     }
 }

--- a/tests/tag_tests.rs
+++ b/tests/tag_tests.rs
@@ -22,10 +22,12 @@ mod tags {
                 b: tag(10) bool,
             }
         ";
-        let expected: ErrorKind = LogicKind::MustBeOptional.into();
+
+        // Act
         let error_reporter = parse_for_errors(slice);
 
         // Assert
+        let expected: ErrorKind = LogicKind::MustBeOptional.into();
         assert_errors_new!(error_reporter, [&expected]);
     }
 
@@ -39,11 +41,12 @@ mod tags {
                 op(myParam: tag(10) int32);
             }
         ";
-        let expected: ErrorKind = LogicKind::MustBeOptional.into();
 
+        // Act
         let error_reporter = parse_for_errors(slice);
 
         // Assert
+        let expected: ErrorKind = LogicKind::MustBeOptional.into();
         assert_errors_new!(error_reporter, [&expected]);
     }
 
@@ -59,6 +62,7 @@ mod tags {
             }
         ";
 
+        // Act
         let error_reporter = parse_for_errors(slice);
 
         // Assert
@@ -78,13 +82,15 @@ mod tags {
                 op(p1: int32, p2: tag(10) int32?, p3: int32, p4: int32, p5: tag(20) int32?);
             }
         ";
+
+        // Act
+        let error_reporter = parse_for_errors(slice);
+
+        // Assert
         let expected: [ErrorKind; 2] = [
             LogicKind::RequiredParametersMustBeFirst.into(),
             LogicKind::RequiredParametersMustBeFirst.into(),
         ];
-        let error_reporter = parse_for_errors(slice);
-
-        // Assert
         assert_errors_new!(error_reporter, expected);
     }
 
@@ -101,12 +107,12 @@ mod tags {
                 op(c: tag(1) C?);
             }
         ";
-        let expected: ErrorKind = LogicKind::CannotBeClass.into();
 
         // Act
         let errors = parse_for_errors(slice);
 
         // Assert
+        let expected: ErrorKind = LogicKind::CannotBeClass.into();
         assert_errors_new!(errors, [&expected]);
     }
 
@@ -126,12 +132,12 @@ mod tags {
                 op(s: tag(1) S?);
             }
         ";
-        let expected: ErrorKind = LogicKind::CannotContainClasses.into();
 
         // Act
         let errors = parse_for_errors(slice);
 
         // Assert
+        let expected: ErrorKind = LogicKind::CannotContainClasses.into();
         assert_errors_new!(errors, [&expected]);
     }
 
@@ -150,6 +156,7 @@ mod tags {
 
         // Assert
         let data_member = ast.find_element::<DataMember>("Test::S::a").unwrap();
+
         assert_eq!(data_member.tag(), Some(1));
         assert!(data_member.data_type.is_optional);
     }
@@ -168,12 +175,11 @@ mod tags {
         // Act
         let error_reporter = parse_for_errors(slice);
 
+        // Assert
         let expected = [
             LogicKind::DuplicateTag.into(),
             ErrorKind::new_note("The data member `a` has previous used the tag value `1`".to_owned()),
         ];
-
-        // Assert
         assert_errors_new!(error_reporter, expected);
     }
 
@@ -191,12 +197,12 @@ mod tags {
             ",
             value = max_value + 1
         );
-        let expected: ErrorKind = LogicKind::TagOutOfBounds.into();
 
         // Act
         let error_reporter = parse_for_errors(slice);
 
         // Assert
+        let expected: ErrorKind = LogicKind::TagOutOfBounds.into();
         assert_errors_new!(error_reporter, [&expected]);
     }
 
@@ -213,12 +219,12 @@ mod tags {
             ",
             value = -1
         );
-        let expected: ErrorKind = LogicKind::MustBePositive("a".to_owned()).into();
 
         // Act
         let error_reporter = parse_for_errors(slice);
 
         // Assert
+        let expected: ErrorKind = LogicKind::MustBePositive("a".to_owned()).into();
         assert_errors_new!(error_reporter, [&expected]);
     }
 

--- a/tests/trait_tests.rs
+++ b/tests/trait_tests.rs
@@ -25,17 +25,17 @@ mod traits {
                     module Test;
                     trait ATrait;
                 ";
+
+                // Act
+                let error_reporter = parse_for_errors(slice);
+
+                // Assert
                 let expected = [
                     LogicKind::NotSupportedWithEncoding("trait".to_owned(), "ATrait".to_owned(), Encoding::Slice1)
                         .into(),
                     ErrorKind::new_note("file encoding was set to Slice1 here:".to_owned()),
                     ErrorKind::new_note("traits are not supported by the Slice1 encoding".to_owned()),
                 ];
-
-                // Act
-                let error_reporter = parse_for_errors(slice);
-
-                // Assert
                 assert_errors_new!(error_reporter, expected);
             }
         }

--- a/tests/typealias_tests.rs
+++ b/tests/typealias_tests.rs
@@ -90,6 +90,7 @@ mod typealias {
 
         // Assert
         let type_alias = ast.find_element::<TypeAlias>("Test::MyInt").unwrap();
+
         assert_eq!(type_alias.identifier(), "MyInt");
         assert!(matches!(
             type_alias.underlying.concrete_type(),
@@ -114,6 +115,7 @@ mod typealias {
 
         // Assert
         let data_member = ast.find_element::<DataMember>("Test::S::a").unwrap();
+
         assert_eq!(data_member.identifier(), "a");
         assert!(matches!(
             data_member.data_type.concrete_type(),


### PR DESCRIPTION
Closes #205 

This PR moves expected setup from the arrange section to the assert section. It additionally does minor cleanup.