### PR TITLE
Allow `deprecated` attribute on `DataMember`

### DIFF
--- a/src/validators/attribute.rs
+++ b/src/validators/attribute.rs
@@ -9,7 +9,7 @@ pub fn attribute_validators() -> ValidationChain {
     vec![
         Validator::Attributes(is_compressible),
         Validator::Operations(validate_format_attribute),
-        Validator::Members(cannot_be_deprecated),
+        Validator::Parameters(cannot_be_deprecated),
     ]
 }
 
@@ -69,9 +69,9 @@ fn validate_format_attribute(operation: &Operation, diagnostic_reporter: &mut Di
         }
     }
 }
-/// Validates that the `deprecated` attribute cannot be applied to members.
-fn cannot_be_deprecated(members: Vec<&dyn Member>, diagnostic_reporter: &mut DiagnosticReporter) {
-    members.iter().for_each(|m| {
+/// Validates that the `deprecated` attribute cannot be applied to parameters.
+fn cannot_be_deprecated(parameters: &[&Parameter], diagnostic_reporter: &mut DiagnosticReporter) {
+    parameters.iter().for_each(|m| {
         if m.has_attribute("deprecated", false) {
             let diagnostic = Diagnostic::new(
                 LogicErrorKind::DeprecatedAttributeCannotBeApplied(m.kind().to_owned() + "(s)"),

--- a/tests/attribute_tests.rs
+++ b/tests/attribute_tests.rs
@@ -145,27 +145,6 @@ mod attributes {
         }
 
         #[test]
-        fn cannot_deprecate_data_members() {
-            // Arrange
-            let slice = "
-                module Test;
-
-                struct S {
-                    [deprecated]
-                    s: string,
-                }
-            ";
-
-            // Act
-            let diagnostic_reporter = parse_for_diagnostics(slice);
-
-            // Assert
-            let expected: DiagnosticKind =
-                LogicErrorKind::DeprecatedAttributeCannotBeApplied("data member(s)".to_owned()).into();
-            assert_errors_new!(diagnostic_reporter, [&expected]);
-        }
-
-        #[test]
         fn deprecated_can_contain_message() {
             // Arrange
             let slice = "


### PR DESCRIPTION
Closes #256 

This PR releaxes the validation of  `cannot_be_deprecated` from `Vec<&dyn Member>r` to `&[&Parameter]`. As such, `DataMember`s can now be deprecated.

A test that validated that `DataMembers` cannot be deprecated was additionally removed.