### PR TITLE
Removed 'AttributeOnlyValidForTopLevelModules'.

### DIFF
--- a/src/diagnostics/errors.rs
+++ b/src/diagnostics/errors.rs
@@ -262,10 +262,8 @@ pub enum ErrorKind {
     /// An invalid Slice encoding was used.
     InvalidEncodingVersion(i64),
 
-    // ----------------  SliceC-C# Errors ---------------- //
+    // ----------------  Attribute Errors ---------------- //
     // The following are errors that are needed to report cs attribute errors.
-    // TODO: Clean up these errors
-
     MissingRequiredArgument(String), // (arg)
 
     MissingRequiredAttribute(String), // (attribute)


### PR DESCRIPTION
This tiny PR just removes that error. That's it.
It's only a PR to make sure that everyone is okay with ditching it.

We only used it for `cs::namespace` but that goes on any module now.
As is, I think this error is too niche to be worth keeping.
Feel free to reject this if you disagree!