### PR TITLE
Allow Slice Keywords in Attributes

### DIFF
--- a/tests/attribute_tests.rs
+++ b/tests/attribute_tests.rs
@@ -688,6 +688,26 @@ mod attributes {
         }
 
         #[test]
+        fn attribute_directives_can_be_slice_keywords() {
+            // Arrange
+            let slice = "
+                [custom]
+                module Test;
+            ";
+
+            // Act
+            let ast = parse_for_ast(slice);
+
+            // Assert
+            let module = ast.find_element::<Module>("Test").unwrap();
+            assert_eq!(module.attributes.len(), 1);
+            assert!(matches!(
+                &module.attributes[0].kind,
+                AttributeKind::Other { directive, .. } if directive == "custom",
+            ));
+        }
+
+        #[test]
         fn parent_attributes() {
             // Arrange
             let slice = r#"


### PR DESCRIPTION
This PR changes the Slice lexer to no longer lex Slice keywords in attributes.
Now any Slice keywords that appear in an attribute are treated as normal identifiers.

Previously they were treated as Slice keywords, making this a syntax error:
```
[cs::custom] <- syntax error because this isn't the syntax for declaring a custom type.
module Test;
```

See #378