### PR TITLE
Preprocessor directive comment support implemented

### DIFF
--- a/tests/preprocessor_tests.rs
+++ b/tests/preprocessor_tests.rs
@@ -305,6 +305,7 @@ fn preprocessor_ignores_comments() {
         module Test;
         interface I {}
         #endif // This is another comment
+        // Hello
     ";
 
     // Act


### PR DESCRIPTION
Closes #305 

This PR updates the preprocessor lexer to support line comments `//`.
