### PR TITLE
Moved 'get_deprecated_attribute' to 'Entity'.

### DIFF
--- a/src/ast/patchers/type_ref_patcher.rs
+++ b/src/ast/patchers/type_ref_patcher.rs
@@ -209,13 +209,13 @@ impl TypeRefPatcher<'_> {
         // Check if the type is an entity, and if so, check if it has the `deprecated` attribute.
         // Only entities can be deprecated, so this check is sufficient.
         if let Ok(entity) = <&dyn Entity>::try_from(node) {
-            if let Some(args) = entity.get_deprecated_attribute(true) {
+            if let Some(argument) = entity.get_deprecated_attribute(true) {
                 // Compute the warning message. The `deprecated` attribute can have either 0 or 1 arguments, so we
                 // only check the first argument. If it's present, we attach it to the warning message we emit.
                 self.diagnostic_reporter.report_error(Diagnostic::new_with_notes(
                     WarningKind::UseOfDeprecatedEntity(
                         entity.identifier().to_owned(),
-                        args.first().map_or_else(String::new, |arg| ": ".to_owned() + arg),
+                        argument.map_or_else(String::new, |arg| ": ".to_owned() + arg),
                     ),
                     Some(type_ref.span()),
                     vec![Note::new(

--- a/src/grammar/traits.rs
+++ b/src/grammar/traits.rs
@@ -64,7 +64,7 @@ pub trait Commentable: Symbol {
 }
 
 pub trait Entity: NamedSymbol + Attributable + Commentable {
-    fn deprecation_reason(&self, check_parent: bool) -> Option<Option<&String>> {
+    fn get_deprecated_attribute(&self, check_parent: bool) -> Option<Option<&String>> {
         self.get_attribute("deprecated", check_parent).map(|args| args.first())
     }
 }

--- a/src/validators/attribute.rs
+++ b/src/validators/attribute.rs
@@ -74,7 +74,7 @@ fn validate_format_attribute(operation: &Operation, diagnostic_reporter: &mut Di
 /// Validates that the `deprecated` attribute cannot be applied to parameters.
 fn cannot_be_deprecated(parameters: &[&Parameter], diagnostic_reporter: &mut DiagnosticReporter) {
     parameters.iter().for_each(|m| {
-        if m.deprecation_reason(false).is_some() {
+        if m.get_deprecated_attribute(false).is_some() {
             let diagnostic = Diagnostic::new(
                 LogicErrorKind::DeprecatedAttributeCannotBeApplied(m.kind().to_owned() + "(s)"),
                 Some(m.span()),

--- a/tests/attribute_tests.rs
+++ b/tests/attribute_tests.rs
@@ -121,7 +121,7 @@ mod attributes {
 
             // Assert
             let operation = ast.find_element::<Operation>("Test::I::op").unwrap();
-            assert!(operation.deprecation_reason(false).is_some());
+            assert!(operation.get_deprecated_attribute(false).is_some());
         }
 
         #[test]
@@ -163,7 +163,7 @@ mod attributes {
 
             // Assert
             let operation = ast.find_element::<Operation>("Test::I::op").unwrap();
-            assert_eq!(operation.deprecation_reason(false).unwrap().unwrap(), "Deprecation message here");
+            assert_eq!(operation.get_deprecated_attribute(false).unwrap().unwrap(), "Deprecation message here");
         }
 
         #[test]


### PR DESCRIPTION
This PR moves the `get_deprecated_attribute` function from `Attributable` to `Entity`.
This is because only `Entity`s supposed the `deprecated` attribute, so it's more correct to place it there.