### PR TITLE
Delete 'new_warning' helper function from the tests.

### DIFF
--- a/tests/attribute_tests.rs
+++ b/tests/attribute_tests.rs
@@ -8,7 +8,7 @@ mod attributes {
 
         use crate::assert_errors;
         use crate::helpers::parsing_helpers::{parse_for_ast, parse_for_diagnostics};
-        use slice::diagnostics::{Error, ErrorKind, WarningKind};
+        use slice::diagnostics::{Error, ErrorKind, Warning, WarningKind};
         use slice::grammar::*;
         use test_case::test_case;
 
@@ -192,7 +192,7 @@ mod attributes {
             let diagnostics = parse_for_diagnostics(slice);
 
             // Assert
-            let expected = &crate::helpers::new_warning(WarningKind::UseOfDeprecatedEntity {
+            let expected = &Warning::new(WarningKind::UseOfDeprecatedEntity {
                 identifier: "Bar".to_owned(),
                 deprecation_reason: "".to_owned(),
             });
@@ -219,7 +219,7 @@ mod attributes {
             let diagnostics = parse_for_diagnostics(slice);
 
             // Assert
-            let expected = &crate::helpers::new_warning(WarningKind::UseOfDeprecatedEntity {
+            let expected = &Warning::new(WarningKind::UseOfDeprecatedEntity {
                 identifier: "Bar".to_owned(),
                 deprecation_reason: "".to_owned(),
             });
@@ -244,7 +244,7 @@ mod attributes {
             let diagnostics = parse_for_diagnostics(slice);
 
             // Assert
-            let expected = &crate::helpers::new_warning(WarningKind::UseOfDeprecatedEntity {
+            let expected = &Warning::new(WarningKind::UseOfDeprecatedEntity {
                 identifier: "A".to_owned(),
                 deprecation_reason: ": Message here".to_owned(),
             });
@@ -267,7 +267,7 @@ mod attributes {
             let diagnostics = parse_for_diagnostics(slice);
 
             // Assert
-            let expected = &crate::helpers::new_warning(WarningKind::UseOfDeprecatedEntity {
+            let expected = &Warning::new(WarningKind::UseOfDeprecatedEntity {
                 identifier: "A".to_owned(),
                 deprecation_reason: "".to_owned(),
             });
@@ -518,7 +518,7 @@ mod attributes {
             let diagnostics = parse_for_diagnostics(slice);
 
             // Assert
-            let expected = &crate::helpers::new_warning(WarningKind::ExtraParameterInDocComment {
+            let expected = &Warning::new(WarningKind::ExtraParameterInDocComment {
                 identifier: "x".to_owned(),
             });
 

--- a/tests/comment_tests.rs
+++ b/tests/comment_tests.rs
@@ -6,7 +6,7 @@ mod comments {
 
     use crate::assert_errors;
     use crate::helpers::parsing_helpers::{parse_for_ast, parse_for_diagnostics};
-    use slice::diagnostics::WarningKind;
+    use slice::diagnostics::{Warning, WarningKind};
     use slice::grammar::*;
     use test_case::test_case;
 
@@ -301,10 +301,10 @@ mod comments {
 
         // Assert
         let expected = [
-            crate::helpers::new_warning(WarningKind::CouldNotResolveLink {
+            Warning::new(WarningKind::CouldNotResolveLink {
                 identifier: "FakeException".to_owned(),
             }),
-            crate::helpers::new_warning(WarningKind::OperationDoesNotThrow {
+            Warning::new(WarningKind::OperationDoesNotThrow {
                 identifier: "testOp".to_owned(),
             }),
         ];
@@ -424,7 +424,7 @@ mod comments {
         let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
-        let expected = crate::helpers::new_warning(WarningKind::CouldNotResolveLink {
+        let expected = Warning::new(WarningKind::CouldNotResolveLink {
             identifier: "OtherStruct".to_owned(),
         });
         assert_errors!(diagnostics, [&expected]);
@@ -444,7 +444,7 @@ mod comments {
         let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
-        let expected = crate::helpers::new_warning(WarningKind::LinkToInvalidElement {
+        let expected = Warning::new(WarningKind::LinkToInvalidElement {
             kind: "primitive".to_owned(),
         });
         assert_errors!(diagnostics, [&expected]);
@@ -464,7 +464,7 @@ mod comments {
         let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
-        let expected = crate::helpers::new_warning(WarningKind::DocCommentSyntax {
+        let expected = Warning::new(WarningKind::DocCommentSyntax {
             message: "doc comment tag 'linked' is invalid".to_owned(),
         });
         assert_errors!(diagnostics, [&expected]);
@@ -514,10 +514,10 @@ mod comments {
 
         // Assert
         let expected = [
-            crate::helpers::new_warning(WarningKind::OperationDoesNotThrow {
+            Warning::new(WarningKind::OperationDoesNotThrow {
                 identifier: "testOp".to_owned(),
             }),
-            crate::helpers::new_warning(WarningKind::OperationDoesNotThrow {
+            Warning::new(WarningKind::OperationDoesNotThrow {
                 identifier: "testOpTwo".to_owned(),
             }),
         ];

--- a/tests/helpers/mod.rs
+++ b/tests/helpers/mod.rs
@@ -1,17 +1,4 @@
 // Copyright (c) ZeroC, Inc.
 
-use slice::diagnostics::{Warning, WarningKind};
-
 pub mod macros;
 pub mod parsing_helpers;
-
-// This helper method is used for generating test spans for warnings. The 'assert_errors!' macro currently does not
-// verify if the spans of emitted diagnostics are correct. However, 'Warning' requires a span to be constructed.
-pub fn new_warning(kind: WarningKind) -> Warning {
-    let span = slice::slice_file::Span {
-        start: slice::slice_file::Location { row: 0, col: 0 },
-        end: slice::slice_file::Location { row: 0, col: 0 },
-        file: "string".to_string(),
-    };
-    Warning::new(kind).set_span(&span)
-}


### PR DESCRIPTION
This PR deletes the `new_warning` function from the test helpers.

Before #401, the constructor for `Warning` used to require 2 parameters: a `WarningKind` and ` Span`.
This helper function was used to construct a dummy `Span` to satisfy the constructor.

But, since #401 was merged, `Warning` no longer requires a `Span` up-front, and so this helper function is useless.
We can just create the `Warning` like normal (symmetric to `Error`).

I think the fact that we no longer need this dummy span and helper function is a testament to how #401 improved the API.