### PR TITLE
Remove unnecessary `message` on `Diagnostic`, switch to using `fmt::Display`

### DIFF
--- a/src/compilation_result.rs
+++ b/src/compilation_result.rs
@@ -82,7 +82,7 @@ impl CompilationData {
             let mut message = vec![];
 
             // Emit the message with the prefix.
-            message.push(format!("{prefix}: {}", style(&diagnostic.message()).bold()));
+            message.push(format!("{prefix}: {}", style(diagnostic.message()).bold()));
 
             // If the diagnostic contains a span, show a snippet containing the offending code.
             if let Some(span) = diagnostic.span() {

--- a/src/diagnostics/errors.rs
+++ b/src/diagnostics/errors.rs
@@ -48,7 +48,7 @@ impl Error {
 
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}", self.kind)
+        write!(f, "{}", self.kind.message())
     }
 }
 

--- a/src/diagnostics/mod.rs
+++ b/src/diagnostics/mod.rs
@@ -21,6 +21,14 @@ pub enum Diagnostic {
 }
 
 impl Diagnostic {
+    /// Returns the message of the diagnostic.
+    pub fn message(&self) -> String {
+        match self {
+            Diagnostic::Error(error) => error.to_string(),
+            Diagnostic::Warning(warning) => warning.to_string(),
+        }
+    }
+
     /// Returns the [Span] of the diagnostic if it has one.
     pub fn span(&self) -> Option<&Span> {
         match self {
@@ -42,14 +50,6 @@ impl Diagnostic {
         match self {
             Diagnostic::Error(error) => error.error_code(),
             Diagnostic::Warning(warning) => Some(warning.error_code()),
-        }
-    }
-
-    /// Returns the message of the diagnostic.
-    pub fn message(&self) -> String {
-        match self {
-            Diagnostic::Error(error) => error.to_string(),
-            Diagnostic::Warning(warning) => warning.to_string(),
         }
     }
 }
@@ -119,16 +119,13 @@ macro_rules! implement_diagnostic_functions {
                     )*
                 }
             }
-        }
 
-        impl std::fmt::Display for WarningKind {
-            fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-                let message: String = match self {
+            pub fn message(&self) -> String {
+                match self {
                     $(
                         implement_diagnostic_functions!(@description $kind, $($variant),*) => $message.into(),
                     )*
-                };
-                write!(f, "{}", message)
+                }
             }
         }
     };
@@ -142,16 +139,13 @@ macro_rules! implement_diagnostic_functions {
                     )*
                 }
             }
-        }
 
-        impl std::fmt::Display for ErrorKind {
-            fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-                let message: String = match self {
+            pub fn message(&self) -> String {
+                match self {
                     $(
                         implement_diagnostic_functions!(@description $kind, $($variant),*) => $message.into(),
                     )*
-                };
-                write!(f, "{}", message)
+                }
             }
         }
     };

--- a/src/diagnostics/warnings.rs
+++ b/src/diagnostics/warnings.rs
@@ -60,7 +60,7 @@ impl Warning {
 
 impl std::fmt::Display for Warning {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{}", self.kind)
+        write!(f, "{}", self.kind.message())
     }
 }
 


### PR DESCRIPTION
As brought up by @InsertCreativityHere in https://github.com/zeroc-ice/icerpc/issues/295#issuecomment-1371119841, we did not need to implement this `message` method as it is trivial. 

We do the same thing for `Error`, `Warning`, `ErrorKind`, annd `WarningKind` so this PR updates those accordingly.