### PR TITLE
Show `Note` snippet only if it's `Span` is different from parent diagnostic

### DIFF
--- a/src/compilation_result.rs
+++ b/src/compilation_result.rs
@@ -98,8 +98,8 @@ impl CompilationData {
                     style(&note.message).bold(),
                 ));
                 // Only display the snippet if the note has a different span than the diagnostic.
-                if let Some(span) = &note.span {
-                    if note.span() != diagnostic.span() {
+                if note.span.as_ref() != diagnostic.span() {
+                    if let Some(span) = &note.span {
                         Self::append_snippet(&mut message, span, &files)
                     }
                 }

--- a/src/diagnostics/mod.rs
+++ b/src/diagnostics/mod.rs
@@ -98,11 +98,6 @@ impl Note {
             span: span.cloned(),
         }
     }
-
-    /// Returns the [Span] of the note if it has one.
-    pub fn span(&self) -> Option<&Span> {
-        self.span.as_ref()
-    }
 }
 
 /// A macro that implements the `error_code` and `message` functions for [WarningKind] and [ErrorKind] enums.


### PR DESCRIPTION
Closes #397 