### PR TITLE
Fix Incorrect Bounds on Tag Values

### DIFF
--- a/src/errors/logic.rs
+++ b/src/errors/logic.rs
@@ -374,7 +374,7 @@ implement_error_functions!(
     (
         LogicKind::TagOutOfBounds,
         2090,
-        "tag values must be greater than or equal to 0 and less than 2147483647"
+        "tag values must be within the range 0 <= value <= 2147483647"
     ),
     (
         LogicKind::MustBeUnique,

--- a/src/parser/slice.rs
+++ b/src/parser/slice.rs
@@ -648,7 +648,7 @@ impl<'a> SliceParser<'a> {
         Ok(match_nodes!(input.children();
             [_, integer(integer)] => {
                 // Checking that tags must fit in an i32 and be non-negative.
-                if !RangeInclusive::new(0, (i32::MAX - 1) as i64).contains(&integer) {
+                if !RangeInclusive::new(0, i32::MAX as i64).contains(&integer) {
                     let span = get_span_for(&input);
                     input.user_data().borrow_mut().error_reporter.report(LogicKind::TagOutOfBounds, Some(&span));
                 }

--- a/tests/tag_tests.rs
+++ b/tests/tag_tests.rs
@@ -184,6 +184,28 @@ mod tags {
         assert_errors_new!(error_reporter, expected);
     }
 
+    #[test_case(0)]
+    #[test_case(i32::MAX / 2)]
+    #[test_case(i32::MAX)]
+    fn valid_tag_value(value: i32) {
+        // Arrange
+        let slice = format!(
+            "
+            module Test;
+            interface I {{
+                testOp(a: tag({value}) int32?);
+            }}
+            ",
+            value = value
+        );
+
+        // Act
+        let error_reporter = parse_for_errors(slice);
+
+        // Assert
+        assert_errors!(error_reporter);
+    }
+
     #[test_case(77757348128678234_i64 ; "Random large value")]
     #[test_case((i32::MAX as i64) + 1; "Slightly over")]
     fn cannot_have_tag_with_value_larger_than_max(value: i64) {


### PR DESCRIPTION
Closes #221 

I am just opening this PR to link the issue and give context to the issue. Originally the tag bounds were supposed to be from `0 <= tag value <= i32::MAX`. However, the error stated that it should be `0 <=  tag value < i32::MAX`. Therefore, the validation was updated to enforce the error message's bounds.

However, this was not the original intent of the validation. As such, the error message has been updated and a test has been added to verify that the correct bounds are enforced.