### PR TITLE
Moved 'uses_classes' Function

### DIFF
--- a/src/grammar/elements/class.rs
+++ b/src/grammar/elements/class.rs
@@ -59,10 +59,6 @@ impl Type for Class {
         1 // A class may be encoded as an index instead of an instance, taking up 1 byte.
     }
 
-    fn uses_classes(&self) -> bool {
-        true
-    }
-
     fn is_class_type(&self) -> bool {
         true
     }

--- a/src/grammar/elements/custom_type.rs
+++ b/src/grammar/elements/custom_type.rs
@@ -30,10 +30,6 @@ impl Type for CustomType {
         0
     }
 
-    fn uses_classes(&self) -> bool {
-        false
-    }
-
     fn is_class_type(&self) -> bool {
         false
     }

--- a/src/grammar/elements/dictionary.rs
+++ b/src/grammar/elements/dictionary.rs
@@ -26,11 +26,6 @@ impl Type for Dictionary {
         1
     }
 
-    fn uses_classes(&self) -> bool {
-        // It is disallowed for key types to use classes, so we only have to check the value type.
-        self.value_type.uses_classes()
-    }
-
     fn is_class_type(&self) -> bool {
         false
     }

--- a/src/grammar/elements/enum.rs
+++ b/src/grammar/elements/enum.rs
@@ -59,10 +59,6 @@ impl Type for Enum {
         }
     }
 
-    fn uses_classes(&self) -> bool {
-        false
-    }
-
     fn is_class_type(&self) -> bool {
         false
     }

--- a/src/grammar/elements/exception.rs
+++ b/src/grammar/elements/exception.rs
@@ -63,10 +63,6 @@ impl Type for Exception {
             .sum()
     }
 
-    fn uses_classes(&self) -> bool {
-        self.all_members().iter().any(|member| member.data_type.uses_classes())
-    }
-
     fn is_class_type(&self) -> bool {
         false
     }

--- a/src/grammar/elements/interface.rs
+++ b/src/grammar/elements/interface.rs
@@ -88,10 +88,6 @@ impl Type for Interface {
         2
     }
 
-    fn uses_classes(&self) -> bool {
-        false
-    }
-
     fn is_class_type(&self) -> bool {
         false
     }

--- a/src/grammar/elements/primitive.rs
+++ b/src/grammar/elements/primitive.rs
@@ -141,10 +141,6 @@ impl Type for Primitive {
         }
     }
 
-    fn uses_classes(&self) -> bool {
-        matches!(self, Self::AnyClass)
-    }
-
     fn is_class_type(&self) -> bool {
         matches!(self, Self::AnyClass)
     }

--- a/src/grammar/elements/sequence.rs
+++ b/src/grammar/elements/sequence.rs
@@ -44,10 +44,6 @@ impl Type for Sequence {
         1
     }
 
-    fn uses_classes(&self) -> bool {
-        self.element_type.uses_classes()
-    }
-
     fn is_class_type(&self) -> bool {
         false
     }

--- a/src/grammar/elements/struct.rs
+++ b/src/grammar/elements/struct.rs
@@ -49,10 +49,6 @@ impl Type for Struct {
         }
     }
 
-    fn uses_classes(&self) -> bool {
-        self.members().iter().any(|member| member.data_type.uses_classes())
-    }
-
     fn is_class_type(&self) -> bool {
         false
     }

--- a/src/grammar/elements/type_alias.rs
+++ b/src/grammar/elements/type_alias.rs
@@ -41,10 +41,6 @@ impl Type for TypeAlias {
         self.underlying.min_wire_size()
     }
 
-    fn uses_classes(&self) -> bool {
-        self.underlying.uses_classes()
-    }
-
     fn is_class_type(&self) -> bool {
         self.underlying.is_class_type()
     }

--- a/src/grammar/traits.rs
+++ b/src/grammar/traits.rs
@@ -98,7 +98,6 @@ pub trait Type: Element + AsTypes {
     fn type_string(&self) -> String;
     fn is_fixed_size(&self) -> bool;
     fn min_wire_size(&self) -> u32;
-    fn uses_classes(&self) -> bool;
     fn is_class_type(&self) -> bool;
     fn tag_format(&self) -> Option<TagFormat>;
     fn supported_encodings(&self) -> SupportedEncodings;


### PR DESCRIPTION
This PR was spurred by #149.

The function `uses_classes` is implemented by every `Type` in the compiler, and is publicly defined on the `Type` trait.
But we only use this function in one place: internally in the validators.

This PR removes the function from the trait, and all the implementations of it.
Instead, it's just a nested helper function for the validator now.

This doesn't technically '_fix_' #149, but now that it's 'hidden' away, I don't think the problem is relevant anymore.