### PR TITLE
Removed 'impl Clone' from 'TypeRef'

### DIFF
--- a/src/grammar/elements/type_ref.rs
+++ b/src/grammar/elements/type_ref.rs
@@ -87,19 +87,6 @@ impl<T: Type + ?Sized> TypeRef<T> {
     }
 }
 
-impl<T: Element + ?Sized> Clone for TypeRef<T> {
-    fn clone(&self) -> Self {
-        TypeRef {
-            type_string: self.type_string.clone(),
-            definition: self.definition.clone(),
-            is_optional: self.is_optional,
-            scope: self.scope.clone(),
-            attributes: self.attributes.clone(),
-            span: self.span.clone(),
-        }
-    }
-}
-
 impl<T: Element + ?Sized> Attributable for TypeRef<T> {
     fn attributes(&self) -> &Vec<Attribute> {
         &self.attributes

--- a/src/utils/code_gen_util.rs
+++ b/src/utils/code_gen_util.rs
@@ -2,7 +2,7 @@
 
 // TODO this entire file needs to be looked over again.
 
-use crate::grammar::{Element, Member, TypeRef};
+use crate::grammar::Member;
 
 /// The context that a type is being used in while generating code. This is used primarily by the
 /// `type_to_string` methods in each of the language mapping's code generators.
@@ -44,10 +44,4 @@ pub fn get_sorted_members<'a, T: Member>(members: &[&'a T]) -> (Vec<&'a T>, Vec<
     tagged_members.sort_by_key(|member| member.tag().unwrap());
 
     (required_members, tagged_members)
-}
-
-pub fn clone_as_non_optional<T: Element + ?Sized>(type_ref: &TypeRef<T>) -> TypeRef<T> {
-    let mut cloned = type_ref.clone();
-    cloned.is_optional = false;
-    cloned
 }


### PR DESCRIPTION
This has a sister PR for C#: https://github.com/zeroc-ice/icerpc-csharp/pull/1632

We implement `Clone` on `TypeRef`, but we only use this once in: `clone_as_non_optional`.
And we only use `clone_as_non_optional` once in: `encode_tagged_type` (in `slicec-cs`).
And `clone_as_non_optional` only changes the `is_optional` field of a `TypeRef` to false. That's it.

I find this all pretty overkill.

And more importantly, I don't think that `TypeRef` should be `Clone`able in the first place.
1) None of the other grammar elements are
2) It seems inefficient to clone all the fields of a struct just to toggle a bool,
3) All elements should be owned by the AST, but this cloned copy exists fully outside of the AST.

**3 is especially important.** The AST is a web of references & cycles (by nature) backed by smart pointers.
These pointers aren't beholden to the borrow checker; They guarantee all the same rules, _except_, our `WeakPtr`s can dangle (point to something that doesn't exist) (this is necessary to form the cycles our grammar requires).

This is still impossible though. Everything is owned by the AST and goes out of scope at the same time.
So, It's impossible for a `WeakPtr` to outlive the thing it's pointing at; both of them live in the AST.
Cloning something in the AST violates this, since it returns an owned copy outside of it.

The AST is a kind of firewall. Only things inside the AST can safely reference other things inside the AST.