### PR TITLE
'parse_for_diagnostics' now returns the Diagnostics directly.

### DIFF
--- a/src/compilation_result.rs
+++ b/src/compilation_result.rs
@@ -63,9 +63,6 @@ impl CompilationData {
     }
 
     fn output_to_console(self, writer: &mut impl Write) -> std::io::Result<()> {
-        // Take ownership of the files from `self`
-        let files = self.files;
-
         // The for loop consumes the diagnostics, so we compute the count now.
         let counts = self.diagnostic_reporter.get_totals();
 
@@ -86,7 +83,7 @@ impl CompilationData {
 
             // If the diagnostic contains a span, show a snippet containing the offending code.
             if let Some(span) = diagnostic.span() {
-                Self::append_snippet(&mut message, span, &files);
+                Self::append_snippet(&mut message, span, &self.files);
             }
 
             // If the diagnostic contains notes, display them.
@@ -100,7 +97,7 @@ impl CompilationData {
                 // Only display the snippet if the note has a different span than the diagnostic.
                 if note.span.as_ref() != diagnostic.span() {
                     if let Some(span) = &note.span {
-                        Self::append_snippet(&mut message, span, &files)
+                        Self::append_snippet(&mut message, span, &self.files)
                     }
                 }
             });

--- a/tests/attribute_tests.rs
+++ b/tests/attribute_tests.rs
@@ -74,13 +74,13 @@ mod attributes {
             );
 
             // Act
-            let diagnostic_reporter = parse_for_diagnostics(slice);
+            let diagnostics = parse_for_diagnostics(slice);
 
             // Assert
             let expected = Error::new(ErrorKind::CannotBeEmpty {
                 member_identifier: "format attribute".to_owned(),
             });
-            assert_errors!(diagnostic_reporter, [&expected]);
+            assert_errors!(diagnostics, [&expected]);
         }
 
         #[test]
@@ -97,7 +97,7 @@ mod attributes {
             ";
 
             // Act
-            let diagnostic_reporter = parse_for_diagnostics(slice);
+            let diagnostics = parse_for_diagnostics(slice);
 
             // Assert
             let expected = Error::new(ErrorKind::ArgumentNotSupported {
@@ -109,7 +109,7 @@ mod attributes {
                 None,
             );
 
-            assert_errors!(diagnostic_reporter, [&expected]);
+            assert_errors!(diagnostics, [&expected]);
         }
 
         #[test]
@@ -146,13 +146,13 @@ mod attributes {
             ";
 
             // Act
-            let diagnostic_reporter = parse_for_diagnostics(slice);
+            let diagnostics = parse_for_diagnostics(slice);
 
             // Assert
             let expected = Error::new(ErrorKind::DeprecatedAttributeCannotBeApplied {
                 kind: "parameter(s)".to_owned(),
             });
-            assert_errors!(diagnostic_reporter, [&expected]);
+            assert_errors!(diagnostics, [&expected]);
         }
 
         #[test]
@@ -199,14 +199,14 @@ mod attributes {
             ";
 
             // Act
-            let diagnostic_reporter = parse_for_diagnostics(slice);
+            let diagnostics = parse_for_diagnostics(slice);
 
             // Assert
             let expected = &crate::helpers::new_warning(WarningKind::UseOfDeprecatedEntity {
                 identifier: "Bar".to_owned(),
                 deprecation_reason: "".to_owned(),
             });
-            assert_errors!(diagnostic_reporter, [&expected]);
+            assert_errors!(diagnostics, [&expected]);
         }
 
         #[test]
@@ -231,14 +231,14 @@ mod attributes {
             ";
 
             // Act
-            let diagnostic_reporter = parse_for_diagnostics(slice);
+            let diagnostics = parse_for_diagnostics(slice);
 
             // Assert
             let expected = &crate::helpers::new_warning(WarningKind::UseOfDeprecatedEntity {
                 identifier: "Bar".to_owned(),
                 deprecation_reason: "".to_owned(),
             });
-            assert_errors!(diagnostic_reporter, [&expected]);
+            assert_errors!(diagnostics, [&expected]);
         }
 
         #[test]
@@ -259,14 +259,14 @@ mod attributes {
                 ";
 
             // Act
-            let diagnostic_reporter = parse_for_diagnostics(slice);
+            let diagnostics = parse_for_diagnostics(slice);
 
             // Assert
             let expected = &crate::helpers::new_warning(WarningKind::UseOfDeprecatedEntity {
                 identifier: "A".to_owned(),
                 deprecation_reason: ": Message here".to_owned(),
             });
-            assert_errors!(diagnostic_reporter, [&expected]);
+            assert_errors!(diagnostics, [&expected]);
         }
 
         #[test]
@@ -286,14 +286,14 @@ mod attributes {
                 ";
 
             // Act
-            let diagnostic_reporter = parse_for_diagnostics(slice);
+            let diagnostics = parse_for_diagnostics(slice);
 
             // Assert
             let expected = &crate::helpers::new_warning(WarningKind::UseOfDeprecatedEntity {
                 identifier: "A".to_owned(),
                 deprecation_reason: "".to_owned(),
             });
-            assert_errors!(diagnostic_reporter, [&expected]);
+            assert_errors!(diagnostics, [&expected]);
         }
 
         #[test]
@@ -333,7 +333,7 @@ mod attributes {
             ";
 
             // Act
-            let diagnostic_reporter = parse_for_diagnostics(slice);
+            let diagnostics = parse_for_diagnostics(slice);
 
             // Assert
             let expected = Error::new(ErrorKind::ArgumentNotSupported {
@@ -344,7 +344,7 @@ mod attributes {
                 "The valid arguments for the compress attribute are 'Args' and 'Return'",
                 None,
             );
-            assert_errors!(diagnostic_reporter, [&expected]);
+            assert_errors!(diagnostics, [&expected]);
         }
 
         #[test]
@@ -361,11 +361,11 @@ mod attributes {
             ";
 
             // Act
-            let diagnostic_reporter = parse_for_diagnostics(slice);
+            let diagnostics = parse_for_diagnostics(slice);
 
             // Assert
             let expected = Error::new(ErrorKind::CompressAttributeCannotBeApplied);
-            assert_errors!(diagnostic_reporter, [&expected]);
+            assert_errors!(diagnostics, [&expected]);
         }
 
         #[test]
@@ -460,10 +460,10 @@ mod attributes {
         )]
         fn ignore_warnings_attribute(slice: &str) {
             // Act
-            let diagnostic_reporter = parse_for_diagnostics(slice);
+            let diagnostics = parse_for_diagnostics(slice);
 
             // Assert
-            assert_errors!(diagnostic_reporter);
+            assert_errors!(diagnostics);
         }
 
         #[test]
@@ -480,7 +480,7 @@ mod attributes {
             ";
 
             // Act
-            let diagnostic_reporter = parse_for_diagnostics(slice);
+            let diagnostics = parse_for_diagnostics(slice);
 
             // Assert
             let expected = [
@@ -491,7 +491,7 @@ mod attributes {
                     code: "w001".to_owned(),
                 }),
             ];
-            assert_errors!(diagnostic_reporter, expected);
+            assert_errors!(diagnostics, expected);
         }
 
         #[test_case(
@@ -524,10 +524,10 @@ mod attributes {
         )]
         fn ignore_warnings_attribute_args(slice: &str) {
             // Act
-            let diagnostic_reporter = parse_for_diagnostics(slice);
+            let diagnostics = parse_for_diagnostics(slice);
 
             // Assert
-            assert_errors!(diagnostic_reporter);
+            assert_errors!(diagnostics);
         }
 
         #[test_case(
@@ -560,7 +560,7 @@ mod attributes {
         // Test that if args are passed to ignoreWarnings, that only those warnings are ignored
         fn ignore_warnings_attribute_with_args_will_not_ignore_all_warnings(slice: &str) {
             // Act
-            let diagnostic_reporter = parse_for_diagnostics(slice);
+            let diagnostics = parse_for_diagnostics(slice);
 
             // Assert
             let expected = &crate::helpers::new_warning(WarningKind::ExtraParameterInDocComment {
@@ -568,7 +568,7 @@ mod attributes {
             });
 
             debug_assert_eq!(expected.error_code(), "W002");
-            assert_errors!(diagnostic_reporter, [&expected]);
+            assert_errors!(diagnostics, [&expected]);
         }
     }
 

--- a/tests/classes/container.rs
+++ b/tests/classes/container.rs
@@ -74,9 +74,9 @@ fn cycles_are_allowed(cycle_string: &str) {
         "
     );
 
-    let diagnostic_reporter = parse_for_diagnostics(slice);
+    let diagnostics = parse_for_diagnostics(slice);
 
-    assert_errors!(diagnostic_reporter);
+    assert_errors!(diagnostics);
 }
 
 /// Verifies that classes can be empty
@@ -113,12 +113,12 @@ fn cannot_redefine_data_members() {
     ";
 
     // Act
-    let diagnostic_reporter = parse_for_diagnostics(slice);
+    let diagnostics = parse_for_diagnostics(slice);
 
     // Assert
     let expected = [Error::new(ErrorKind::Redefinition {
         identifier: "a".to_string(),
     })
     .add_note("'a' was previously defined here", None)];
-    assert_errors!(diagnostic_reporter, &expected);
+    assert_errors!(diagnostics, &expected);
 }

--- a/tests/classes/encoding.rs
+++ b/tests/classes/encoding.rs
@@ -18,7 +18,7 @@ mod slice2 {
         ";
 
         // Act
-        let diagnostic_reporter = parse_for_diagnostics(slice);
+        let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
         let error_kind = ErrorKind::NotSupportedWithEncoding {
@@ -34,6 +34,6 @@ mod slice2 {
             )
             .add_note("classes are only supported by the Slice1 encoding", None);
 
-        assert_errors!(diagnostic_reporter, [&expected]);
+        assert_errors!(diagnostics, [&expected]);
     }
 }

--- a/tests/classes/inheritance.rs
+++ b/tests/classes/inheritance.rs
@@ -57,7 +57,7 @@ fn does_not_support_multiple_inheritance() {
     ";
 
     // Act
-    let diagnostic_reporter = parse_for_diagnostics(slice);
+    let diagnostics = parse_for_diagnostics(slice);
 
     // Assert
     let expected = Error::new(ErrorKind::Syntax {
@@ -65,7 +65,7 @@ fn does_not_support_multiple_inheritance() {
     })
     .set_span(&Span::new((13, 20).into(), (13, 21).into(), "string-0"));
 
-    assert_errors!(diagnostic_reporter, [&expected]);
+    assert_errors!(diagnostics, [&expected]);
 }
 
 #[test]
@@ -86,14 +86,14 @@ fn data_member_shadowing_is_disallowed() {
     ";
 
     // Act
-    let diagnostic_reporter = parse_for_diagnostics(slice);
+    let diagnostics = parse_for_diagnostics(slice);
 
     // Assert
     let expected = Error::new(ErrorKind::Shadows {
         identifier: "i".to_owned(),
     })
     .add_note("'i' was previously defined here", None);
-    assert_errors!(diagnostic_reporter, [&expected]);
+    assert_errors!(diagnostics, [&expected]);
 }
 
 #[test]

--- a/tests/comment_tests.rs
+++ b/tests/comment_tests.rs
@@ -97,12 +97,10 @@ mod comments {
         ";
 
         // Act
-        let diagnostic_reporter = parse_for_diagnostics(slice);
+        let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
-        assert_errors!(diagnostic_reporter, [
-            "void operation must not contain doc comment return tag"
-        ]);
+        assert_errors!(diagnostics, ["void operation must not contain doc comment return tag"]);
     }
 
     #[test]
@@ -120,10 +118,10 @@ mod comments {
         ";
 
         // Act
-        let diagnostic_reporter = parse_for_diagnostics(slice);
+        let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
-        assert_errors!(diagnostic_reporter, [
+        assert_errors!(diagnostics, [
             "doc comment has a param tag for 'testParam2', but there is no parameter by that name",
         ]);
     }
@@ -144,10 +142,10 @@ mod comments {
         ";
 
         // Act
-        let diagnostic_reporter = parse_for_diagnostics(slice);
+        let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
-        assert_errors!(diagnostic_reporter);
+        assert_errors!(diagnostics);
     }
 
     #[test]
@@ -187,10 +185,10 @@ mod comments {
         ";
 
         // Act
-        let diagnostic_reporter = parse_for_diagnostics(slice);
+        let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
-        assert_errors!(diagnostic_reporter, [
+        assert_errors!(diagnostics, [
             "doc comment indicates that struct 'S' throws, however, only operations can throw",
         ]);
     }
@@ -306,13 +304,13 @@ mod comments {
             ";
 
         // Act
-        let diagnostic_reporter = parse_for_diagnostics(slice);
+        let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
         let expected = &crate::helpers::new_warning(WarningKind::InvalidDocCommentLinkIdentifier {
             identifier: "OtherStruct".to_owned(),
         });
-        assert_errors!(diagnostic_reporter, [&expected]);
+        assert_errors!(diagnostics, [&expected]);
     }
 
     #[test]
@@ -327,12 +325,12 @@ mod comments {
             ";
 
         // Act
-        let diagnostic_reporter = parse_for_diagnostics(slice);
+        let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
         let expected = &crate::helpers::new_warning(WarningKind::InvalidDocCommentTag {
             tag: "@linked".to_owned(),
         });
-        assert_errors!(diagnostic_reporter, [&expected]);
+        assert_errors!(diagnostics, [&expected]);
     }
 }

--- a/tests/dictionaries/key_type.rs
+++ b/tests/dictionaries/key_type.rs
@@ -14,11 +14,11 @@ fn optionals_are_disallowed() {
     ";
 
     // Act
-    let diagnostic_reporter = parse_for_diagnostics(slice);
+    let diagnostics = parse_for_diagnostics(slice);
 
     // Assert
     let expected = Error::new(ErrorKind::KeyMustBeNonOptional);
-    assert_errors!(diagnostic_reporter, [&expected]);
+    assert_errors!(diagnostics, [&expected]);
 }
 
 #[test_case("bool"; "bool")]
@@ -45,10 +45,10 @@ fn allowed_primitive_types(key_type: &str) {
     );
 
     // Act
-    let diagnostic_reporter = parse_for_diagnostics(slice);
+    let diagnostics = parse_for_diagnostics(slice);
 
     // Assert
-    assert_errors!(diagnostic_reporter);
+    assert_errors!(diagnostics);
 }
 
 #[test_case("float32"; "float32")]
@@ -64,13 +64,13 @@ fn disallowed_primitive_types(key_type: &str) {
     );
 
     // Act
-    let diagnostic_reporter = parse_for_diagnostics(slice);
+    let diagnostics = parse_for_diagnostics(slice);
 
     // Assert
     let expected = Error::new(ErrorKind::KeyTypeNotSupported {
         identifier: key_type.to_owned(),
     });
-    assert_errors!(diagnostic_reporter, [&expected]);
+    assert_errors!(diagnostics, [&expected]);
 }
 
 #[test_case("sequence<int8>", "sequences" ; "sequences")]
@@ -85,13 +85,13 @@ fn collections_are_disallowed(key_type: &str, key_kind: &str) {
     );
 
     // Act
-    let diagnostic_reporter = parse_for_diagnostics(slice);
+    let diagnostics = parse_for_diagnostics(slice);
 
     // Assert
     let expected = Error::new(ErrorKind::KeyTypeNotSupported {
         identifier: key_kind.to_owned(),
     });
-    assert_errors!(diagnostic_reporter, [&expected]);
+    assert_errors!(diagnostics, [&expected]);
 }
 
 #[test_case("MyEnum", "unchecked enum MyEnum {}" ; "enums")]
@@ -107,10 +107,10 @@ fn allowed_constructed_types(key_type: &str, key_type_def: &str) {
     );
 
     // Act
-    let diagnostic_reporter = parse_for_diagnostics(slice);
+    let diagnostics = parse_for_diagnostics(slice);
 
     // Assert
-    assert_errors!(diagnostic_reporter);
+    assert_errors!(diagnostics);
 }
 
 #[test_case("MyClass", "class MyClass {}", "class" ; "classes")]
@@ -129,7 +129,7 @@ fn disallowed_constructed_types(key_type: &str, key_type_def: &str, key_kind: &s
     );
 
     // Act
-    let diagnostic_reporter = parse_for_diagnostics(slice);
+    let diagnostics = parse_for_diagnostics(slice);
 
     // Assert
     let expected = Error::new(ErrorKind::KeyTypeNotSupported {
@@ -137,7 +137,7 @@ fn disallowed_constructed_types(key_type: &str, key_type_def: &str, key_kind: &s
     })
     .add_note(format!("{key_kind} '{key_type}' is defined here:"), None);
 
-    assert_errors!(diagnostic_reporter, [&expected]);
+    assert_errors!(diagnostics, [&expected]);
 }
 
 #[test]
@@ -154,11 +154,11 @@ fn non_compact_structs_are_disallowed() {
     ";
 
     // Act
-    let diagnostic_reporter = parse_for_diagnostics(slice);
+    let diagnostics = parse_for_diagnostics(slice);
 
     // Assert
     let expected = Error::new(ErrorKind::StructKeyMustBeCompact).add_note("Struct 'MyStruct' is defined here:", None);
-    assert_errors!(diagnostic_reporter, [&expected]);
+    assert_errors!(diagnostics, [&expected]);
 }
 
 #[test]
@@ -182,10 +182,10 @@ fn compact_struct_with_allowed_members_is_allowed() {
     ";
 
     // Act
-    let diagnostic_reporter = parse_for_diagnostics(slice);
+    let diagnostics = parse_for_diagnostics(slice);
 
     // Assert
-    assert_errors!(diagnostic_reporter);
+    assert_errors!(diagnostics);
 }
 
 #[test]
@@ -211,7 +211,7 @@ fn compact_struct_with_disallowed_members_is_disallowed() {
     ";
 
     // Act
-    let diagnostic_reporter = parse_for_diagnostics(slice);
+    let diagnostics = parse_for_diagnostics(slice);
 
     // Assert
     let expected: [Error; 7] = [
@@ -239,5 +239,5 @@ fn compact_struct_with_disallowed_members_is_disallowed() {
         })
         .add_note("struct 'Outer' is defined here:", None),
     ];
-    assert_errors!(diagnostic_reporter, expected);
+    assert_errors!(diagnostics, expected);
 }

--- a/tests/encoding_tests.rs
+++ b/tests/encoding_tests.rs
@@ -21,10 +21,10 @@ mod encodings {
         );
 
         // Act
-        let diagnostic_reporter = parse_for_diagnostics(slice);
+        let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
-        assert_errors!(diagnostic_reporter);
+        assert_errors!(diagnostics);
     }
 
     #[test]
@@ -35,11 +35,11 @@ mod encodings {
         ";
 
         // Act
-        let diagnostic_reporter = parse_for_diagnostics(slice);
+        let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
         let expected = [Error::new(ErrorKind::InvalidEncodingVersion { encoding: 3 })];
-        assert_errors!(diagnostic_reporter, expected);
+        assert_errors!(diagnostics, expected);
     }
 
     #[test]
@@ -51,10 +51,10 @@ mod encodings {
         ";
 
         // Act
-        let diagnostic_reporter = parse_for_diagnostics(slice);
+        let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
         let expected = Error::new(ErrorKind::Syntax{message: "expected one of '[', 'class', 'compact', 'custom', 'doc comment', 'enum', 'exception', 'interface', 'module', 'struct', 'typealias', or 'unchecked', but found 'encoding'".to_owned()});
-        assert_errors!(diagnostic_reporter, [&expected]);
+        assert_errors!(diagnostics, [&expected]);
     }
 }

--- a/tests/enums/container.rs
+++ b/tests/enums/container.rs
@@ -65,7 +65,7 @@ fn implicit_enumerator_values_overflow_cleanly() {
     ";
 
     // Act
-    let diagnostic_reporter = parse_for_diagnostics(slice);
+    let diagnostics = parse_for_diagnostics(slice);
 
     // Assert
     let expected = [
@@ -82,7 +82,7 @@ fn implicit_enumerator_values_overflow_cleanly() {
             max: 2147483647,
         }),
     ];
-    assert_errors!(diagnostic_reporter, expected);
+    assert_errors!(diagnostics, expected);
 }
 
 #[test]
@@ -98,10 +98,10 @@ fn enumerator_values_can_be_out_of_order() {
         ";
 
     // Act
-    let diagnostic_reporter = parse_for_diagnostics(slice);
+    let diagnostics = parse_for_diagnostics(slice);
 
     // Assert
-    assert_errors!(diagnostic_reporter);
+    assert_errors!(diagnostics);
 }
 
 #[test]
@@ -119,7 +119,7 @@ fn validate_backing_type_out_of_bounds() {
     );
 
     // Act
-    let diagnostic_reporter = parse_for_diagnostics(slice);
+    let diagnostics = parse_for_diagnostics(slice);
 
     // Assert
     let expected = Error::new(ErrorKind::EnumeratorValueOutOfBounds {
@@ -128,7 +128,7 @@ fn validate_backing_type_out_of_bounds() {
         min: -32768_i128,
         max: 32767_i128,
     });
-    assert_errors!(diagnostic_reporter, [&expected]);
+    assert_errors!(diagnostics, [&expected]);
 }
 
 #[test]
@@ -148,10 +148,10 @@ fn validate_backing_type_bounds() {
     );
 
     // Act
-    let diagnostic_reporter = parse_for_diagnostics(slice);
+    let diagnostics = parse_for_diagnostics(slice);
 
     // Assert
-    assert_errors!(diagnostic_reporter);
+    assert_errors!(diagnostics);
 }
 
 #[test_case("string"; "string")]
@@ -170,14 +170,14 @@ fn invalid_underlying_type(underlying_type: &str) {
     );
 
     // Act
-    let diagnostic_reporter = parse_for_diagnostics(slice);
+    let diagnostics = parse_for_diagnostics(slice);
 
     // Assert
     let expected = Error::new(ErrorKind::UnderlyingTypeMustBeIntegral {
         enum_identifier: "E".to_owned(),
         kind: underlying_type.to_owned(),
     });
-    assert_errors!(diagnostic_reporter, [&expected]);
+    assert_errors!(diagnostics, [&expected]);
 }
 
 #[test_case("10", "expected one of '[', '}', 'doc comment', or 'identifier', but found '10'"; "numeric identifier")]
@@ -195,10 +195,10 @@ fn enumerator_invalid_identifiers(identifier: &str, expected: &str) {
     );
 
     // Act
-    let diagnostic_reporter = parse_for_diagnostics(slice);
+    let diagnostics = parse_for_diagnostics(slice);
 
     // Assert
-    assert_errors!(diagnostic_reporter, [expected]);
+    assert_errors!(diagnostics, [expected]);
 }
 
 #[test]
@@ -214,13 +214,13 @@ fn optional_underlying_types_fail() {
     ";
 
     // Act
-    let diagnostic_reporter = parse_for_diagnostics(slice);
+    let diagnostics = parse_for_diagnostics(slice);
 
     // Assert
     let expected = Error::new(ErrorKind::CannotUseOptionalUnderlyingType {
         enum_identifier: "E".to_owned(),
     });
-    assert_errors!(diagnostic_reporter, [&expected]);
+    assert_errors!(diagnostics, [&expected]);
 }
 
 #[test]
@@ -237,12 +237,12 @@ fn enumerators_must_be_unique() {
     ";
 
     // Act
-    let diagnostic_reporter = parse_for_diagnostics(slice);
+    let diagnostics = parse_for_diagnostics(slice);
 
     // Assert
     let expected = Error::new(ErrorKind::DuplicateEnumeratorValue { enumerator_value: 1 })
         .add_note("the value was previously used by 'A' here:", None);
-    assert_errors!(diagnostic_reporter, [&expected]);
+    assert_errors!(diagnostics, [&expected]);
 }
 
 #[test_case("unchecked enum", true ; "unchecked")]
@@ -281,9 +281,9 @@ fn checked_enums_can_not_be_empty() {
         enum_identifier: "E".to_owned(),
     });
 
-    let diagnostic_reporter = parse_for_diagnostics(slice);
+    let diagnostics = parse_for_diagnostics(slice);
 
-    assert_errors!(diagnostic_reporter, [&expected]);
+    assert_errors!(diagnostics, [&expected]);
 }
 
 #[test]
@@ -344,11 +344,11 @@ fn duplicate_enumerators_are_disallowed_across_different_bases() {
     ";
 
     // Act
-    let diagnostic_reporter = parse_for_diagnostics(slice);
+    let diagnostics = parse_for_diagnostics(slice);
 
     // Assert
     let expected = Error::new(ErrorKind::DuplicateEnumeratorValue { enumerator_value: 79 });
-    assert_errors!(diagnostic_reporter, [&expected]);
+    assert_errors!(diagnostics, [&expected]);
 }
 
 mod slice1 {
@@ -373,7 +373,7 @@ mod slice1 {
         ";
 
         // Act
-        let diagnostic_reporter = parse_for_diagnostics(slice);
+        let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
         const MAX_VALUE: i128 = i32::MAX as i128;
@@ -397,7 +397,7 @@ mod slice1 {
                 max: MAX_VALUE,
             }),
         ];
-        assert_errors!(diagnostic_reporter, expected_errors);
+        assert_errors!(diagnostics, expected_errors);
     }
 
     #[test]
@@ -417,7 +417,7 @@ mod slice1 {
         );
 
         // Act
-        let diagnostic_reporter = parse_for_diagnostics(slice);
+        let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
         let expected = Error::new(ErrorKind::EnumeratorValueOutOfBounds {
@@ -426,7 +426,7 @@ mod slice1 {
             min: 0,
             max: i32::MAX as i128,
         });
-        assert_errors!(diagnostic_reporter, [&expected]);
+        assert_errors!(diagnostics, [&expected]);
     }
 }
 
@@ -451,10 +451,10 @@ mod slice2 {
         ";
 
         // Act
-        let diagnostic_reporter = parse_for_diagnostics(slice);
+        let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
-        assert_errors!(diagnostic_reporter);
+        assert_errors!(diagnostics);
     }
 
     #[test]

--- a/tests/enums/encoding.rs
+++ b/tests/enums/encoding.rs
@@ -23,7 +23,7 @@ mod slice1 {
         ";
 
         // Act
-        let diagnostic_reporter = parse_for_diagnostics(slice);
+        let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
         let expected = Error::new(ErrorKind::NotSupportedWithEncoding {
@@ -37,7 +37,7 @@ mod slice1 {
             None,
         );
 
-        assert_errors!(diagnostic_reporter, [&expected]);
+        assert_errors!(diagnostics, [&expected]);
     }
 }
 
@@ -69,9 +69,9 @@ mod slice2 {
         );
 
         // Act
-        let diagnostic_reporter = parse_for_diagnostics(slice);
+        let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
-        assert_errors!(diagnostic_reporter);
+        assert_errors!(diagnostics);
     }
 }

--- a/tests/enums/tags.rs
+++ b/tests/enums/tags.rs
@@ -19,8 +19,8 @@ fn cannot_contain_tags() {
     ";
 
     // Act
-    let diagnostic_reporter = parse_for_diagnostics(slice);
+    let diagnostics = parse_for_diagnostics(slice);
 
     // Act & Assert
-    assert_errors!(diagnostic_reporter);
+    assert_errors!(diagnostics);
 }

--- a/tests/exceptions/container.rs
+++ b/tests/exceptions/container.rs
@@ -77,12 +77,12 @@ fn cannot_redefine_data_members() {
     ";
 
     // Act
-    let diagnostic_reporter = parse_for_diagnostics(slice);
+    let diagnostics = parse_for_diagnostics(slice);
 
     // Assert
     let expected = Error::new(ErrorKind::Redefinition {
         identifier: "a".to_owned(),
     })
     .add_note("'a' was previously defined here", None);
-    assert_errors!(diagnostic_reporter, [&expected]);
+    assert_errors!(diagnostics, [&expected]);
 }

--- a/tests/exceptions/encoding.rs
+++ b/tests/exceptions/encoding.rs
@@ -28,14 +28,14 @@ mod slice1 {
         ";
 
         // Act
-        let diagnostic_reporter = parse_for_diagnostics(slice);
+        let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
         let expected = Error::new(ErrorKind::ExceptionNotSupported {
             encoding: Encoding::Slice1,
         })
         .add_note("file encoding was set to Slice1 here:", None);
-        assert_errors!(diagnostic_reporter, [&expected]);
+        assert_errors!(diagnostics, [&expected]);
     }
 }
 
@@ -65,7 +65,7 @@ mod slice2 {
         ";
 
         // Act
-        let diagnostic_reporter = parse_for_diagnostics(slice);
+        let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
         let expected = Error::new(ErrorKind::NotSupportedWithEncoding {
@@ -80,7 +80,7 @@ mod slice2 {
         )
         .add_note("exception inheritance is only supported by the Slice1 encoding", None);
 
-        assert_errors!(diagnostic_reporter, [&expected]);
+        assert_errors!(diagnostics, [&expected]);
     }
 
     /// Verifies that the slice parser with the Slice2 encoding does not emit errors when parsing
@@ -102,10 +102,10 @@ mod slice2 {
         ";
 
         // Act
-        let diagnostic_reporter = parse_for_diagnostics(slice);
+        let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
-        assert_errors!(diagnostic_reporter);
+        assert_errors!(diagnostics);
     }
 
     /// Verify that exceptions which are only Slice1 encodable a Slice2 operation.
@@ -132,16 +132,17 @@ mod slice2 {
         ";
 
         // Act
-        let diagnostic_reporter = compile_from_strings(&[slice1, slice2], None)
+        let diagnostics = compile_from_strings(&[slice1, slice2], None)
             .unwrap_err()
-            .diagnostic_reporter;
+            .diagnostic_reporter
+            .into_diagnostics();
 
         // Assert
         let expected = Error::new(ErrorKind::UnsupportedType {
             kind: "E".to_owned(),
             encoding: Encoding::Slice2,
         });
-        assert_errors!(diagnostic_reporter, [&expected]);
+        assert_errors!(diagnostics, [&expected]);
     }
 
     #[test]
@@ -157,10 +158,10 @@ mod slice2 {
         ";
 
         // Act
-        let diagnostic_reporter = parse_for_diagnostics(slice);
+        let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
         let expected = Error::new(ErrorKind::AnyExceptionNotSupported);
-        assert_errors!(diagnostic_reporter, [&expected]);
+        assert_errors!(diagnostics, [&expected]);
     }
 }

--- a/tests/exceptions/inheritance.rs
+++ b/tests/exceptions/inheritance.rs
@@ -51,7 +51,7 @@ fn does_not_support_multiple_inheritance() {
     ";
 
     // Act
-    let diagnostic_reporter = parse_for_diagnostics(slice);
+    let diagnostics = parse_for_diagnostics(slice);
 
     // Assert
     let expected = Error::new(ErrorKind::Syntax {
@@ -59,7 +59,7 @@ fn does_not_support_multiple_inheritance() {
     })
     .set_span(&Span::new((13, 20).into(), (13, 21).into(), "string-0"));
 
-    assert_errors!(diagnostic_reporter, [&expected]);
+    assert_errors!(diagnostics, [&expected]);
 }
 
 #[test]
@@ -79,14 +79,14 @@ fn must_inherit_from_exception() {
     ";
 
     // Act
-    let diagnostic_reporter = parse_for_diagnostics(slice);
+    let diagnostics = parse_for_diagnostics(slice);
 
     // Assert
     let expected = Error::new(ErrorKind::ConcreteTypeMismatch {
         expected: "exception".to_owned(),
         kind: "class".to_owned(),
     });
-    assert_errors!(diagnostic_reporter, [&expected]);
+    assert_errors!(diagnostics, [&expected]);
 }
 
 #[test]
@@ -108,14 +108,14 @@ fn data_member_shadowing_is_disallowed() {
     ";
 
     // Act
-    let diagnostic_reporter = parse_for_diagnostics(slice);
+    let diagnostics = parse_for_diagnostics(slice);
 
     // Assert
     let expected = Error::new(ErrorKind::Shadows {
         identifier: "i".to_owned(),
     })
     .add_note("'i' was previously defined here", None);
-    assert_errors!(diagnostic_reporter, [&expected]);
+    assert_errors!(diagnostics, [&expected]);
 }
 
 #[test]

--- a/tests/helpers/macros.rs
+++ b/tests/helpers/macros.rs
@@ -6,27 +6,25 @@
 /// diagnostic reporter errors.
 #[macro_export]
 macro_rules! assert_errors {
-    ($diagnostic_reporter:expr) => {
-        let errors = $diagnostic_reporter.into_diagnostics();
+    ($diagnostics:expr) => {
         assert!(
-            errors.is_empty(),
+            $diagnostics.is_empty(),
             "Expected no errors, got {}.\n{:?}",
-            errors.len(),
-            errors,
+            $diagnostics.len(),
+            $diagnostics,
         );
     };
 
-    ($diagnostic_reporter:expr, $expected_errors:expr) => {
-        let errors = $diagnostic_reporter.into_diagnostics();
+    ($diagnostics:expr, $expected_errors:expr) => {
         assert_eq!(
-            errors.len(),
+            $diagnostics.len(),
             $expected_errors.len(),
             "Expected {} errors, got {}.\n{:?}",
             $expected_errors.len(),
-            errors.len(),
-            errors,
+            $diagnostics.len(),
+            $diagnostics,
         );
-        for (i, error) in errors.iter().enumerate() {
+        for (i, error) in $diagnostics.iter().enumerate() {
             assert_eq!(&error.message(), &$expected_errors[i].to_string());
         }
     };

--- a/tests/helpers/parsing_helpers.rs
+++ b/tests/helpers/parsing_helpers.rs
@@ -2,7 +2,7 @@
 
 use slice::ast::Ast;
 use slice::compile_from_strings;
-use slice::diagnostics::DiagnosticReporter;
+use slice::diagnostics::Diagnostic;
 
 /// This function is used to parse a Slice file and return the AST.
 pub fn parse_for_ast(slice: impl Into<String>) -> Ast {
@@ -13,11 +13,12 @@ pub fn parse_for_ast(slice: impl Into<String>) -> Ast {
 }
 
 /// This function is used to parse a Slice file and return the DiagnosticReporter.
-pub fn parse_for_diagnostics(slice: impl Into<String>) -> DiagnosticReporter {
-    match compile_from_strings(&[&slice.into()], None) {
-        Ok(data) => data.diagnostic_reporter,
-        Err(data) => data.diagnostic_reporter,
-    }
+pub fn parse_for_diagnostics(slice: impl Into<String>) -> Vec<Diagnostic> {
+    let data = match compile_from_strings(&[&slice.into()], None) {
+        Ok(data) => data,
+        Err(data) => data,
+    };
+    data.diagnostic_reporter.into_diagnostics()
 }
 
 /// This function returns the kind of an element, but pluralized.

--- a/tests/interfaces/encoding.rs
+++ b/tests/interfaces/encoding.rs
@@ -28,7 +28,11 @@ fn operation_members_are_compatible_with_encoding() {
     ";
 
     // Act
-    let result = compile_from_strings(&[slice1, slice2], None).err().unwrap();
+    let diagnostics = compile_from_strings(&[slice1, slice2], None)
+        .err()
+        .unwrap()
+        .diagnostic_reporter
+        .into_diagnostics();
 
     // Assert
     let expected = Error::new(ErrorKind::UnsupportedType {
@@ -37,7 +41,7 @@ fn operation_members_are_compatible_with_encoding() {
     })
     .add_note("file encoding was set to Slice2 here:", None);
 
-    assert_errors!(result.diagnostic_reporter, [&expected]);
+    assert_errors!(diagnostics, [&expected]);
 }
 
 #[test]
@@ -52,11 +56,11 @@ fn anyexception_cannot_be_used_without_slice1() {
     ";
 
     // Act
-    let diagnostic_reporter = parse_for_diagnostics(slice);
+    let diagnostics = parse_for_diagnostics(slice);
 
     // Assert
     let expected = Error::new(ErrorKind::AnyExceptionNotSupported);
-    assert_errors!(diagnostic_reporter, [&expected]);
+    assert_errors!(diagnostics, [&expected]);
 }
 
 mod slice1 {

--- a/tests/interfaces/inheritance.rs
+++ b/tests/interfaces/inheritance.rs
@@ -94,14 +94,14 @@ fn must_inherit_from_interface() {
     ";
 
     // Act
-    let diagnostic_reporter = parse_for_diagnostics(slice);
+    let diagnostics = parse_for_diagnostics(slice);
 
     // Assert
     let expected = Error::new(ErrorKind::ConcreteTypeMismatch {
         expected: "interface".to_owned(),
         kind: "class".to_owned(),
     });
-    assert_errors!(diagnostic_reporter, [&expected]);
+    assert_errors!(diagnostics, [&expected]);
 }
 
 #[test]
@@ -126,10 +126,10 @@ fn operation_shadowing_is_disallowed() {
     .add_note("'op' was previously defined here", None);
 
     // Act
-    let diagnostic_reporter = parse_for_diagnostics(slice);
+    let diagnostics = parse_for_diagnostics(slice);
 
     // Assert
-    assert_errors!(diagnostic_reporter, [&expected]);
+    assert_errors!(diagnostics, [&expected]);
 }
 
 #[test]

--- a/tests/interfaces/mod.rs
+++ b/tests/interfaces/mod.rs
@@ -42,10 +42,10 @@ fn can_have_self_referencing_operations() {
     ";
 
     // Act
-    let reporter = parse_for_diagnostics(slice);
+    let diagnostics = parse_for_diagnostics(slice);
 
     // Assert
-    assert_errors!(reporter);
+    assert_errors!(diagnostics);
 }
 
 #[test]
@@ -105,12 +105,12 @@ fn cannot_redefine_operations() {
     ";
 
     // Act
-    let diagnostic_reporter = parse_for_diagnostics(slice);
+    let diagnostics = parse_for_diagnostics(slice);
 
     // Assert
     let expected = Error::new(ErrorKind::Redefinition {
         identifier: "op".to_owned(),
     })
     .add_note("'op' was previously defined here", None);
-    assert_errors!(diagnostic_reporter, [&expected]);
+    assert_errors!(diagnostics, [&expected]);
 }

--- a/tests/interfaces/operations.rs
+++ b/tests/interfaces/operations.rs
@@ -244,14 +244,14 @@ fn operations_can_only_throw_exceptions() {
     ";
 
     // Act
-    let diagnostic_reporter = parse_for_diagnostics(slice);
+    let diagnostics = parse_for_diagnostics(slice);
 
     // Assert
     let expected = Error::new(ErrorKind::ConcreteTypeMismatch {
         expected: "exception".to_owned(),
         kind: "struct".to_owned(),
     });
-    assert_errors!(diagnostic_reporter, [&expected]);
+    assert_errors!(diagnostics, [&expected]);
 }
 
 #[test_case("()"; "0 elements")]
@@ -270,11 +270,11 @@ fn return_tuple_must_contain_two_or_more_elements(return_tuple: &str) {
     );
 
     // Act
-    let diagnostic_reporter = parse_for_diagnostics(slice);
+    let diagnostics = parse_for_diagnostics(slice);
 
     // Assert
     let expected = Error::new(ErrorKind::ReturnTuplesMustContainAtLeastTwoElements);
-    assert_errors!(diagnostic_reporter, [&expected]);
+    assert_errors!(diagnostics, [&expected]);
 }
 
 mod streams {
@@ -320,7 +320,7 @@ mod streams {
         ";
 
         // Act
-        let diagnostic_reporter = parse_for_diagnostics(slice);
+        let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
         let expected = [
@@ -329,7 +329,7 @@ mod streams {
             }),
             Error::new(ErrorKind::MultipleStreamedMembers),
         ];
-        assert_errors!(diagnostic_reporter, expected);
+        assert_errors!(diagnostics, expected);
     }
 
     #[test]
@@ -345,12 +345,12 @@ mod streams {
         ";
 
         // Act
+        let diagnostics = parse_for_diagnostics(slice);
+
+        // Assert
         let expected = Error::new(ErrorKind::StreamedMembersMustBeLast {
             parameter_identifier: "s".to_owned(),
         });
-
-        // Assert
-        let diagnostic_reporter = parse_for_diagnostics(slice);
-        assert_errors!(diagnostic_reporter, [&expected]);
+        assert_errors!(diagnostics, [&expected]);
     }
 }

--- a/tests/mixed_encoding_tests.rs
+++ b/tests/mixed_encoding_tests.rs
@@ -80,7 +80,7 @@ fn invalid_mixed_encoding_fails() {
     let parser_result = compile_from_strings(&[encoding1_slice, encoding2_slice], None);
 
     // Assert
-    let diagnostic_reporter = parser_result.err().unwrap().diagnostic_reporter;
+    let diagnostics = parser_result.err().unwrap().diagnostic_reporter.into_diagnostics();
     let expected = [
         Error::new(ErrorKind::UnsupportedType {
             kind: "ACustomType".to_owned(),
@@ -94,5 +94,5 @@ fn invalid_mixed_encoding_fails() {
         .add_note("file encoding was set to Slice1 here:", None),
     ];
 
-    assert_errors!(diagnostic_reporter, expected);
+    assert_errors!(diagnostics, expected);
 }

--- a/tests/module_tests.rs
+++ b/tests/module_tests.rs
@@ -93,10 +93,10 @@ mod module {
         ";
 
         // Act
-        let reporter = parse_for_diagnostics(slice);
+        let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
-        assert_errors!(reporter, [
+        assert_errors!(diagnostics, [
             "expected one of '[', '[[', 'doc comment', 'encoding', or 'module', but found 'custom'"
         ]);
     }
@@ -117,7 +117,7 @@ mod module {
         ";
 
         // Act
-        let errors = parse_for_diagnostics(slice);
+        let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
         let expected = vec![
@@ -128,7 +128,7 @@ mod module {
                 identifier: "A".to_owned(),
             }),
         ];
-        assert_errors!(errors, expected);
+        assert_errors!(diagnostics, expected);
     }
 
     #[test]
@@ -143,13 +143,13 @@ mod module {
         ";
 
         // Act
-        let errors = parse_for_diagnostics(slice);
+        let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
         let expected = vec![Error::new(ErrorKind::FileScopedModuleCannotContainSubModules {
             identifier: "D".to_owned(),
         })];
-        assert_errors!(errors, expected);
+        assert_errors!(diagnostics, expected);
     }
 
     #[test]
@@ -168,14 +168,14 @@ mod module {
         ";
 
         // Act
-        let diagnostic_reporter = parse_for_diagnostics(slice);
+        let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
         let expected = Error::new(ErrorKind::Redefinition {
             identifier: "Bar".to_owned(),
         })
         .add_note("'Bar' was previously defined here", None);
-        assert_errors!(diagnostic_reporter, [&expected]);
+        assert_errors!(diagnostics, [&expected]);
     }
 
     #[test_case("Foo"; "module")]
@@ -190,9 +190,9 @@ mod module {
         );
 
         // Act
-        let diagnostic_reporter = parse_for_diagnostics(slice);
+        let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
-        assert_errors!(diagnostic_reporter);
+        assert_errors!(diagnostics);
     }
 }

--- a/tests/parser_tests.rs
+++ b/tests/parser_tests.rs
@@ -12,10 +12,10 @@ fn parse_empty_string() {
     let slice = "";
 
     // Act
-    let reporter = parse_for_diagnostics(slice);
+    let diagnostics = parse_for_diagnostics(slice);
 
     // Assert
-    assert_errors!(reporter);
+    assert_errors!(diagnostics);
 }
 
 #[test]
@@ -24,10 +24,10 @@ fn parse_string_containing_only_whitespace() {
     let slice = " ";
 
     // Act
-    let reporter = parse_for_diagnostics(slice);
+    let diagnostics = parse_for_diagnostics(slice);
 
     // Assert
-    assert_errors!(reporter);
+    assert_errors!(diagnostics);
 }
 
 #[test]
@@ -37,10 +37,10 @@ fn parse_ideographic_space() {
     let slice = "　";
 
     // Act
-    let reporter = parse_for_diagnostics(slice);
+    let diagnostics = parse_for_diagnostics(slice);
 
     // Assert
-    assert_errors!(reporter);
+    assert_errors!(diagnostics);
 }
 
 #[test]
@@ -53,7 +53,7 @@ fn string_literals_cannot_contain_newlines() {
     "#;
 
     // Act
-    let diagnostic_reporter = parse_for_diagnostics(slice);
+    let diagnostics = parse_for_diagnostics(slice);
 
     // Assert
     let span = Span::new((2, 22).into(), (2, 32).into(), "string-0");
@@ -61,5 +61,5 @@ fn string_literals_cannot_contain_newlines() {
         message: "unterminated string literal".to_owned(),
     })
     .set_span(&span);
-    assert_errors!(diagnostic_reporter, [&expected]);
+    assert_errors!(diagnostics, [&expected]);
 }

--- a/tests/preprocessor_tests.rs
+++ b/tests/preprocessor_tests.rs
@@ -45,11 +45,10 @@ fn undefined_preprocessor_directive_blocks_are_consumed() {
         ";
 
     // Act
-    let compilation_data = compile_from_strings(&[slice], None).unwrap();
+    let ast = parse_for_ast(slice);
 
     // Assert
-    assert!(compilation_data.ast.find_element::<Interface>("Test::I").is_err());
-    assert_errors!(compilation_data.diagnostic_reporter);
+    assert!(ast.find_element::<Interface>("Test::I").is_err());
 }
 
 #[test]
@@ -58,10 +57,10 @@ fn preprocessor_consumes_comments() {
     let slice = "// This is a comment";
 
     // Act
-    let reporter = parse_for_diagnostics(slice);
+    let diagnostics = parse_for_diagnostics(slice);
 
     // Assert
-    assert_errors!(reporter);
+    assert_errors!(diagnostics);
 }
 
 #[test]
@@ -289,10 +288,10 @@ fn preprocessor_nested_expressions() {
 )]
 fn preprocessor_conditionals_can_contain_empty_source_blocks(slice: &str) {
     // Arrange/Act
-    let reporter = parse_for_diagnostics(slice);
+    let diagnostics = parse_for_diagnostics(slice);
 
     // Assert
-    assert_errors!(reporter);
+    assert_errors!(diagnostics);
 }
 
 #[test]
@@ -323,8 +322,8 @@ fn preprocessor_single_backslash_suggestion() {
     ";
 
     // Act
-    let reporter = parse_for_diagnostics(slice);
+    let diagnostics = parse_for_diagnostics(slice);
 
     // Assert
-    assert_errors!(reporter, [r#"unknown symbol '/', try using '//' instead"#]);
+    assert_errors!(diagnostics, [r#"unknown symbol '/', try using '//' instead"#]);
 }

--- a/tests/primitives/encoding.rs
+++ b/tests/primitives/encoding.rs
@@ -34,7 +34,7 @@ mod slice1 {
         );
 
         // Act
-        let diagnostic_reporter = parse_for_diagnostics(slice);
+        let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
         let expected = Error::new(ErrorKind::UnsupportedType {
@@ -42,7 +42,7 @@ mod slice1 {
             encoding: Encoding::Slice1,
         })
         .add_note("file encoding was set to Slice1 here:", None);
-        assert_errors!(diagnostic_reporter, [&expected]);
+        assert_errors!(diagnostics, [&expected]);
     }
 
     /// Verifies that valid Slice1 types (bool, uint8, int16, int32, int64, float32, float64,
@@ -71,10 +71,10 @@ mod slice1 {
         );
 
         // Act
-        let diagnostic_reporter = parse_for_diagnostics(slice);
+        let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
-        assert_errors!(diagnostic_reporter);
+        assert_errors!(diagnostics);
     }
 }
 
@@ -101,7 +101,7 @@ mod slice2 {
         ";
 
         // Act
-        let diagnostic_reporter = parse_for_diagnostics(slice);
+        let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
         let expected = Error::new(ErrorKind::UnsupportedType {
@@ -115,7 +115,7 @@ mod slice2 {
         )
         .add_note("classes are only supported by the Slice1 encoding", None);
 
-        assert_errors!(diagnostic_reporter, [&expected]);
+        assert_errors!(diagnostics, [&expected]);
     }
 
     /// Verifies that valid Slice2 types (bool, int8, uint8, int16, uint16, int32, uint32,
@@ -150,10 +150,10 @@ mod slice2 {
         );
 
         // Act
-        let diagnostic_reporter = parse_for_diagnostics(slice);
+        let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
-        assert_errors!(diagnostic_reporter);
+        assert_errors!(diagnostics);
     }
 
     #[test_case("uint8?"; "optional uint8")]
@@ -187,9 +187,9 @@ mod slice2 {
         );
 
         // Act
-        let diagnostic_reporter = parse_for_diagnostics(slice);
+        let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
-        assert_errors!(diagnostic_reporter);
+        assert_errors!(diagnostics);
     }
 }

--- a/tests/scope_resolution_tests.rs
+++ b/tests/scope_resolution_tests.rs
@@ -20,14 +20,14 @@ mod scope_resolution {
         ";
 
         // Act
-        let diagnostic_reporter = parse_for_diagnostics(slice);
+        let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
         let expected = Error::new(ErrorKind::FileScopedModuleCannotContainSubModules {
             identifier: "T".to_owned(),
         })
         .add_note("file level module 'T' declared here", None);
-        assert_errors!(diagnostic_reporter, [&expected]);
+        assert_errors!(diagnostics, [&expected]);
     }
 
     #[test]
@@ -228,14 +228,14 @@ mod scope_resolution {
         ";
 
         // Act
-        let diagnostic_reporter = parse_for_diagnostics(slice);
+        let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
         let expected = Error::new(ErrorKind::Redefinition {
             identifier: "B".to_string(),
         })
         .add_note("'B' was previously defined here", None);
-        assert_errors!(diagnostic_reporter, [&expected]);
+        assert_errors!(diagnostics, [&expected]);
     }
 
     #[test]
@@ -262,14 +262,14 @@ mod scope_resolution {
         ";
 
         // Act
-        let diagnostic_reporter = parse_for_diagnostics(slice);
+        let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
         let expected = Error::new(ErrorKind::TypeMismatch {
             expected: "Type".to_string(),
             actual: "module".to_string(),
         });
-        assert_errors!(diagnostic_reporter, [&expected]);
+        assert_errors!(diagnostics, [&expected]);
     }
 
     #[test]
@@ -286,12 +286,12 @@ mod scope_resolution {
         ";
 
         // Act
-        let diagnostic_reporter = parse_for_diagnostics(slice);
+        let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
         let expected = Error::new(ErrorKind::DoesNotExist {
             identifier: "Nested::C".to_string(),
         });
-        assert_errors!(diagnostic_reporter, [&expected]);
+        assert_errors!(diagnostics, [&expected]);
     }
 }

--- a/tests/structs/container.rs
+++ b/tests/structs/container.rs
@@ -80,7 +80,7 @@ mod structs {
         ";
 
         // Act
-        let diagnostic_reporter = parse_for_diagnostics(slice);
+        let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
         let expected = Error::new(ErrorKind::Redefinition {
@@ -88,7 +88,7 @@ mod structs {
         })
         .add_note("'a' was previously defined here", None);
 
-        assert_errors!(diagnostic_reporter, [&expected]);
+        assert_errors!(diagnostics, [&expected]);
     }
 }
 
@@ -110,10 +110,10 @@ mod compact_structs {
         ";
 
         // Act
-        let diagnostic_reporter = parse_for_diagnostics(slice);
+        let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
         let expected = Error::new(ErrorKind::CompactStructCannotBeEmpty);
-        assert_errors!(diagnostic_reporter, [&expected]);
+        assert_errors!(diagnostics, [&expected]);
     }
 }

--- a/tests/structs/encoding.rs
+++ b/tests/structs/encoding.rs
@@ -22,7 +22,7 @@ mod slice1 {
         ";
 
         // Act
-        let diagnostic_reporter = parse_for_diagnostics(slice);
+        let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
         let expected = Error::new(ErrorKind::NotSupportedWithEncoding {
@@ -33,7 +33,7 @@ mod slice1 {
         .add_note("file encoding was set to Slice1 here:", None)
         .add_note("structs must be 'compact' to be supported by the Slice1 encoding", None);
 
-        assert_errors!(diagnostic_reporter, [&expected]);
+        assert_errors!(diagnostics, [&expected]);
     }
 }
 
@@ -59,7 +59,7 @@ mod slice2 {
         ";
 
         // Act
-        let diagnostic_reporter = parse_for_diagnostics(slice);
+        let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
         let expected = Error::new(ErrorKind::UnsupportedType {
@@ -72,7 +72,7 @@ mod slice2 {
             None,
         );
 
-        assert_errors!(diagnostic_reporter, [&expected]);
+        assert_errors!(diagnostics, [&expected]);
     }
 
     /// Verifies using the slice parser with Slice2 will not emit errors when parsing
@@ -91,9 +91,9 @@ mod slice2 {
         ";
 
         // Act
-        let diagnostic_reporter = parse_for_diagnostics(slice);
+        let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
-        assert_errors!(diagnostic_reporter);
+        assert_errors!(diagnostics);
     }
 }

--- a/tests/structs/tags.rs
+++ b/tests/structs/tags.rs
@@ -49,11 +49,11 @@ mod compact_structs {
         ";
 
         // Act
-        let diagnostic_reporter = parse_for_diagnostics(slice);
+        let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
         let expected = Error::new(ErrorKind::CompactStructCannotContainTaggedMembers)
             .add_note("struct 'S' is declared compact here", None);
-        assert_errors!(diagnostic_reporter, [&expected]);
+        assert_errors!(diagnostics, [&expected]);
     }
 }

--- a/tests/tag_tests.rs
+++ b/tests/tag_tests.rs
@@ -25,13 +25,13 @@ mod tags {
         ";
 
         // Act
-        let diagnostic_reporter = parse_for_diagnostics(slice);
+        let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
         let expected = Error::new(ErrorKind::TaggedMemberMustBeOptional {
             member_identifier: "b".to_owned(),
         });
-        assert_errors!(diagnostic_reporter, [&expected]);
+        assert_errors!(diagnostics, [&expected]);
     }
 
     #[test]
@@ -47,13 +47,13 @@ mod tags {
         ";
 
         // Act
-        let diagnostic_reporter = parse_for_diagnostics(slice);
+        let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
         let expected = Error::new(ErrorKind::TaggedMemberMustBeOptional {
             member_identifier: "myParam".to_string(),
         });
-        assert_errors!(diagnostic_reporter, [&expected]);
+        assert_errors!(diagnostics, [&expected]);
     }
 
     #[test]
@@ -69,7 +69,7 @@ mod tags {
         ";
 
         // Act
-        let diagnostic_reporter = parse_for_diagnostics(slice);
+        let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
         let expected = Error::new(ErrorKind::OptionalsNotSupported {
@@ -77,7 +77,7 @@ mod tags {
         })
         .add_note("file encoding was set to Slice1 here:", None);
 
-        assert_errors!(diagnostic_reporter, [&expected]);
+        assert_errors!(diagnostics, [&expected]);
     }
 
     #[test]
@@ -93,7 +93,7 @@ mod tags {
         ";
 
         // Act
-        let diagnostic_reporter = parse_for_diagnostics(slice);
+        let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
         let expected = [
@@ -104,7 +104,7 @@ mod tags {
                 parameter_identifier: "p4".to_owned(),
             }),
         ];
-        assert_errors!(diagnostic_reporter, expected);
+        assert_errors!(diagnostics, expected);
     }
 
     #[test]
@@ -125,13 +125,13 @@ mod tags {
         ";
 
         // Act
-        let errors = parse_for_diagnostics(slice);
+        let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
         let expected = Error::new(ErrorKind::CannotTagClass {
             member_identifier: "c".to_owned(),
         });
-        assert_errors!(errors, [&expected]);
+        assert_errors!(diagnostics, [&expected]);
     }
 
     #[test]
@@ -157,13 +157,13 @@ mod tags {
         ";
 
         // Act
-        let errors = parse_for_diagnostics(slice);
+        let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
         let expected = Error::new(ErrorKind::CannotTagContainingClass {
             member_identifier: "s".to_owned(),
         });
-        assert_errors!(errors, [&expected]);
+        assert_errors!(diagnostics, [&expected]);
     }
 
     #[test]
@@ -200,14 +200,14 @@ mod tags {
         ";
 
         // Act
-        let diagnostic_reporter = parse_for_diagnostics(slice);
+        let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
         let expected = Error::new(ErrorKind::CannotHaveDuplicateTag {
             member_identifier: "b".to_owned(),
         })
         .add_note("The data member 'a' has previous used the tag value '1'", None);
-        assert_errors!(diagnostic_reporter, [&expected]);
+        assert_errors!(diagnostics, [&expected]);
     }
 
     #[test_case(0)]
@@ -226,10 +226,10 @@ mod tags {
         );
 
         // Act
-        let diagnostic_reporter = parse_for_diagnostics(slice);
+        let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
-        assert_errors!(diagnostic_reporter);
+        assert_errors!(diagnostics);
     }
 
     #[test_case(77757348128678234_i64 ; "Random large value")]
@@ -247,11 +247,11 @@ mod tags {
         );
 
         // Act
-        let diagnostic_reporter = parse_for_diagnostics(slice);
+        let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
         let expected = Error::new(ErrorKind::TagValueOutOfBounds);
-        assert_errors!(diagnostic_reporter, [&expected]);
+        assert_errors!(diagnostics, [&expected]);
     }
 
     #[test]
@@ -266,11 +266,11 @@ mod tags {
         ";
 
         // Act
-        let diagnostic_reporter = parse_for_diagnostics(slice);
+        let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
         let expected = Error::new(ErrorKind::TagValueOutOfBounds);
-        assert_errors!(diagnostic_reporter, [&expected]);
+        assert_errors!(diagnostics, [&expected]);
     }
 
     #[test]
@@ -285,10 +285,10 @@ mod tags {
         ";
 
         // Act
-        let diagnostic_reporter = parse_for_diagnostics(slice);
+        let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
-        assert_errors!(diagnostic_reporter, [
+        assert_errors!(diagnostics, [
             "expected one of '-' or 'integer literal', but found 'test string'"
         ]);
     }

--- a/tests/typealias_tests.rs
+++ b/tests/typealias_tests.rs
@@ -51,10 +51,10 @@ mod typealias {
         ";
 
         // Act
-        let reporter = parse_for_diagnostics(slice);
+        let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
-        assert_errors!(reporter);
+        assert_errors!(diagnostics);
     }
 
     #[test]
@@ -70,10 +70,10 @@ mod typealias {
         ";
 
         // Act
-        let reporter = parse_for_diagnostics(slice);
+        let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
-        assert_errors!(reporter);
+        assert_errors!(diagnostics);
     }
 
     #[test]


### PR DESCRIPTION
This PR changes `parse_for_diagnostics` to return `Vec<Diagnostic>` instead of a `DiagnosticReporter`,
and changes the name for it to consistently be `diagnostics` (instead of a mix of `reporter`, `errors`, `diagnostics`, ...).

The only real change is in `tests/helpers/parsing_helpers.rs`

This seems more true to the name (it isn't named `parse_for_diagnostic_reporter`), and makes the code slightly simpler.
All we ever do with the reporter is call `into_diagnostics` on it anyways, so there's no need to keep the whole reporter around,
when all we really need are the diagnostics inside of it.

**The real reason for this PR is so the `DiagnosticReporter` doesn't live outside of `CompilationData`,**
making it possible to try filtering warnings when we emit diagnostics, instead of when we report them.
That's why I ran into this, but I think these changes are more semantically correct regardless.