### PR TITLE
`ignore_warnings` to `ignoreWarnings`

### DIFF
--- a/src/diagnostics/diagnostic_reporter.rs
+++ b/src/diagnostics/diagnostic_reporter.rs
@@ -18,7 +18,7 @@ pub struct DiagnosticReporter {
     treat_warnings_as_errors: bool,
     /// Can specify json to serialize errors as JSON or console to output errors to console.
     pub diagnostic_format: DiagnosticFormat,
-    /// The relative paths of all Slice files that have the file level `ignore_warnings` attribute.
+    /// The relative paths of all Slice files that have the file level `ignoreWarnings` attribute.
     pub file_level_ignored_warnings: HashMap<String, Vec<String>>,
     // If true, diagnostic output will not be styled.
     pub disable_color: bool,
@@ -60,7 +60,7 @@ impl DiagnosticReporter {
     pub fn report_warning(&mut self, warning: Warning, entity: &dyn Entity) {
         self.warning_count += 1;
 
-        // Returns true if the Slice file has the file level `ignore_warnings` attribute with no arguments (ignoring all
+        // Returns true if the Slice file has the file level `ignoreWarnings` attribute with no arguments (ignoring all
         // warnings), or if it has an argument matching the error code of the warning.
         if match self.file_level_ignored_warnings.get(&warning.span.file) {
             None => false,
@@ -71,7 +71,7 @@ impl DiagnosticReporter {
             return;
         }
 
-        // Returns true if the entity (or its parent) has the`ignore_warnings` attribute with no arguments (ignoring all
+        // Returns true if the entity (or its parent) has the`ignoreWarnings` attribute with no arguments (ignoring all
         // warnings), or if it has an argument matching the error code of the warning.
         if match entity.get_ignored_warnings(true) {
             None => false,

--- a/src/grammar/mod.rs
+++ b/src/grammar/mod.rs
@@ -18,6 +18,6 @@ pub mod attributes {
     pub const COMPRESS: &str = "compress";
     pub const DEPRECATED: &str = "deprecated";
     pub const FORMAT: &str = "format";
-    pub const IGNORE_WARNINGS: &str = "ignore_warnings";
+    pub const IGNORE_WARNINGS: &str = "ignoreWarnings";
     pub const ONEWAY: &str = "oneway";
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -56,7 +56,7 @@ pub fn parse_files(options: &SliceOptions) -> ParserResult {
         }
     }
 
-    // Update the diagnostic reporter with the slice files that contain the file level ignore_warnings attribute.
+    // Update the diagnostic reporter with the slice files that contain the file level ignoreWarnings attribute.
     diagnostic_reporter.file_level_ignored_warnings = file_ignored_warnings_map(&slice_files);
     let parsed_data = ParsedData {
         ast,
@@ -91,7 +91,7 @@ pub fn parse_strings(inputs: &[&str], options: Option<SliceOptions>) -> ParserRe
         }
     }
 
-    // Update the diagnostic reporter with the slice files that contain the file level ignore_warnings attribute.
+    // Update the diagnostic reporter with the slice files that contain the file level ignoreWarnings attribute.
     diagnostic_reporter.file_level_ignored_warnings = file_ignored_warnings_map(&slice_files);
     let parsed_data = ParsedData {
         ast,
@@ -138,7 +138,7 @@ fn find_slice_files(paths: &[String]) -> Vec<String> {
 }
 
 // Returns a HashMap where the keys are the relative paths of the .slice files that have the file level
-// `ignore_warnings` attribute and the values are the arguments of the attribute.
+// `ignoreWarnings` attribute and the values are the arguments of the attribute.
 fn file_ignored_warnings_map(files: &HashMap<String, SliceFile>) -> HashMap<String, Vec<String>> {
     files
         .iter()

--- a/tests/attribute_tests.rs
+++ b/tests/attribute_tests.rs
@@ -364,14 +364,14 @@ mod attributes {
             interface I {
                 // The below doc comment will generate a warning
                 /// A test operation. Similar to {@linked OtherOp}{}.
-                [ignore_warnings]
+                [ignoreWarnings]
                 op(s: string) -> string;
             }
             "; "simple"
         )]
         #[test_case(
             "
-            [ignore_warnings]
+            [ignoreWarnings]
             module A {
                 struct A1 {
                     b: B::B1,
@@ -385,7 +385,7 @@ mod attributes {
         )]
         #[test_case(
             "
-            [ignore_warnings]
+            [ignoreWarnings]
             module A {
                 struct A1 {
                     b: sequence<B::B1>,
@@ -399,7 +399,7 @@ mod attributes {
         )]
         #[test_case(
             "
-            [[ignore_warnings]]
+            [[ignoreWarnings]]
             module A {
                 struct A1 {
                     b: B::B1,
@@ -426,14 +426,14 @@ mod attributes {
                 // The below doc comment will generate a warning
                 /// A test operation. Similar to {@linked OtherOp}{}.
                 /// @param b A test parameter.
-                [ignore_warnings(W005, W001)]
+                [ignoreWarnings(W005, W001)]
                 op(s: string) -> string;
             }
             "; "entity"
         )]
         #[test_case(
             "
-            [[ignore_warnings(W005, W001)]]
+            [[ignoreWarnings(W005, W001)]]
             module Test;
 
             interface I {
@@ -459,25 +459,25 @@ mod attributes {
             interface I {
                 /// @param x a parameter that should be used in ops
                 /// @returns a result
-                [ignore_warnings(W002, W003)]
+                [ignoreWarnings(W002, W003)]
                 op(s: string);
             }
             "; "entity"
         )]
         #[test_case(
             "
-            [[ignore_warnings(W002, W003)]]
+            [[ignoreWarnings(W002, W003)]]
             module Test;
 
             interface I {
                 /// @param x a parameter that should be used in ops
                 /// @returns a result
-                [ignore_warnings(W002, W003)]
+                [ignoreWarnings(W002, W003)]
                 op(s: string);
             }
             "; "file level"
         )]
-        // Test that if args are passed to ignore_warnings, that only those warnings are ignored
+        // Test that if args are passed to ignoreWarnings, that only those warnings are ignored
         fn ignore_warnings_attribute_with_args_will_not_ignore_all_warnings(slice: &str) {
             // Act
             let diagnostic_reporter = parse_for_diagnostics(slice);


### PR DESCRIPTION
The ignore warnings had a typo resulting in the syntax being `[ignore_warnings(...)]` when it should have been `[ignoreWarnings(...)]`.