### PR TITLE
Fix exception specifications being validated as Members

### DIFF
--- a/src/ast/patchers/encoding_patcher.rs
+++ b/src/ast/patchers/encoding_patcher.rs
@@ -367,8 +367,8 @@ impl ComputeSupportedEncodings for Interface {
                 Throws::None => {}
                 Throws::Specific(exception_type) => {
                     // Ensure the exception is supported by the operation's (file's) encoding.
-                    let exception_def = exception_type.definition();
-                    if !patcher.get_supported_encodings_for(exception_def).supports(file_encoding) {
+                    let supported_encodings = patcher.get_supported_encodings_for(exception_type.definition());
+                    if !supported_encodings.supports(file_encoding) {
                         let error = Error::new_with_notes(
                             ErrorKind::UnsupportedType(exception_type.type_string(), *file_encoding),
                             Some(exception_type.span()),


### PR DESCRIPTION
I re-used the `get_supported_encodings_for_type_ref` function for checking the encoding compatibility of exception specifications (an exception in an `encoding = 1` file can only have `Slice1` compatible data members).

But this function performs additional checks such as disallowing exceptions to be used as types in Slice1,
which causes bogus errors like in #355.

This PR fixes the problem by no longer using the function, and just directly checking if the exception is supported by it's operation encoding.