### PR TITLE
Allow `AnyClass` to be Optional

### DIFF
--- a/src/ast/patchers/encoding_patcher.rs
+++ b/src/ast/patchers/encoding_patcher.rs
@@ -166,7 +166,7 @@ impl EncodingPatcher<'_> {
                 supported_encodings
             }
             Types::Primitive(primitive) => {
-                if matches!(primitive, Primitive::ServiceAddress) {
+                if matches!(primitive, Primitive::ServiceAddress | Primitive::AnyClass) {
                     allow_nullable_with_slice_1 = true;
                 }
                 primitive.supported_encodings()


### PR DESCRIPTION
This tiny PR allows `AnyClass` to be marked optional in files marked with `encoding = 1`.
Usually we disallow optionals for Slice1 except for classes, interfaces, and tags.

The fact that `AnyClass` isn't allowed to be optional is a bug, and this PR fixes it.