### PR TITLE
Implemented Locatable trait

### DIFF
--- a/src/ast/patchers/encoding_patcher.rs
+++ b/src/ast/patchers/encoding_patcher.rs
@@ -96,7 +96,7 @@ impl EncodingPatcher<'_> {
                 entity_def.identifier().to_owned(),
                 file_encoding,
             );
-            self.error_reporter.report(error, Some(entity_def.span()));
+            self.error_reporter.report(error, Some(entity_def));
             self.emit_file_encoding_mismatch_error(entity_def);
 
             // Replace the supported encodings with a dummy that supports all encodings.
@@ -183,7 +183,7 @@ impl EncodingPatcher<'_> {
                 errors.push(error);
             }
             for error in errors {
-                self.error_reporter.report(error, Some(type_ref.span()));
+                self.error_reporter.report(error, Some(type_ref));
             }
             self.emit_file_encoding_mismatch_error(type_ref);
 
@@ -352,7 +352,7 @@ impl ComputeSupportedEncodings for Interface {
                 // Streamed parameters are not supported by the Slice1 encoding.
                 if member.is_streamed && *file_encoding == Encoding::Slice1 {
                     let error = LogicKind::StreamedParametersNotSupported(Encoding::Slice1);
-                    patcher.error_reporter.report(error, Some(member.span()));
+                    patcher.error_reporter.report(error, Some(member));
                     patcher.emit_file_encoding_mismatch_error(member);
                 }
             }

--- a/src/ast/patchers/type_ref_patcher.rs
+++ b/src/ast/patchers/type_ref_patcher.rs
@@ -209,8 +209,7 @@ impl TypeRefPatcher<'_> {
         match lookup_result {
             Ok(definition) => Some(definition),
             Err(message) => {
-                self.error_reporter
-                    .report(ErrorKind::Syntax(message), Some(type_ref.span()));
+                self.error_reporter.report(ErrorKind::Syntax(message), Some(type_ref));
                 None
             }
         }
@@ -256,7 +255,7 @@ impl TypeRefPatcher<'_> {
                 type_alias_chain.push(current_type_alias);
                 let error =
                     LogicKind::SelfReferentialTypeAliasNeedsConcreteType(current_type_alias.module_scoped_identifier());
-                self.error_reporter.report(error, Some(current_type_alias.span()));
+                self.error_reporter.report(error, Some(current_type_alias));
                 for window in type_alias_chain[i..].windows(2) {
                     let message = format!(
                         "type alias '{}' uses type alias '{}' here:",
@@ -264,7 +263,7 @@ impl TypeRefPatcher<'_> {
                         window[1].identifier(),
                     );
                     self.error_reporter
-                        .report(ErrorKind::new_note(message), Some(window[0].underlying.span()));
+                        .report(ErrorKind::new_note(message), Some(&window[0].underlying));
                 }
 
                 return Err("Failed to resolve type due to a cycle in its definition".to_owned());

--- a/src/grammar/comments.rs
+++ b/src/grammar/comments.rs
@@ -1,6 +1,9 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
+use crate::grammar::Locatable;
 use crate::slice_file::Span;
+
+use super::implement_Locatable_for;
 
 // TODO improve this to track the span of individual doc comment fields, so we can check for
 // comment validity: EX: making sure 'params' match the operation's actual parameters, etc.
@@ -32,3 +35,5 @@ impl DocComment {
             .collect();
     }
 }
+
+implement_Locatable_for!(DocComment);

--- a/src/grammar/elements/attribute.rs
+++ b/src/grammar/elements/attribute.rs
@@ -29,4 +29,5 @@ impl Attribute {
 }
 
 implement_Element_for!(Attribute, "attribute");
+implement_Locatable_for!(Attribute);
 implement_Symbol_for!(Attribute);

--- a/src/grammar/elements/file_encoding.rs
+++ b/src/grammar/elements/file_encoding.rs
@@ -10,4 +10,5 @@ pub struct FileEncoding {
 }
 
 implement_Element_for!(FileEncoding, "file encoding");
+implement_Locatable_for!(FileEncoding);
 implement_Symbol_for!(FileEncoding);

--- a/src/grammar/elements/identifier.rs
+++ b/src/grammar/elements/identifier.rs
@@ -21,4 +21,5 @@ impl Identifier {
 }
 
 implement_Element_for!(Identifier, "identifier");
+implement_Locatable_for!(Identifier);
 implement_Symbol_for!(Identifier);

--- a/src/grammar/elements/type_ref.rs
+++ b/src/grammar/elements/type_ref.rs
@@ -128,5 +128,6 @@ impl<T: Element + ?Sized> std::ops::Deref for TypeRef<T> {
 }
 
 implement_Element_for!(TypeRef<T>, "type reference", Element + ?Sized);
+implement_Locatable_for!(TypeRef<T>, Element + ?Sized);
 implement_Symbol_for!(TypeRef<T>, Element + ?Sized);
 implement_Scoped_Symbol_for!(TypeRef<T>, Element + ?Sized);

--- a/src/grammar/traits.rs
+++ b/src/grammar/traits.rs
@@ -11,9 +11,11 @@ pub trait Element: std::fmt::Debug {
     fn kind(&self) -> &'static str;
 }
 
-pub trait Symbol: Element {
+pub trait Locatable {
     fn span(&self) -> &Span;
 }
+
+pub trait Symbol: Element + Locatable {}
 
 pub trait ScopedSymbol: Symbol {
     fn module_scope(&self) -> &str;
@@ -105,13 +107,19 @@ macro_rules! implement_Element_for {
     };
 }
 
-macro_rules! implement_Symbol_for {
+macro_rules! implement_Locatable_for {
     ($type:ty$(, $($bounds:tt)+)?) => {
-        impl$(<T: $($bounds)+>)? Symbol for $type {
+        impl$(<T: $($bounds)+>)? Locatable for $type {
             fn span(&self) -> &Span {
                 &self.span
             }
         }
+    };
+}
+
+macro_rules! implement_Symbol_for {
+    ($type:ty$(, $($bounds:tt)+)?) => {
+        impl$(<T: $($bounds)+>)? Symbol for $type { }
     };
 }
 
@@ -182,6 +190,7 @@ macro_rules! implement_Commentable_for {
 
 macro_rules! implement_Entity_for {
     ($type:ty) => {
+        implement_Locatable_for!($type);
         implement_Symbol_for!($type);
         implement_Named_Symbol_for!($type);
         implement_Scoped_Symbol_for!($type);
@@ -228,6 +237,6 @@ macro_rules! implement_Member_for {
 
 pub(crate) use {
     implement_Attributable_for, implement_Commentable_for, implement_Contained_for, implement_Container_for,
-    implement_Element_for, implement_Entity_for, implement_Member_for, implement_Named_Symbol_for,
-    implement_Scoped_Symbol_for, implement_Symbol_for,
+    implement_Element_for, implement_Entity_for, implement_Locatable_for, implement_Member_for,
+    implement_Named_Symbol_for, implement_Scoped_Symbol_for, implement_Symbol_for,
 };

--- a/src/parser/cycle_detection.rs
+++ b/src/parser/cycle_detection.rs
@@ -34,8 +34,7 @@ impl<'a> CycleDetector<'a> {
                 type_id = &type_id,
                 cycle_string = &self.dependency_stack[i..].join(" -> "),
             );
-            self.error_reporter
-                .report(ErrorKind::Syntax(message), Some(type_def.span()));
+            self.error_reporter.report(ErrorKind::Syntax(message), Some(type_def));
 
             true
         } else {

--- a/src/parser/slice.rs
+++ b/src/parser/slice.rs
@@ -264,9 +264,9 @@ impl<'a> SliceParser<'a> {
             [_, identifier(identifier), compact_id(compact_id), _, inheritance_list(bases)] => {
                 // Classes can only inherit from a single base class.
                 if bases.len() > 1 {
-                    input.user_data().borrow_mut().error_reporter.report(
+                    input.user_data().borrow_mut().error_reporter.report_span(
                         LogicKind::ClassesCanOnlyInheritFromSingleBase,
-                        Some(&span),
+                        &span,
                     );
                 }
 
@@ -306,9 +306,9 @@ impl<'a> SliceParser<'a> {
             [_, identifier(identifier), _, inheritance_list(bases)] => {
                 // Exceptions can only inherit from a single base exception.
                 if bases.len() > 1 {
-                    input.user_data().borrow_mut().error_reporter.report(
+                    input.user_data().borrow_mut().error_reporter.report_span(
                         LogicKind::CanOnlyInheritFromSingleBase,
-                        Some(&span),
+                        &span,
                     )
                 }
 
@@ -512,9 +512,9 @@ impl<'a> SliceParser<'a> {
                 // TODO: should we move this into the validators, instead of a parse-time check?
                 if return_elements.len() < 2 {
                     let span = get_span_for(&input);
-                    input.user_data().borrow_mut().error_reporter.report(
+                    input.user_data().borrow_mut().error_reporter.report_span(
                         LogicKind::ReturnTuplesMustContainAtLeastTwoElements,
-                        Some(&span),
+                        &span,
                     );
                 }
                 return_elements
@@ -650,7 +650,7 @@ impl<'a> SliceParser<'a> {
                 // Checking that tags must fit in an i32 and be non-negative.
                 if !RangeInclusive::new(0, (i32::MAX - 1) as i64).contains(&integer) {
                     let span = get_span_for(&input);
-                    input.user_data().borrow_mut().error_reporter.report(LogicKind::TagOutOfBounds, Some(&span));
+                    input.user_data().borrow_mut().error_reporter.report_span(LogicKind::TagOutOfBounds, &span);
                 }
                 integer as u32
             }
@@ -1171,12 +1171,12 @@ impl<'a> SliceParser<'a> {
 
                             error_reporter.report(
                                 ErrorKind::Syntax("file level modules cannot contain sub-modules".to_owned()),
-                                Some(&module_def.borrow().span),
+                                Some(module_def.borrow()),
                             );
 
-                            error_reporter.report(
+                            error_reporter.report_span(
                                 ErrorKind::new_note(format!("file level module '{}' declared here", &identifier.value)),
-                                Some(&span),
+                                &span,
                             );
                         }
                     }

--- a/src/validators/attribute.rs
+++ b/src/validators/attribute.rs
@@ -38,7 +38,7 @@ fn validate_format_attribute(operation: &Operation, error_reporter: &mut ErrorRe
     if let Some(attribute) = operation.get_raw_attribute("format", false) {
         match attribute.arguments.len() {
             // The format attribute must have arguments
-            0 => error_reporter.report(LogicKind::CannotBeEmpty("format attribute"), Some(attribute.span())),
+            0 => error_reporter.report(LogicKind::CannotBeEmpty("format attribute"), Some(attribute)),
             _ => {
                 // Validate format attributes are allowed ones.
                 attribute
@@ -51,14 +51,14 @@ fn validate_format_attribute(operation: &Operation, error_reporter: &mut ErrorRe
                     .for_each(|arg| {
                         error_reporter.report(
                             LogicKind::ArgumentNotSupported(arg.to_owned(), "format attribute".to_owned()),
-                            Some(attribute.span()),
+                            Some(attribute),
                         );
                         error_reporter.report(
                             ErrorKind::new_note(format!(
                                 "The valid arguments for the format attribute are {}",
                                 message_value_separator(&["Compact", "Sliced"])
                             )),
-                            Some(attribute.span()),
+                            Some(attribute),
                         );
                     });
             }
@@ -70,9 +70,9 @@ fn validate_format_attribute(operation: &Operation, error_reporter: &mut ErrorRe
 fn cannot_be_deprecated(members: Vec<&dyn Member>, error_reporter: &mut ErrorReporter) {
     members.iter().for_each(|m| {
         if m.has_attribute("deprecated", false) {
-            error_reporter.report(
+            error_reporter.report_span(
                 LogicKind::DeprecatedAttributeCannotBeApplied(m.kind().to_owned() + "(s)"),
-                Some(m.span()),
+                m.span(),
             );
         }
     });
@@ -87,9 +87,7 @@ fn is_compressible(element: &dyn Attributable, error_reporter: &mut ErrorReporte
     let kind = element.kind();
     if !supported_on.contains(&kind) {
         match element.get_raw_attribute("compress", false) {
-            Some(attribute) => {
-                error_reporter.report(LogicKind::CompressAttributeCannotBeApplied, Some(attribute.span()))
-            }
+            Some(attribute) => error_reporter.report(LogicKind::CompressAttributeCannotBeApplied, Some(attribute)),
             None => (),
         }
     }
@@ -102,14 +100,14 @@ fn is_compressible(element: &dyn Attributable, error_reporter: &mut ErrorReporte
                 if !valid_arguments.contains(&arg.as_str()) {
                     error_reporter.report(
                         LogicKind::ArgumentNotSupported(arg.to_owned(), "compress attribute".to_owned()),
-                        Some(attribute.span()),
+                        Some(attribute),
                     );
                     error_reporter.report(
                         ErrorKind::new_note(format!(
                             "The valid argument(s) for the compress attribute are {}",
                             message_value_separator(&valid_arguments).as_str(),
                         )),
-                        Some(attribute.span()),
+                        Some(attribute),
                     );
                 }
             }),

--- a/src/validators/comments.rs
+++ b/src/validators/comments.rs
@@ -18,7 +18,7 @@ fn non_empty_return_comment(operation: &Operation, error_reporter: &mut ErrorRep
         // `DocComment.return_members` contains a list of descriptions of the return members.
         // example: @return A description of the return value.`
         if comment.returns.is_some() && operation.return_members().is_empty() {
-            error_reporter.report(WarningKind::DocCommentIndicatesReturn, Some(&comment.span));
+            error_reporter.report(WarningKind::DocCommentIndicatesReturn, Some(comment));
         }
     }
 }
@@ -32,10 +32,7 @@ fn missing_parameter_comment(operation: &Operation, error_reporter: &mut ErrorRe
                 .map(|p| p.identifier.value.clone())
                 .any(|identifier| identifier == param.0)
             {
-                error_reporter.report(
-                    WarningKind::DocCommentIndicatesParam(param.0.clone()),
-                    Some(&comment.span),
-                );
+                error_reporter.report(WarningKind::DocCommentIndicatesParam(param.0.clone()), Some(comment));
             }
         });
     }
@@ -49,7 +46,7 @@ fn only_operations_can_throw(commentable: &dyn Entity, error_reporter: &mut Erro
                 commentable.kind().to_owned(),
                 commentable.identifier().to_owned(),
             );
-            error_reporter.report(warning, Some(&comment.span));
+            error_reporter.report(warning, Some(comment));
         };
     }
 }

--- a/src/validators/identifiers.rs
+++ b/src/validators/identifiers.rs
@@ -17,10 +17,10 @@ pub fn check_for_redefinition(mut identifiers: Vec<&Identifier>, error_reporter:
     identifiers.windows(2).for_each(|window| {
         if window[0].value == window[1].value {
             let error = LogicKind::Redefinition(window[1].value.clone());
-            error_reporter.report(error, Some(window[1].span()));
+            error_reporter.report(error, Some(window[1]));
             error_reporter.report(
                 ErrorKind::new_note(format!("`{}` was previously defined here", window[0].value)),
-                Some(window[0].span()),
+                Some(window[0]),
             );
         }
     });
@@ -37,10 +37,10 @@ pub fn check_for_shadowing(
             .filter(|inherited_identifier| inherited_identifier.value == identifier.value)
             .for_each(|inherited_identifier| {
                 let error = LogicKind::Shadows(identifier.value.clone());
-                error_reporter.report(error, Some(identifier.span()));
+                error_reporter.report(error, Some(*identifier));
                 error_reporter.report(
                     ErrorKind::new_note(format!("`{}` was previously defined here", inherited_identifier.value)),
-                    Some(inherited_identifier.span()),
+                    Some(*inherited_identifier),
                 );
             });
     });

--- a/src/validators/miscellaneous.rs
+++ b/src/validators/miscellaneous.rs
@@ -18,7 +18,7 @@ fn stream_parameter_is_last(members: &[&Parameter], error_reporter: &mut ErrorRe
     if let Some((_, nonstreamed_members)) = members.split_last() {
         for member in nonstreamed_members {
             if member.is_streamed {
-                error_reporter.report(LogicKind::StreamsMustBeLast, Some(member.span()));
+                error_reporter.report(LogicKind::StreamsMustBeLast, Some(*member));
             }
         }
     }
@@ -27,6 +27,6 @@ fn stream_parameter_is_last(members: &[&Parameter], error_reporter: &mut ErrorRe
 fn validate_compact_struct_not_empty(struct_def: &Struct, error_reporter: &mut ErrorReporter) {
     // Compact structs must be non-empty.
     if struct_def.is_compact && struct_def.members().is_empty() {
-        error_reporter.report(LogicKind::CompactStructIsEmpty, Some(struct_def.span()));
+        error_reporter.report(LogicKind::CompactStructIsEmpty, Some(struct_def));
     }
 }

--- a/src/validators/tag.rs
+++ b/src/validators/tag.rs
@@ -28,14 +28,14 @@ fn tags_are_unique(members: Vec<&dyn Member>, error_reporter: &mut ErrorReporter
     tagged_members.sort_by_key(|member| member.tag().unwrap());
     tagged_members.windows(2).for_each(|window| {
         if window[0].tag() == window[1].tag() {
-            error_reporter.report(LogicKind::DuplicateTag, Some(window[1].span()));
-            error_reporter.report(
+            error_reporter.report_span(LogicKind::DuplicateTag, window[1].span());
+            error_reporter.report_span(
                 ErrorKind::new_note(format!(
                     "The data member `{}` has previous used the tag value `{}`",
                     &window[0].identifier(),
                     window[0].tag().unwrap()
                 )),
-                Some(window[0].span()),
+                window[0].span(),
             );
         };
     });
@@ -50,7 +50,7 @@ fn parameter_order(parameters: &[&Parameter], error_reporter: &mut ErrorReporter
         Some(_) => true,
         None if seen => {
             let error = LogicKind::RequiredParametersMustBeFirst;
-            error_reporter.report(error, Some(parameter.data_type.span()));
+            error_reporter.report(error, Some(&parameter.data_type));
             true
         }
         None => false,
@@ -65,10 +65,10 @@ fn compact_structs_cannot_contain_tags(struct_def: &Struct, error_reporter: &mut
         for member in struct_def.members() {
             if member.tag.is_some() {
                 let error = LogicKind::NotSupportedInCompactStructs;
-                error_reporter.report(error, Some(member.span()));
+                error_reporter.report(error, Some(member));
                 error_reporter.report(
                     ErrorKind::new_note(format!("struct '{}' is declared compact here", struct_def.identifier())),
-                    Some(struct_def.span()),
+                    Some(struct_def),
                 );
             }
         }
@@ -86,7 +86,7 @@ fn tags_have_optional_types(members: Vec<&dyn Member>, error_reporter: &mut Erro
     // Validate that tagged members are optional.
     for member in tagged_members {
         if !member.data_type().is_optional {
-            error_reporter.report(LogicKind::MustBeOptional, Some(member.span()));
+            error_reporter.report_span(LogicKind::MustBeOptional, member.span());
         }
     }
 }
@@ -101,7 +101,7 @@ fn cannot_tag_classes(members: Vec<&dyn Member>, error_reporter: &mut ErrorRepor
 
     for member in tagged_members {
         if member.data_type().definition().is_class_type() {
-            error_reporter.report(LogicKind::CannotBeClass, Some(member.span()));
+            error_reporter.report_span(LogicKind::CannotBeClass, member.span());
         }
     }
 }
@@ -127,7 +127,7 @@ fn tagged_containers_cannot_contain_classes(members: Vec<&dyn Member>, error_rep
             }
             _ => member.data_type().definition().uses_classes(),
         } {
-            error_reporter.report(LogicKind::CannotContainClasses, Some(member.span()));
+            error_reporter.report_span(LogicKind::CannotContainClasses, member.span());
         }
     }
 }


### PR DESCRIPTION
Closes #206 

This PR implements a new Locatable trait and uses it to simplify many of the calls to `ErrorReporter.report`. However, due to trait upcasting being experimental an additional `report_span` method was needed to report some errors.

For example, we cannot upcast a `&dyn NamedSymbol` to a `&dyn Locatable`. However, we can still call `.span()` on the `NamedSymbol`