### PR TITLE
Simplified 'Attribute' fields.

### DIFF
--- a/src/grammar/elements/attribute.rs
+++ b/src/grammar/elements/attribute.rs
@@ -5,27 +5,9 @@ use crate::slice_file::Span;
 
 #[derive(Clone, Debug)]
 pub struct Attribute {
-    pub prefix: Option<String>,
     pub directive: String,
-    pub prefixed_directive: String,
     pub arguments: Vec<String>,
     pub span: Span,
-}
-
-impl Attribute {
-    pub(crate) fn new(prefix: Option<String>, directive: String, arguments: Vec<String>, span: Span) -> Self {
-        let prefixed_directive = prefix.clone().map_or(
-            directive.clone(),                   // Default value if prefix == None
-            |prefix| prefix + "::" + &directive, // Function to call if prefix == Some
-        );
-        Attribute {
-            prefix,
-            directive,
-            prefixed_directive,
-            arguments,
-            span,
-        }
-    }
 }
 
 implement_Element_for!(Attribute, "attribute");

--- a/src/grammar/elements/type_ref.rs
+++ b/src/grammar/elements/type_ref.rs
@@ -99,7 +99,7 @@ impl<T: Element + ?Sized> Attributable for TypeRef<T> {
         }
         self.attributes
             .iter()
-            .find(|&attribute| attribute.prefixed_directive == directive)
+            .find(|&attribute| attribute.directive == directive)
     }
 }
 

--- a/src/grammar/traits.rs
+++ b/src/grammar/traits.rs
@@ -175,7 +175,7 @@ macro_rules! implement_Attributable_for {
 
             fn get_raw_attribute(&self, directive: &str, recurse: bool) -> Option<&Attribute> {
                 for attribute in &self.attributes {
-                    if attribute.prefixed_directive == directive {
+                    if attribute.directive == directive {
                         return Some(attribute);
                     }
                 }

--- a/src/parsers/slice/grammar.rs
+++ b/src/parsers/slice/grammar.rs
@@ -556,13 +556,12 @@ fn construct_unpatched_type_ref_definition(mut identifier: Identifier) -> TypeRe
     TypeRefDefinition::Unpatched(identifier.value)
 }
 
-fn construct_attribute(raw_directive: Identifier, arguments: Option<Vec<String>>, span: Span) -> Attribute {
-    let arguments = arguments.unwrap_or_default();
-    let (prefix, directive) = match raw_directive.value.split_once("::") {
-        Some((p, d)) => (Some(p.to_owned()), d.to_owned()),
-        None => (None, raw_directive.value.to_owned()),
-    };
-    Attribute::new(prefix, directive, arguments, span)
+fn construct_attribute(directive: Identifier, arguments: Option<Vec<String>>, span: Span) -> Attribute {
+    Attribute {
+        directive: directive.value,
+        arguments: arguments.unwrap_or_default(),
+        span,
+    }
 }
 
 fn try_parse_integer(parser: &mut Parser, s: &str, span: Span) -> i64 {

--- a/src/slice_file.rs
+++ b/src/slice_file.rs
@@ -202,6 +202,6 @@ impl Attributable for SliceFile {
         }
         self.attributes
             .iter()
-            .find(|&attribute| attribute.prefixed_directive == directive)
+            .find(|&attribute| attribute.directive == directive)
     }
 }

--- a/tests/attribute_tests.rs
+++ b/tests/attribute_tests.rs
@@ -561,9 +561,7 @@ mod attributes {
             let operation = ast.find_element::<Operation>("Test::I::op").unwrap();
 
             assert!(operation.has_attribute("foo::bar", true));
-            assert_eq!(operation.attributes[0].directive, "bar");
-            assert_eq!(operation.attributes[0].prefixed_directive, "foo::bar");
-            assert_eq!(operation.attributes[0].prefix, Some("foo".to_owned()));
+            assert_eq!(operation.attributes[0].directive, "foo::bar");
             assert_eq!(operation.attributes[0].arguments.len(), 0);
         }
 
@@ -587,9 +585,7 @@ mod attributes {
             let operation = ast.find_element::<Operation>("Test::I::op").unwrap();
 
             assert!(operation.has_attribute("foo::bar", true));
-            assert_eq!(operation.attributes[0].directive, "bar");
-            assert_eq!(operation.attributes[0].prefixed_directive, "foo::bar");
-            assert_eq!(operation.attributes[0].prefix, Some("foo".to_owned()));
+            assert_eq!(operation.attributes[0].directive, "foo::bar");
             assert_eq!(operation.attributes[0].arguments, vec!["a", "b", "c"]);
         }
 


### PR DESCRIPTION
This PR implements #286 by removing 2 fields on the `Attribute` struct.
It has a sister PR for C#: https://github.com/zeroc-ice/icerpc-csharp/pull/1996