### PR TITLE
Implemented Symbol on DocComment.

### DIFF
--- a/src/grammar/comments.rs
+++ b/src/grammar/comments.rs
@@ -1,5 +1,6 @@
 // Copyright (c) ZeroC, Inc. All rights reserved.
 
+use crate::grammar::{implement_Element_for, implement_Symbol_for, Element, Symbol};
 use crate::slice_file::Span;
 
 // TODO improve this to track the span of individual doc comment fields, so we can check for
@@ -64,3 +65,6 @@ pub fn find_inline_tags(comment: &str) -> Vec<(&str, &str)> {
     }
     tags
 }
+
+implement_Element_for!(DocComment, "doc comment");
+implement_Symbol_for!(DocComment);

--- a/src/parse_result.rs
+++ b/src/parse_result.rs
@@ -39,14 +39,14 @@ impl ParsedData {
             }
             .bold();
 
-            // Create the message using the prefix
+            // Emit the message with the prefix.
             eprintln!("{}: {}", prefix, style(&diagnostic).bold());
 
-            // If the diagnostic contains a location, show a snippet containing the offending code
+            // If the diagnostic contains a span, show a snippet containing the offending code.
             if let Some(span) = diagnostic.span {
                 Self::show_snippet(span, files)
             }
-            // If the diagnostic contain a notes, display them.
+            // If the diagnostic contains notes, display them.
             diagnostic.notes.into_iter().for_each(|note| {
                 eprintln!(
                     "    {} {}: {:}",

--- a/src/validators/comments.rs
+++ b/src/validators/comments.rs
@@ -22,7 +22,7 @@ fn non_empty_return_comment(operation: &Operation, diagnostic_reporter: &mut Dia
         if comment.returns.is_some() && operation.return_members().is_empty() {
             diagnostic_reporter.report(Diagnostic::new(
                 WarningKind::ExtraReturnValueInDocComment,
-                Some(&comment.span),
+                Some(comment.span()),
             ));
         }
     }
@@ -39,7 +39,7 @@ fn missing_parameter_comment(operation: &Operation, diagnostic_reporter: &mut Di
             {
                 diagnostic_reporter.report(Diagnostic::new(
                     WarningKind::ExtraParameterInDocComment(param.0.clone()),
-                    Some(&comment.span),
+                    Some(comment.span()),
                 ));
             }
         });
@@ -52,7 +52,7 @@ fn only_operations_can_throw(commentable: &dyn Entity, diagnostic_reporter: &mut
         if !supported_on.contains(&commentable.kind()) && !comment.throws.is_empty() {
             let warning =
                 WarningKind::ExtraThrowInDocComment(commentable.kind().to_owned(), commentable.identifier().to_owned());
-            diagnostic_reporter.report(Diagnostic::new(warning, Some(&comment.span)));
+            diagnostic_reporter.report(Diagnostic::new(warning, Some(comment.span())));
         };
     }
 }
@@ -69,14 +69,14 @@ fn linked_identifiers_exist(commentable: &dyn Entity, ast: &Ast, diagnostic_repo
                     {
                         diagnostic_reporter.report(Diagnostic::new(
                             WarningKind::InvalidDocCommentLinkIdentifier(value.to_owned()),
-                            Some(&comment.span),
+                            Some(comment.span()),
                         ));
                     }
                 }
                 other if other.starts_with('@') => {
                     diagnostic_reporter.report(Diagnostic::new(
                         WarningKind::InvalidDocCommentTag(other.to_owned()),
-                        Some(&comment.span),
+                        Some(comment.span()),
                     ));
                 }
                 _ => {}

--- a/tests/comment_tests.rs
+++ b/tests/comment_tests.rs
@@ -269,8 +269,8 @@ mod comments {
         let interface_def = ast.find_element::<Interface>("tests::MyInterface").unwrap();
         let interface_doc = interface_def.comment().unwrap();
 
-        assert_eq!(interface_doc.span.start, expected_start.into());
-        assert_eq!(interface_doc.span.end, expected_end.into());
+        assert_eq!(interface_doc.span().start, expected_start.into());
+        assert_eq!(interface_doc.span().end, expected_end.into());
     }
 
     #[test_case("/* This is a block comment. */"; "block comment")]


### PR DESCRIPTION
This PR implements the `Symbol` trait on `DocComment`.

A Symbol is anything that is physically written in a slice file, and so has a `span` in it.
`DocComment`s fit this bill, so they should implement the trait. It's that easy!

This closes #238.

It also (possibly controversially) fixes some typos I found in `parse_result` while grepping for `span|location`.