### PR TITLE
Add 'is_file_scoped' field to 'Module'.

### DIFF
--- a/src/grammar/elements/module.rs
+++ b/src/grammar/elements/module.rs
@@ -8,6 +8,7 @@ use crate::utils::ptr_util::WeakPtr;
 pub struct Module {
     pub identifier: Identifier,
     pub contents: Vec<Definition>,
+    pub is_file_scoped: bool,
     pub parent: Option<WeakPtr<Module>>,
     pub scope: Scope,
     pub attributes: Vec<Attribute>,

--- a/src/parsers/slice/grammar.lalrpop
+++ b/src/parsers/slice/grammar.lalrpop
@@ -95,7 +95,7 @@ extern {
 // Grammar Rules
 
 pub SliceFile: (Option<FileEncoding>, Vec<Attribute>, Vec<OwnedPtr<Module>>) = {
-    <sfp: SliceFilePrelude> <flm: FileLevelModule> => (sfp.0, sfp.1, vec![flm]),
+    <sfp: SliceFilePrelude> <flm: FileScopedModule> => (sfp.0, sfp.1, vec![flm]),
     <sfp: SliceFilePrelude> <ms: Module*> => (sfp.0, sfp.1, ms),
 }
 
@@ -114,15 +114,15 @@ FileEncoding: FileEncoding = {
     }
 }
 
-FileLevelModule: OwnedPtr<Module> = {
+FileScopedModule: OwnedPtr<Module> = {
     <p: Prelude> <l: @L> module_keyword <i: ModuleIdentifier> <r: @R> ";" <ds: Definition*> => {
-        construct_module(parser, p, i, ds, Span::new(l, r, parser.file_name))
+        construct_module(parser, p, i, ds, true, Span::new(l, r, parser.file_name))
     }
 }
 
 Module: OwnedPtr<Module> = {
     <p: Prelude> <l: @L> module_keyword <i: ModuleIdentifier> <r: @R> "{" <ds: Definition*> "}" => {
-        construct_module(parser, p, i, ds, Span::new(l, r, parser.file_name))
+        construct_module(parser, p, i, ds, false, Span::new(l, r, parser.file_name))
     }
 }
 

--- a/src/parsers/slice/grammar.rs
+++ b/src/parsers/slice/grammar.rs
@@ -110,6 +110,7 @@ fn construct_module(
     (comment, attributes): (Option<DocComment>, Vec<Attribute>),
     identifier: Identifier,
     definitions: Vec<Node>,
+    is_file_scoped: bool,
     span: Span,
 ) -> OwnedPtr<Module> {
     // In case nested module syntax was used, we split the identifier on '::' and construct a module for each segment.
@@ -124,6 +125,7 @@ fn construct_module(
                 span: span.clone(),
             },
             contents: Vec::new(),
+            is_file_scoped: false,
             parent: None,
             scope: parser.current_scope.clone(),
             attributes: Vec::new(),
@@ -140,6 +142,7 @@ fn construct_module(
     unsafe {
         // Any attributes, comments, or definitions belong to the innermost module, stored as `current_module`.
         // We re-borrow it every time we set a field to make ensure that the borrows are dropped immediately.
+        current_module.borrow_mut().is_file_scoped = is_file_scoped;
         current_module.borrow_mut().attributes = attributes;
         current_module.borrow_mut().comment = comment;
         for definition in definitions {

--- a/tests/module_tests.rs
+++ b/tests/module_tests.rs
@@ -7,6 +7,20 @@ mod module {
     use crate::helpers::parsing_helpers::parse_for_ast;
     use slice::grammar::*;
     use slice::parse_from_strings;
+    use test_case::test_case;
+
+    #[test_case("{}", false; "normal")]
+    #[test_case(";", true; "file_scoped")]
+    fn can_be_defined(content: &str, expected: bool) {
+        // Arrange
+        let slice = format!("module Test {content}");
+
+        // Act
+        let ast = parse_for_ast(slice);
+
+        // Assert
+        assert_eq!(ast.find_element::<Module>("Test").unwrap().is_file_scoped, expected);
+    }
 
     #[test]
     fn can_be_reopened() {

--- a/tests/scope_resolution_tests.rs
+++ b/tests/scope_resolution_tests.rs
@@ -11,7 +11,7 @@ mod scope_resolution {
 
     #[test]
     #[ignore] // TODO: This validation is no longer done by the parser, and should be done by a validator.
-    fn file_level_modules_can_not_contain_sub_modules() {
+    fn file_scoped_modules_can_not_contain_sub_modules() {
         // Arrange
         let slice = "
             module T;


### PR DESCRIPTION
This implements #330, which will be required for #312.
It also renamed some places where we wrote `file-level` instead of `file-scoped`