### PR TITLE
Detect duplicate source and reference files and issue warnings

### DIFF
--- a/src/ast/patchers/type_ref_patcher.rs
+++ b/src/ast/patchers/type_ref_patcher.rs
@@ -227,18 +227,16 @@ impl TypeRefPatcher<'_> {
 
                 // Compute the warning message. The `deprecated` attribute can have either 0 or 1 arguments, so we
                 // only check the first argument. If it's present, we attach it to the warning message we emit.
-                Warning::new(
-                    WarningKind::UseOfDeprecatedEntity {
-                        identifier: entity.identifier().to_owned(),
-                        deprecation_reason: argument.map_or_else(String::new, |arg| ": ".to_owned() + &arg),
-                    },
-                    type_ref.span(),
-                )
+                Warning::new(WarningKind::UseOfDeprecatedEntity {
+                    identifier: entity.identifier().to_owned(),
+                    deprecation_reason: argument.map_or_else(String::new, |arg| ": ".to_owned() + &arg),
+                })
+                .set_span(type_ref.span())
                 .add_note(
                     format!("{} was deprecated here:", entity.identifier()),
                     Some(entity.span()),
                 )
-                .report(self.diagnostic_reporter, container);
+                .report(self.diagnostic_reporter, Some(container));
             }
         }
     }

--- a/src/diagnostics/mod.rs
+++ b/src/diagnostics/mod.rs
@@ -33,7 +33,7 @@ impl Diagnostic {
     pub fn span(&self) -> Option<&Span> {
         match self {
             Diagnostic::Error(error) => error.span.as_ref(),
-            Diagnostic::Warning(warning) => Some(&warning.span),
+            Diagnostic::Warning(warning) => warning.span.as_ref(),
         }
     }
 

--- a/src/validators/comments.rs
+++ b/src/validators/comments.rs
@@ -20,8 +20,9 @@ fn non_empty_return_comment(operation: &Operation, diagnostic_reporter: &mut Dia
         // `DocComment.return_members` contains a list of descriptions of the return members.
         // example: @return A description of the return value.
         if comment.returns.is_some() && operation.return_members().is_empty() {
-            Warning::new(WarningKind::ExtraReturnValueInDocComment, comment.span())
-                .report(diagnostic_reporter, operation);
+            Warning::new(WarningKind::ExtraReturnValueInDocComment)
+                .set_span(comment.span())
+                .report(diagnostic_reporter, Some(operation));
         }
     }
 }
@@ -35,13 +36,11 @@ fn missing_parameter_comment(operation: &Operation, diagnostic_reporter: &mut Di
                 .map(|p| p.identifier.value.clone())
                 .any(|identifier| identifier == param.0)
             {
-                Warning::new(
-                    WarningKind::ExtraParameterInDocComment {
-                        identifier: param.0.clone(),
-                    },
-                    comment.span(),
-                )
-                .report(diagnostic_reporter, operation);
+                Warning::new(WarningKind::ExtraParameterInDocComment {
+                    identifier: param.0.clone(),
+                })
+                .set_span(comment.span())
+                .report(diagnostic_reporter, Some(operation));
             }
         });
     }
@@ -55,7 +54,9 @@ fn only_operations_can_throw(entity: &dyn Entity, diagnostic_reporter: &mut Diag
                 kind: entity.kind().to_owned(),
                 identifier: entity.identifier().to_owned(),
             };
-            Warning::new(warning_kind, comment.span()).report(diagnostic_reporter, entity)
+            Warning::new(warning_kind)
+                .set_span(comment.span())
+                .report(diagnostic_reporter, Some(entity))
         };
     }
 }
@@ -69,21 +70,17 @@ fn linked_identifiers_exist(entity: &dyn Entity, ast: &Ast, diagnostic_reporter:
                         .find_element_with_scope::<dyn Entity>(value, entity.module_scope())
                         .is_err()
                     {
-                        Warning::new(
-                            WarningKind::InvalidDocCommentLinkIdentifier {
-                                identifier: value.to_owned(),
-                            },
-                            comment.span(),
-                        )
-                        .report(diagnostic_reporter, entity);
+                        Warning::new(WarningKind::InvalidDocCommentLinkIdentifier {
+                            identifier: value.to_owned(),
+                        })
+                        .set_span(comment.span())
+                        .report(diagnostic_reporter, Some(entity));
                     }
                 }
                 other if other.starts_with('@') => {
-                    Warning::new(
-                        WarningKind::InvalidDocCommentTag { tag: other.to_owned() },
-                        comment.span(),
-                    )
-                    .report(diagnostic_reporter, entity);
+                    Warning::new(WarningKind::InvalidDocCommentTag { tag: other.to_owned() })
+                        .set_span(comment.span())
+                        .report(diagnostic_reporter, Some(entity));
                 }
                 _ => {}
             }

--- a/tests/attribute_tests.rs
+++ b/tests/attribute_tests.rs
@@ -503,14 +503,14 @@ mod attributes {
                 // The below doc comment will generate a warning
                 /// A test operation. Similar to {@linked OtherOp}{}.
                 /// @param b A test parameter.
-                [ignoreWarnings(W005, W001)]
+                [ignoreWarnings(W006, W002)]
                 op(s: string) -> string;
             }
             "; "entity"
         )]
         #[test_case(
             "
-            [[ignoreWarnings(W005, W001)]]
+            [[ignoreWarnings(W006, W002)]]
             module Test;
 
             interface I
@@ -538,21 +538,21 @@ mod attributes {
             {
                 /// @param x a parameter that should be used in ops
                 /// @returns a result
-                [ignoreWarnings(W002, W003)]
+                [ignoreWarnings(W003, W004)]
                 op(s: string);
             }
             "; "entity"
         )]
         #[test_case(
             "
-            [[ignoreWarnings(W002, W003)]]
+            [[ignoreWarnings(W003, W004)]]
             module Test;
 
             interface I
             {
                 /// @param x a parameter that should be used in ops
                 /// @returns a result
-                [ignoreWarnings(W002, W003)]
+                [ignoreWarnings(W003, W004)]
                 op(s: string);
             }
             "; "file level"
@@ -567,7 +567,7 @@ mod attributes {
                 identifier: "x".to_owned(),
             });
 
-            debug_assert_eq!(expected.error_code(), "W001");
+            debug_assert_eq!(expected.error_code(), "W002");
             assert_errors!(diagnostic_reporter, [&expected]);
         }
     }

--- a/tests/diagnostic_output_tests.rs
+++ b/tests/diagnostic_output_tests.rs
@@ -37,7 +37,7 @@ mod output {
 
         // Assert
         let expected = concat!(
-            r#"{"message":"doc comment has a param tag for 'x', but there is no parameter by that name","severity":"warning","span":{"start":{"row":6,"col":13},"end":{"row":6,"col":38},"file":"string-0"},"notes":[],"error_code":"W001"}"#,
+            r#"{"message":"doc comment has a param tag for 'x', but there is no parameter by that name","severity":"warning","span":{"start":{"row":6,"col":13},"end":{"row":6,"col":38},"file":"string-0"},"notes":[],"error_code":"W002"}"#,
             "\n",
             r#"{"message":"invalid enum `E`: enums must contain at least one enumerator","severity":"error","span":{"start":{"row":10,"col":9},"end":{"row":10,"col":15},"file":"string-0"},"notes":[],"error_code":"E010"}"#,
             "\n",
@@ -82,7 +82,7 @@ mod output {
 
         // Assert
         let expected = "\
-warning [W001]: doc comment has a param tag for 'x', but there is no parameter by that name
+warning [W002]: doc comment has a param tag for 'x', but there is no parameter by that name
  --> string-0:6:13
   |
 6 |             /// @param x this is an x

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -13,5 +13,5 @@ pub fn new_warning(kind: WarningKind) -> Warning {
         end: slice::slice_file::Location { row: 0, col: 0 },
         file: "string".to_string(),
     };
-    Warning::new(kind, &span)
+    Warning::new(kind).set_span(&span)
 }


### PR DESCRIPTION
This PR changes how we deal with duplicate files and adds a new duplicate file warning. This required changed the behavior of warnings in general.

Previously all duplicate files were simply ignored. In the case of a source file, it would overwrite a reference file.

We now issue warnings (but continue and "replace" the old file) in the following cases:

- There are two duplicate source files: `slicec-cs a.slice a.slice`
- There are two duplicate reference files: `slicec-cs a.slice -R b.slice -R b.slice`

NOTE that the check performs a full canonical check, so it will resolve symlinks. This is the only thing rust offers and I think the behavior is fine.

We dot NOT issue warnings in the following case. We just ignore the reference file.
`slicec-cs a.slice -R a.slice`
