### PR TITLE
Allow Nested Preprocessor Directives

### DIFF
--- a/src/parsers/preprocessor/grammar.lalrpop
+++ b/src/parsers/preprocessor/grammar.lalrpop
@@ -44,14 +44,18 @@ extern {
 
 // Grammar Rules
 
-pub SliceFile: std::iter::Flatten<std::vec::IntoIter<Option<SourceBlock<'input>>>> = {
+pub SliceFile: std::iter::Flatten<std::vec::IntoIter<Vec<SourceBlock<'input>>>> = {
     Main* => <>.into_iter().flatten(),
 }
 
-Main: Option<SourceBlock<'input>> = {
-    source_block => Some(<>),
-    DefineDirective => None,
-    UndefineDirective => None,
+BlockContent: Vec<SourceBlock<'input>> = {
+    Main* => <>.into_iter().flatten().collect()
+}
+
+Main: Vec<SourceBlock<'input>> = {
+    source_block => vec![<>],
+    DefineDirective => Vec::new(),
+    UndefineDirective => Vec::new(),
     ConditionalStatement => <>,
 }
 
@@ -79,8 +83,8 @@ EndifDirective: () = {
     endif_keyword directive_end => (),
 }
 
-ConditionalStatement: Option<SourceBlock<'input>> = {
-    <if_block: (IfDirective source_block?)> <elif_blocks: (ElifDirective source_block?)*> <else_block: (ElseDirective <source_block?>)?> EndifDirective => {
+ConditionalStatement: Vec<SourceBlock<'input>> = {
+    <if_block: (IfDirective BlockContent)> <elif_blocks: (ElifDirective BlockContent)*> <else_block: (ElseDirective <BlockContent>)?> EndifDirective => {
         evaluate_if_statement(if_block, elif_blocks, else_block)
     }
 }

--- a/src/parsers/preprocessor/grammar.rs
+++ b/src/parsers/preprocessor/grammar.rs
@@ -24,20 +24,20 @@ lalrpop_mod!(
 /// Since multiple (or zero) elif blocks can be present, they are passed as a [Vec] (in order).
 /// Since there can only be 0 or 1 else block, it is passed as an [Option].
 fn evaluate_if_statement<'a>(
-    if_block: (bool, Option<SourceBlock<'a>>),
-    elif_blocks: Vec<(bool, Option<SourceBlock<'a>>)>,
-    else_block: Option<Option<SourceBlock<'a>>>,
-) -> Option<SourceBlock<'a>> {
-    // If the if-statement was true, return its block.
+    if_block: (bool, Vec<SourceBlock<'a>>),
+    elif_blocks: Vec<(bool, Vec<SourceBlock<'a>>)>,
+    else_block: Option<Vec<SourceBlock<'a>>>,
+) -> Vec<SourceBlock<'a>> {
+    // If the if-statement was true, return its block's content.
     if if_block.0 {
         return if_block.1;
     }
-    // Check the elif statements in order. If one is true, return its block.
+    // Check the elif statements in order. If one is true, return its block's content.
     for elif_block in elif_blocks {
         if elif_block.0 {
             return elif_block.1;
         }
     }
-    // Otherwise return the optionally present else block.
-    else_block.flatten()
+    // Otherwise, we return the content of the else block if it was present, if not, we return an empty vector.
+    else_block.unwrap_or_default()
 }

--- a/tests/preprocessor_tests.rs
+++ b/tests/preprocessor_tests.rs
@@ -295,6 +295,28 @@ fn preprocessor_conditionals_can_contain_empty_source_blocks(slice: &str) {
 }
 
 #[test]
+fn preprocessor_nested_conditional_blocks() {
+    let slice = "
+        #if !Foo
+            module NotFooModule {}
+            #if !Bar
+                module NotBarModule {}
+            #endif
+        #else
+            module ElseModule {}
+        #endif
+    ";
+
+    // Act
+    let ast = parse_for_ast(slice);
+
+    // Assert
+    assert!(ast.find_element::<Module>("NotFooModule").is_ok());
+    assert!(ast.find_element::<Module>("NotBarModule").is_ok());
+    assert!(ast.find_element::<Module>("ElseModule").is_err());
+}
+
+#[test]
 fn preprocessor_ignores_comments() {
     // Arrange
     // If Bar is defined, then the comment was not ignored


### PR DESCRIPTION
This PR implements #409 by adding support for empty and nested preprocessor directive blocks:
```
# ifdef Foo
    # ifdef Bar      // Currently on main, nesting these is a syntax error.
    # endif
#endif
```