### PR TITLE
Fixed Enumerator Syntax Regression

### DIFF
--- a/src/parsers/slice/grammar.lalrpop
+++ b/src/parsers/slice/grammar.lalrpop
@@ -211,17 +211,15 @@ Enum: OwnedPtr<Enum> = {
     }
 }
 
-EnumeratorValue: EnumeratorValue = {
+EnumeratorValue: Integer = {
     <l: @L> <value: SignedInteger> <r: @R> => {
         let span = Span::new(l, r, parser.file_name);
-        let int = Integer { value, span };
-        construct_enumerator_value(parser, Some(int))
+        Integer { value, span }
     },
-    => construct_enumerator_value(parser, None),
 }
 
 Enumerator: OwnedPtr<Enumerator> = {
-    <p: Prelude> <l: @L> <i: Identifier> <v: ("="? <EnumeratorValue>)> <r: @R> => {
+    <p: Prelude> <l: @L> <i: Identifier> <v: ("=" <EnumeratorValue>)?> <r: @R> => {
         construct_enumerator(parser, p, i, v, Span::new(l, r, parser.file_name))
     }
 }


### PR DESCRIPTION
This fixes #465. Writing an enumerator value without an `=` sign, or having a dangling `=` are both now syntax errors.
Without commas, the parser struggles to handle the currently broken syntax for enumerators.

The old rule lets you optionally include an `=` and an explicit enumerator value independently of each other.
Now both are required, or both are disallowed. You can't have one without the other.