### PR TITLE
Remove `Entities` Wrapper Enum.

### DIFF
--- a/src/grammar/traits.rs
+++ b/src/grammar/traits.rs
@@ -3,7 +3,7 @@
 use super::comments::DocComment;
 use super::elements::{Attribute, Identifier, TypeRef};
 use super::util::{Scope, TagFormat};
-use super::wrappers::{AsEntities, AsTypes};
+use super::wrappers::AsTypes;
 use crate::slice_file::Span;
 use crate::supported_encodings::SupportedEncodings;
 
@@ -67,7 +67,7 @@ pub trait Commentable: Symbol {
     fn comment(&self) -> Option<&DocComment>;
 }
 
-pub trait Entity: NamedSymbol + Attributable + Commentable + AsEntities {}
+pub trait Entity: NamedSymbol + Attributable + Commentable {}
 
 pub trait Container<T>: Entity {
     fn contents(&self) -> &Vec<T>;

--- a/src/grammar/wrappers.rs
+++ b/src/grammar/wrappers.rs
@@ -24,42 +24,6 @@ macro_rules! generate_definition_wrapper {
 
 generate_definition_wrapper!(Module, Struct, Class, Exception, Interface, Enum, Trait, CustomType, TypeAlias);
 
-macro_rules! generate_entities_wrapper {
-    ($($variant:ident),*) => {
-        #[derive(Debug)]
-        pub enum Entities<'a> {
-            $($variant(&'a $variant),)*
-        }
-
-        #[derive(Debug)]
-        pub enum EntitiesMut<'a> {
-            $($variant(&'a mut $variant),)*
-        }
-
-        $(
-        impl AsEntities for $variant {
-            fn concrete_entity(&self) -> Entities {
-                Entities::$variant(self)
-            }
-
-            fn concrete_entity_mut(&mut self) -> EntitiesMut {
-                EntitiesMut::$variant(self)
-            }
-        }
-        )*
-    };
-}
-
-pub trait AsEntities {
-    fn concrete_entity(&self) -> Entities;
-    fn concrete_entity_mut(&mut self) -> EntitiesMut;
-}
-
-generate_entities_wrapper!(
-    Module, Struct, Class, Exception, DataMember, Interface, Operation, Parameter, Enum, Enumerator, Trait, CustomType,
-    TypeAlias
-);
-
 macro_rules! generate_types_wrapper {
     ($($variant:ident),*) => {
         #[derive(Debug)]


### PR DESCRIPTION
This PR removes the `Entities` wrapper and the macro we used to generate it.
Apparently we no longer use it anywhere, and I've always disliked these wrappers anyways.

It was originally for 'downcasting' from a `dyn Entity` trait object to a concrete type like `Module`.