### PR TITLE
Fixes #272

### DIFF
--- a/src/slice_file.rs
+++ b/src/slice_file.rs
@@ -79,6 +79,8 @@ impl SliceFile {
                 last_char_was_carriage_return = character == '\r';
             }
         }
+        // Treat EOF as an end-of-line character.
+        line_positions.push(raw_text.chars().count());
 
         // Extract the name of the slice file without its extension.
         let filename = std::path::Path::new(&relative_path)


### PR DESCRIPTION
The error happens when a snippet expands all the way to EOF.
The snippet extraction needs to know the ending and starting positions of every line in order to extract slices of text.

Currently, it computes these positions by looking through the text for newlines, but this doesn't cover the case of the final line of text in the slice file that ends in EOF instead of a newline.

The simplest fix is to just manually add the position of EOF as an ending position of a line.