### PR TITLE
Cargo dependency caching in `build` workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,7 +24,6 @@ jobs:
           target
         key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
         restore-keys: |
-          ${{ runner.os }}-cargo-${{ hashFiles('Cargo.toml') }}
           ${{ runner.os }}-cargo
     - name: 🔨 Build
       uses: actions-rs/cargo@v1


### PR DESCRIPTION
* This is currently for testing purposes.

Edit: This PR has shifted to adding caching for cargo. This halves the time it takes to run the workflow. Which can be seen in the two latest action runs for this PR.