### PR TITLE
Simplified `IgnoreWarnings` attribute kind.

### DIFF
--- a/src/diagnostics/warnings.rs
+++ b/src/diagnostics/warnings.rs
@@ -49,10 +49,9 @@ impl Warning {
             // Returns true if the entity (or its parent) has the`ignoreWarnings` attribute with no arguments (ignoring
             // all warnings), or if it has an argument matching the error code of the warning.
             if entity.attributes(true).iter().any(|a| match &a.kind {
-                AttributeKind::IgnoreWarnings { warning_codes } => match warning_codes {
-                    Some(codes) => codes.is_empty() || codes.contains(&self.error_code().to_owned()),
-                    None => true,
-                },
+                AttributeKind::IgnoreWarnings { warning_codes } => {
+                    warning_codes.is_empty() || warning_codes.contains(&self.error_code().to_owned())
+                }
                 _ => false,
             }) {
                 // Do not push the warning to the diagnostics vector

--- a/src/grammar/elements/attribute.rs
+++ b/src/grammar/elements/attribute.rs
@@ -60,7 +60,7 @@ impl Attribute {
         }
     }
 
-    pub fn match_ignore_warnings(attribute: &Attribute) -> Option<&Option<Vec<String>>> {
+    pub fn match_ignore_warnings(attribute: &Attribute) -> Option<&Vec<String>> {
         match &attribute.kind {
             AttributeKind::IgnoreWarnings { warning_codes } => Some(warning_codes),
             _ => None,
@@ -80,7 +80,7 @@ pub enum AttributeKind {
     Deprecated { reason: Option<String> },
     Compress { compress_args: bool, compress_return: bool },
     ClassFormat { format: ClassFormat },
-    IgnoreWarnings { warning_codes: Option<Vec<String>> },
+    IgnoreWarnings { warning_codes: Vec<String> },
     Oneway,
 
     // The following are used for attributes that are not recognized by the compiler. They may be language mapping
@@ -243,7 +243,7 @@ impl AttributeKind {
                     }
                 }
                 Some(AttributeKind::IgnoreWarnings {
-                    warning_codes: Some(arguments.to_owned()),
+                    warning_codes: arguments.to_owned(),
                 })
             }
 

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -124,9 +124,7 @@ fn file_ignored_warnings_map(files: &HashMap<String, SliceFile>) -> HashMap<Stri
         .iter()
         .filter_map(|(path, file)| {
             file.attributes.iter().find_map(|attr| match &attr.kind {
-                AttributeKind::IgnoreWarnings { warning_codes } => {
-                    Some((path.clone(), warning_codes.clone().unwrap_or_default()))
-                }
+                AttributeKind::IgnoreWarnings { warning_codes } => Some((path.clone(), warning_codes.clone())),
                 _ => None,
             })
         })


### PR DESCRIPTION
The backing type for the `IgnoreWarnings` attribute is `Option<Vec<String>>`,
but this is redundant, there's no difference between the `None` case and an empty `Vec`.

Looking in the code, we actually never construct a `None` version of this, we _always_ pass in `Some(...)`.

This PR just removes the extra `Option` part, since weren't using it, and it just makes the type more complicated.