### PR TITLE
Optionalized Punctutation

### DIFF
--- a/src/ast/patchers/encoding_patcher.rs
+++ b/src/ast/patchers/encoding_patcher.rs
@@ -227,9 +227,8 @@ impl EncodingPatcher<'_> {
                     span: None,
                 },
                 Note {
-                    message:
-                        "to use a different encoding, specify it at the top of the slice file\nex: 'encoding = 1;'"
-                            .to_owned(),
+                    message: "to use a different encoding, specify it at the top of the slice file\nex: 'encoding = 1'"
+                        .to_owned(),
                     span: None,
                 },
             ]

--- a/src/parsers/slice/grammar.lalrpop
+++ b/src/parsers/slice/grammar.lalrpop
@@ -91,6 +91,9 @@ extern {
         "?" => TokenKind::QuestionMark,
         "->" => TokenKind::Arrow,
         "-" => TokenKind::Minus,
+
+        // Whitespace
+        newline => TokenKind::Newline,
     }
 }
 
@@ -102,7 +105,7 @@ pub SliceFile: (Option<FileEncoding>, Vec<Attribute>, Vec<OwnedPtr<Module>>) = {
 }
 
 SliceFilePrelude: (Option<FileEncoding>, Vec<Attribute>) = {
-    => (None, Vec::new()),
+    newline* => (None, Vec::new()),
     <sfp: SliceFilePrelude> <fe: FileEncoding> => handle_file_encoding(parser, sfp, fe),
     <mut sfp: SliceFilePrelude> <fa: FileAttribute> => {
         sfp.1.push(fa);
@@ -111,19 +114,19 @@ SliceFilePrelude: (Option<FileEncoding>, Vec<Attribute>) = {
 }
 
 FileEncoding: FileEncoding = {
-    <l: @L> encoding_keyword "=" <i: Integer> <r: @R> ";" => {
+    <l: @L> encoding_keyword "=" <i: Integer> <r: @R> StatementEnd newline* => {
         construct_file_encoding(parser, i, Span::new(l, r, parser.file_name))
     }
 }
 
 FileScopedModule: OwnedPtr<Module> = {
-    <p: Prelude> <l: @L> module_keyword <i: ModuleIdentifier> <r: @R> ";" <ds: Definition*> => {
+    <p: Prelude> <l: @L> module_keyword <i: ModuleIdentifier> <r: @R> StatementEnd newline* <ds: Definition*> => {
         construct_module(parser, p, i, ds, true, Span::new(l, r, parser.file_name))
     }
 }
 
 Module: OwnedPtr<Module> = {
-    <p: Prelude> <l: @L> module_keyword <i: ModuleIdentifier> <r: @R> "{" <ds: Definition*> "}" => {
+    <p: Prelude> <l: @L> module_keyword <i: ModuleIdentifier> <r: @R> "{" newline* <ds: Definition*> "}" newline* => {
         construct_module(parser, p, i, ds, false, Span::new(l, r, parser.file_name))
     }
 }
@@ -140,43 +143,43 @@ Definition: Node = {
 }
 
 Struct: OwnedPtr<Struct> = {
-    <p: Prelude> <l: @L> <ck: compact_keyword?> struct_keyword <i: ContainerIdentifier> <r: @R> "{" <dms: List<DataMember>> "}" ContainerEnd => {
+    <p: Prelude> <l: @L> <ck: compact_keyword?> struct_keyword <i: ContainerIdentifier> <r: @R> "{" newline* <dms: List<DataMember>> "}" ContainerEnd newline* => {
         construct_struct(parser, p, ck.is_some(), i, dms, Span::new(l, r, parser.file_name))
     }
 }
 
 Exception: OwnedPtr<Exception> = {
-    <p: Prelude> <l: @L> exception_keyword <i: ContainerIdentifier> <r: @R> <tr: (":" <TypeRef>)?> "{" <dms: List<DataMember>> "}" ContainerEnd => {
+    <p: Prelude> <l: @L> exception_keyword <i: ContainerIdentifier> <r: @R> <tr: (":" <TypeRef>)?> "{" newline* <dms: List<DataMember>> "}" ContainerEnd newline* => {
         construct_exception(parser, p, i, tr, dms, Span::new(l, r, parser.file_name))
     }
 }
 
 Class: OwnedPtr<Class> = {
-    <p: Prelude> <l: @L> class_keyword <i: ContainerIdentifier> <ci: CompactId?> <r: @R> <tr: (":" <TypeRef>)?> "{" <dms: List<DataMember>> "}" ContainerEnd => {
+    <p: Prelude> <l: @L> class_keyword <i: ContainerIdentifier> <ci: CompactId?> <r: @R> <tr: (":" <TypeRef>)?> "{" newline* <dms: List<DataMember>> "}" ContainerEnd newline* => {
         construct_class(parser, p, i, ci, tr, dms, Span::new(l, r, parser.file_name))
     }
 }
 
 DataMember: OwnedPtr<DataMember> = {
-    <p: Prelude> <l: @L> <i: Identifier> ":" <t: Tag?> <tr: TypeRef> <r: @R> => {
+    <p: Prelude> <l: @L> <i: Identifier> ":" newline* <t: Tag?> <tr: TypeRef> <r: @R> => {
         construct_data_member(parser, p, i, t, tr, Span::new(l, r, parser.file_name))
     }
 }
 
 Interface: OwnedPtr<Interface> = {
-    <p: Prelude> <l: @L> interface_keyword <i: ContainerIdentifier> <r: @R> <trs: (":" <NonEmptyList<TypeRef>>)?> "{" <os: Operation*> "}" ContainerEnd => {
+    <p: Prelude> <l: @L> interface_keyword <i: ContainerIdentifier> <r: @R> <trs: (":" <NonEmptyList<TypeRef>>)?> "{" newline* <os: Operation*> "}" ContainerEnd newline* => {
         construct_interface(parser, p, i, trs, os, Span::new(l, r, parser.file_name))
     }
 }
 
 Operation: OwnedPtr<Operation> = {
-    <p: Prelude> <l: @L> <ik: idempotent_keyword?> <i: ContainerIdentifier> "(" <ps: List<Parameter>> ")" <rt: ("->" <ReturnType>)?> <es: ExceptionSpecification?> <r: @R> ";" ContainerEnd => {
+    <p: Prelude> <l: @L> <ik: idempotent_keyword?> <i: ContainerIdentifier> "(" <ps: List<Parameter>> ")" <rt: ("->" <ReturnType>)?> <es: ExceptionSpecification?> <r: @R> StatementEnd ContainerEnd newline* => {
         construct_operation(parser, p, ik.is_some(), i, ps, rt, es, Span::new(l, r, parser.file_name))
     }
 }
 
 Parameter: OwnedPtr<Parameter> = {
-    <p: Prelude> <l: @L> <i: Identifier> ":" <pm: ParameterModifier> <tr: TypeRef> <r: @R> => {
+    <p: Prelude> <l: @L> <i: Identifier> ":" newline* <pm: ParameterModifier> <tr: TypeRef> <r: @R> => {
         construct_parameter(parser, p, i, pm, tr, Span::new(l, r, parser.file_name))
     }
 }
@@ -206,7 +209,7 @@ ParameterModifier: (bool, Option<u32>) = {
 }
 
 Enum: OwnedPtr<Enum> = {
-    <p: Prelude> <l: @L> <uk: unchecked_keyword?> enum_keyword <i: ContainerIdentifier> <r: @R> <tr: (":" <TypeRef>)?> "{" <es: List<Enumerator>> "}" ContainerEnd => {
+    <p: Prelude> <l: @L> <uk: unchecked_keyword?> enum_keyword <i: ContainerIdentifier> <r: @R> <tr: (":" <TypeRef>)?> "{" newline* <es: List<Enumerator>> "}" ContainerEnd newline* => {
         construct_enum(parser, p, uk.is_some(), i, tr, es, Span::new(l, r, parser.file_name))
     }
 }
@@ -227,13 +230,13 @@ Enumerator: OwnedPtr<Enumerator> = {
 }
 
 CustomType: OwnedPtr<CustomType> = {
-    <p: Prelude> <l: @L> custom_keyword <i: Identifier> <r: @R> ";" => {
+    <p: Prelude> <l: @L> custom_keyword <i: Identifier> <r: @R> StatementEnd newline* => {
         construct_custom_type(parser, p, i, Span::new(l, r, parser.file_name))
     }
 }
 
 TypeAlias: OwnedPtr<TypeAlias> = {
-    <p: Prelude> <l: @L> type_alias_keyword <i: Identifier> <r: @R> "=" <tr: TypeRef> ";" => {
+    <p: Prelude> <l: @L> type_alias_keyword <i: Identifier> <r: @R> "=" <tr: TypeRef> StatementEnd newline* => {
         construct_type_alias(parser, p, i, tr, Span::new(l, r, parser.file_name))
     }
 }
@@ -285,9 +288,9 @@ TypeRefDefinition: TypeRefDefinition = {
     GloballyScopedIdentifier => construct_unpatched_type_ref_definition(<>),
 }
 
-FileAttribute = "[[" <Attribute> "]]";
+FileAttribute = "[[" <Attribute> "]]" newline*;
 
-LocalAttribute = "[" <Attribute> "]";
+LocalAttribute = "[" <Attribute> "]" newline*;
 
 Attribute: Attribute = {
     <l: @L> <rsi: RelativelyScopedIdentifier> <aas: ("(" <List<AttributeArgument>> ")")?> <r: @R> => {
@@ -332,7 +335,7 @@ SignedInteger: i128 = {
 }
 
 Tag: u32 = {
-    tag_keyword "(" <l: @L> <i: SignedInteger> <r: @R> ")" => {
+    tag_keyword "(" <l: @L> <i: SignedInteger> <r: @R> ")" newline* => {
         parse_tag_value(parser, i, Span::new(l, r, parser.file_name))
     }
 }
@@ -345,7 +348,7 @@ CompactId: u32 = {
 
 Prelude: (Vec<(&'input str, Span)>, Vec<Attribute>) = {
     => (Vec::new(), Vec::new()),
-    <mut prelude: Prelude> <l: @L> <comment: doc_comment> <r: @R> => {
+    <mut prelude: Prelude> <l: @L> <comment: doc_comment> <r: @R> newline* => {
         prelude.0.push((comment, Span::new(l, r, parser.file_name)));
         prelude
     },
@@ -363,8 +366,8 @@ List<T>: Vec<T> = {
 }
 
 NonEmptyList<T>: Vec<T> = {
-    <element: T> <mut vector: ("," <T>)*> ","? => {
-        vector.insert(0, element);
+    <mut vector: (<T> ListSeparator newline*)*> <element: T> (ListSeparator newline*)? => {
+        vector.push(element);
         vector
     }
 }
@@ -388,3 +391,7 @@ ContainerIdentifier: Identifier = {
 ContainerEnd: () = {
     => parser.current_scope.pop_scope(),
 }
+
+StatementEnd = { ";", newline }
+
+ListSeparator = { ",", newline }

--- a/src/parsers/slice/mod.rs
+++ b/src/parsers/slice/mod.rs
@@ -121,6 +121,11 @@ fn clean_message(expected: &[String]) -> String {
             "\"?\"" => tokens::TokenKind::QuestionMark.to_string(),
             "\"->\"" => tokens::TokenKind::Arrow.to_string(),
             "\"-\"" => tokens::TokenKind::Minus.to_string(),
+
+            // Whitespace
+            "newline" => tokens::TokenKind::Newline.to_string(),
+
+            // TODO actually match these things.
             _ => s.to_owned(),
         })
         .map(|s| format!("'{s}'"))

--- a/src/parsers/slice/tokens.rs
+++ b/src/parsers/slice/tokens.rs
@@ -96,6 +96,9 @@ pub enum TokenKind<'input> {
     QuestionMark, // "?"
     Arrow,        // "->"
     Minus,        // "-"
+
+    // Whitespace
+    Newline, // "\n"
 }
 
 impl std::fmt::Display for TokenKind<'_> {
@@ -171,6 +174,9 @@ impl std::fmt::Display for TokenKind<'_> {
             TokenKind::QuestionMark => "?",
             TokenKind::Arrow => "->",
             TokenKind::Minus => "-",
+
+            // Whitespace
+            TokenKind::Newline => "<newline>",
         })
     }
 }

--- a/tests/attribute_tests.rs
+++ b/tests/attribute_tests.rs
@@ -18,11 +18,11 @@ mod attributes {
             // Arrange
             let slice = format!(
                 "
-                    module Test;
+                    module Test
 
                     interface I {{
                         [format({format})]
-                        op(s: string) -> string;
+                        op(s: string) -> string
                     }}
                 "
             );
@@ -39,10 +39,10 @@ mod attributes {
         fn not_specifying_format_uses_compact_as_default() {
             // Arrange
             let slice = "
-                    module Test;
+                    module Test
 
                     interface I {
-                        op(s: string) -> string;
+                        op(s: string) -> string
                     }
             ";
 
@@ -61,11 +61,11 @@ mod attributes {
             let args = arg.unwrap_or("");
             let slice = format!(
                 "
-                    module Test;
+                    module Test
 
                     interface I {{
                         [format{args}]
-                        op(s: string) -> string;
+                        op(s: string) -> string
                     }}
                 "
             );
@@ -84,11 +84,11 @@ mod attributes {
         fn format_with_invalid_argument_fails() {
             // Arrange
             let slice = "
-                module Test;
+                module Test
 
                 interface I {
                     [format(Foo)]
-                    op(s: string) -> string;
+                    op(s: string) -> string
                 }
             ";
 
@@ -112,11 +112,11 @@ mod attributes {
         fn deprecated() {
             // Arrange
             let slice = "
-                module Test;
+                module Test
 
                 interface I {
                     [deprecated]
-                    op(s: string) -> string;
+                    op(s: string) -> string
                 }
             ";
 
@@ -132,10 +132,10 @@ mod attributes {
         fn cannot_deprecate_parameters() {
             // Arrange
             let slice = "
-                module Test;
+                module Test
 
                 interface I {
-                    op([deprecated] s: string) -> string;
+                    op([deprecated] s: string) -> string
                 }
             ";
 
@@ -153,11 +153,11 @@ mod attributes {
         fn deprecated_can_contain_message() {
             // Arrange
             let slice = "
-                module Test;
+                module Test
 
                 interface I {
                     [deprecated(\"Deprecation message here\")]
-                    op(s: string) -> string;
+                    op(s: string) -> string
                 }
             ";
 
@@ -176,15 +176,15 @@ mod attributes {
         fn deprecated_type_alias() {
             // Arrange
             let slice = "
-                module Test;
+                module Test
 
                 struct Foo {}
 
                 [deprecated]
-                typealias Bar = Foo;
+                typealias Bar = Foo
 
                 interface I {
-                    op(s: Bar) -> string;
+                    op(s: Bar) -> string
                 }
             ";
 
@@ -210,7 +210,7 @@ mod attributes {
 
             module Test {
                 struct Baz {
-                    b: Foo::Bar,
+                    b: Foo::Bar
                 }
             }
             ";
@@ -230,13 +230,13 @@ mod attributes {
         fn cannot_use_deprecated_type() {
             // Arrange
             let slice = "
-                    module Test;
+                    module Test
 
                     [deprecated(\"Message here\")]
                     struct A {}
 
                     struct B {
-                        a: A,
+                        a: A
                     }
                 ";
 
@@ -255,7 +255,7 @@ mod attributes {
         fn cannot_inherit_from_deprecated_entity() {
             // Arrange
             let slice = "
-                    module Test;
+                    module Test
 
                     [deprecated]
                     interface A {}
@@ -278,11 +278,11 @@ mod attributes {
         fn compress() {
             // Arrange
             let slice = "
-                module Test;
+                module Test
 
                 interface I {
                     [compress(Args, Return)]
-                    op(s: string) -> string;
+                    op(s: string) -> string
                 }
             ";
 
@@ -300,11 +300,11 @@ mod attributes {
         fn compress_with_invalid_arguments_fails() {
             // Arrange
             let slice = "
-                module Test;
+                module Test
 
                 interface I {
                     [compress(Foo)]
-                    op(s: string) -> string;
+                    op(s: string) -> string
                 }
             ";
 
@@ -327,7 +327,7 @@ mod attributes {
         fn cannot_compress_structs() {
             // Arrange
             let slice = "
-                module Test;
+                module Test
 
                 [compress()]
                 struct S {
@@ -347,11 +347,11 @@ mod attributes {
         fn compress_with_no_arguments() {
             // Arrange
             let slice = "
-                module Test;
+                module Test
 
                 interface I {
                     [compress()]
-                    op(s: string) -> string;
+                    op(s: string) -> string
                 }
             ";
 
@@ -367,13 +367,13 @@ mod attributes {
 
         #[test_case(
             "
-            module Test;
+            module Test
 
             interface I {
                 // The below doc comment will generate a warning
                 /// A test operation. Similar to {@linked OtherOp}{}.
                 [allow]
-                op(s: string) -> string;
+                op(s: string) -> string
             }
             "; "simple"
         )]
@@ -430,11 +430,11 @@ mod attributes {
         fn allow_with_invalid_code() {
             // Arrange
             let slice = "
-            module Test;
+            module Test
 
             interface I {
                 [allow(W315, w001)]
-                op(s: string) -> string;
+                op(s: string) -> string
             }
             ";
 
@@ -455,27 +455,27 @@ mod attributes {
 
         #[test_case(
             "
-            module Test;
+            module Test
 
             interface I {
                 // The below doc comment will generate a warning
                 /// A test operation. Similar to {@linked OtherOp}{}.
                 /// @param b: A test parameter.
                 [allow(W002, W003)]
-                op(s: string) -> string;
+                op(s: string) -> string
             }
             "; "entity"
         )]
         #[test_case(
             "
             [[allow(W002, W003)]]
-            module Test;
+            module Test
 
             interface I {
                 // The below doc comment will generate a warning
                 /// A test operation. Similar to {@linked OtherOp}{}.
                 /// @param b: A test parameter.
-                op(s: string) -> string;
+                op(s: string) -> string
             }
             "; "file level"
         )]
@@ -489,26 +489,26 @@ mod attributes {
 
         #[test_case(
             "
-            module Test;
+            module Test
 
             interface I {
                 /// @param x: a parameter that should be used in ops
                 /// @returns: a result
                 [allow(W004, W005)]
-                op(s: string);
+                op(s: string)
             }
             "; "entity"
         )]
         #[test_case(
             "
             [[allow(W004, W005)]]
-            module Test;
+            module Test
 
             interface I {
                 /// @param x: a parameter that should be used in ops
                 /// @returns: a result
                 [allow(W004, W005)]
-                op(s: string);
+                op(s: string)
             }
             "; "file level"
         )]
@@ -530,11 +530,12 @@ mod attributes {
         fn non_repeatable_attributes_error() {
             // Act
             let slice = "
-                module Test;
+                module Test
+
                 interface Foo {
                     [compress(Args)]
                     [compress(Return)]
-                    op();
+                    op()
                 }
             ";
 
@@ -560,11 +561,11 @@ mod attributes {
         fn foo_attribute() {
             // Arrange
             let slice = "
-                module Test;
+                module Test
 
                 interface I {
                     [foo::bar]
-                    op(s: string) -> string;
+                    op(s: string) -> string
                 }
             ";
 
@@ -593,11 +594,11 @@ mod attributes {
         fn foo_attribute_with_arguments() {
             // Arrange
             let slice = "
-                module Test;
+                module Test
 
                 interface I {
                     [foo::bar(a, b, c)]
-                    op(s: string) -> string;
+                    op(s: string) -> string
                 }
             ";
 
@@ -630,10 +631,11 @@ mod attributes {
             // Arrange
             let slice = format!(
                 "
-                    module Test;
+                    module Test
+
                     interface I {{
                         [foo::bar({input})]
-                        op(s: string) -> string;
+                        op(s: string) -> string
                     }}
                 "
             );
@@ -661,10 +663,11 @@ mod attributes {
             // Arrange
             let slice = format!(
                 "
-                    module Test;
+                    module Test
+
                     interface I {{
                         [foo::bar({input})]
-                        op(s: string) -> string;
+                        op(s: string) -> string
                     }}
                 "
             );
@@ -681,7 +684,7 @@ mod attributes {
             // Arrange
             let slice = "
                 [custom]
-                module Test;
+                module Test
             ";
 
             // Act
@@ -707,7 +710,7 @@ mod attributes {
                         module C {
                             [attribute("I")]
                             interface I {
-                                op(s: string) -> string;
+                                op(s: string) -> string
                             }
                         }
                     }

--- a/tests/classes/container.rs
+++ b/tests/classes/container.rs
@@ -11,12 +11,12 @@ use test_case::test_case;
 fn can_contain_data_members() {
     // Arrange
     let slice = "
-        encoding = 1;
-        module Test;
+        encoding = 1
+        module Test
         class C {
-            i: int32,
-            s: string,
-            b: bool,
+            i: int32
+            s: string
+            b: bool
         }
     ";
 
@@ -47,25 +47,25 @@ fn can_contain_data_members() {
 #[test_case(
     "
         class C {
-            c: C,
+            c: C
         }
     "; "single class circular reference"
 )]
 #[test_case(
     "
         class C1 {
-            c2: C2,
+            c2: C2
         }
         class C2 {
-            c1: C1,
+            c1: C1
         }
     "; "multi class circular reference"
 )]
 fn cycles_are_allowed(cycle_string: &str) {
     let slice = format!(
         "
-            encoding = 1;
-            module Test;
+            encoding = 1
+            module Test
             {cycle_string}
         "
     );
@@ -80,8 +80,8 @@ fn cycles_are_allowed(cycle_string: &str) {
 fn can_be_empty() {
     // Arrange
     let slice = "
-        encoding = 1;
-        module Test;
+        encoding = 1
+        module Test
         class C {}
     ";
 
@@ -97,11 +97,11 @@ fn can_be_empty() {
 fn cannot_redefine_data_members() {
     // Arrange
     let slice = "
-        encoding = 1;
-        module Test;
+        encoding = 1
+        module Test
         class C {
-            a: int32,
-            a: string,
+            a: int32
+            a: string
         }
     ";
 

--- a/tests/classes/encoding.rs
+++ b/tests/classes/encoding.rs
@@ -11,7 +11,7 @@ mod slice2 {
     fn unsupported_error() {
         // Arrange
         let slice = "
-            module Test;
+            module Test
             class C {}
         ";
 
@@ -27,7 +27,7 @@ mod slice2 {
         let expected = Error::new(error_kind)
             .add_note("file is using the Slice2 encoding by default", None)
             .add_note(
-                "to use a different encoding, specify it at the top of the slice file\nex: 'encoding = 1;'",
+                "to use a different encoding, specify it at the top of the slice file\nex: 'encoding = 1'",
                 None,
             )
             .add_note("classes are only supported by the Slice1 encoding", None);

--- a/tests/classes/inheritance.rs
+++ b/tests/classes/inheritance.rs
@@ -10,8 +10,8 @@ use slice::slice_file::Span;
 fn supports_single_inheritance() {
     // Arrange
     let slice = "
-        encoding = 1;
-        module Test;
+        encoding = 1
+        module Test
         class I {}
 
         class J : I {}
@@ -36,8 +36,8 @@ fn supports_single_inheritance() {
 fn does_not_support_multiple_inheritance() {
     // Arrange
     let slice = "
-        encoding = 1;
-        module Test;
+        encoding = 1
+        module Test
 
         class I {}
 
@@ -62,8 +62,8 @@ fn does_not_support_multiple_inheritance() {
 fn data_member_shadowing_is_disallowed() {
     // Arrange
     let slice = "
-        encoding = 1;
-        module Test;
+        encoding = 1
+        module Test
 
         class I {
             i: int32
@@ -88,8 +88,8 @@ fn data_member_shadowing_is_disallowed() {
 fn inherits_correct_data_members() {
     // Arrange
     let slice = "
-        encoding = 1;
-        module Test;
+        encoding = 1
+        module Test
 
         class A {
             a: int32

--- a/tests/classes/mod.rs
+++ b/tests/classes/mod.rs
@@ -12,8 +12,8 @@ use slice::grammar::*;
 fn support_compact_type_id() {
     // Arrange
     let slice = "
-        encoding = 1;
-        module Test;
+        encoding = 1
+        module Test
 
         class C(42) {}
     ";

--- a/tests/classes/tags.rs
+++ b/tests/classes/tags.rs
@@ -7,13 +7,13 @@ use slice::grammar::*;
 fn can_contain_tags() {
     // Arrange
     let slice = "
-        encoding = 1;
-        module Test;
+        encoding = 1
+        module Test
 
         class C {
-            i: int32,
-            s: string,
-            b: tag(10) bool?,
+            i: int32
+            s: string
+            b: tag(10) bool?
         }
     ";
 

--- a/tests/comment_tests.rs
+++ b/tests/comment_tests.rs
@@ -14,7 +14,7 @@ mod comments {
     fn single_line_doc_comment() {
         // Arrange
         let slice = "
-            module tests;
+            module tests
 
             /// This is a single line doc comment.
             interface MyInterface {}
@@ -46,7 +46,7 @@ mod comments {
     fn multi_line_doc_comment() {
         // Arrange
         let slice = "
-            module tests;
+            module tests
 
             /// This is a
             /// multiline doc comment.
@@ -83,11 +83,11 @@ mod comments {
     fn doc_comments_params() {
         // Arrange
         let slice = "
-            module tests;
+            module tests
 
             interface TestInterface {
                 /// @param testParam: My test param
-                testOp(testParam: string);
+                testOp(testParam: string)
             }
         ";
 
@@ -119,11 +119,11 @@ mod comments {
     fn doc_comments_returns() {
         // Arrange
         let slice = "
-            module tests;
+            module tests
 
             interface TestInterface {
                 /// @returns bool
-                testOp(testParam: string) -> bool;
+                testOp(testParam: string) -> bool
             }
         ";
 
@@ -172,12 +172,12 @@ mod comments {
     fn operation_with_doc_comment_for_param_but_no_param_fails() {
         // Arrange
         let slice = "
-            module tests;
+            module tests
 
             interface TestInterface {
                 /// @param testParam1: A string param
                 /// @param testParam2: A bool param
-                testOp(testParam1: string);
+                testOp(testParam1: string)
             }
         ";
 
@@ -194,7 +194,7 @@ mod comments {
     fn operation_with_correct_doc_comments() {
         // Arrange
         let slice = "
-            module tests;
+            module tests
 
             exception MyException {}
 
@@ -202,7 +202,7 @@ mod comments {
                 /// @param testParam1: A string param
                 /// @returns bool
                 /// @throws MyException: Some message about why testOp throws
-                testOp(testParam1: string) -> bool throws MyException;
+                testOp(testParam1: string) -> bool throws MyException
             }
         ";
 
@@ -217,11 +217,11 @@ mod comments {
     fn doc_comment_throws() {
         // Arrange
         let slice = "
-            module tests;
+            module tests
 
             interface TestInterface {
                 /// @throws: Message about my thrown thing.
-                testOp(testParam: string) -> bool;
+                testOp(testParam: string) -> bool
             }
         ";
 
@@ -250,13 +250,13 @@ mod comments {
     fn doc_comments_throws_specific_type() {
         // Arrange
         let slice = "
-            module tests;
+            module tests
 
             exception MyThrownThing {}
 
             interface TestInterface {
                 /// @throws MyThrownThing: Message about my thrown thing.
-                testOp(testParam: string) -> bool;
+                testOp(testParam: string) -> bool
             }
         ";
 
@@ -288,11 +288,11 @@ mod comments {
     fn doc_comments_throws_invalid_type() {
         // Arrange
         let slice = "
-            module tests;
+            module tests
 
             interface TestInterface {
                 /// @throws FakeException: causes a warning.
-                testOp(testParam: string) -> bool;
+                testOp(testParam: string) -> bool
             }
         ";
 
@@ -315,7 +315,7 @@ mod comments {
     fn doc_comments_non_operations_cannot_throw() {
         // Arrange
         let slice = "
-            module tests;
+            module tests
 
             /// @throws: Message about my thrown thing.
             struct S {}
@@ -334,11 +334,11 @@ mod comments {
     fn doc_comments_see() {
         // Arrange
         let slice = "
-            module tests;
+            module tests
 
             interface TestInterface {
                 /// @see MySee
-                testOp(testParam: string) -> bool;
+                testOp(testParam: string) -> bool
             }
         ";
 
@@ -366,7 +366,7 @@ mod comments {
         // Arrange
         let slice = format!(
             "
-                module tests;
+                module tests
 
                 {comment}
                 interface MyInterface {{}}
@@ -387,7 +387,7 @@ mod comments {
     fn doc_comment_linked_identifiers() {
         // Arrange
         let slice = "
-            module tests;
+            module tests
 
             /// This comment is for {@link TestStruct}
             struct TestStruct {}
@@ -414,7 +414,7 @@ mod comments {
     fn missing_doc_comment_linked_identifiers() {
         // Arrange
         let slice = "
-            module tests;
+            module tests
 
             /// A test struct. Similar to {@link OtherStruct}.
             struct TestStruct {}
@@ -434,7 +434,7 @@ mod comments {
     fn doc_comment_links_to_invalid_element() {
         // Arrange
         let slice = "
-            module tests;
+            module tests
 
             /// A test struct, should probably use {@link bool}.
             struct TestStruct {}
@@ -454,7 +454,7 @@ mod comments {
     fn unknown_doc_comment_tag() {
         // Arrange
         let slice = "
-            module tests;
+            module tests
 
             /// A test struct. Similar to {@linked OtherStruct}{}.
             struct TestStruct {}
@@ -474,14 +474,14 @@ mod comments {
     fn doc_comment_throws_tag_invalid_type() {
         // Arrange
         let slice = "
-            module tests;
+            module tests
 
             exception E {}
             struct S {}
 
             interface I {
                 /// @throws S: Message about my thrown thing.
-                testOp(testParam: string) -> bool throws E ;
+                testOp(testParam: string) -> bool throws E
             }
         ";
 
@@ -496,16 +496,16 @@ mod comments {
     fn doc_comment_throw_tag_operation_throws_nothing() {
         // Arrange
         let slice = "
-            module tests;
+            module tests
 
             exception E {}
 
             interface I {
                 /// @throws E: Message about my thrown thing.
-                testOp(testParam: string) -> bool;
+                testOp(testParam: string) -> bool
 
                 /// @throws : Second message about my thrown thing.
-                testOpTwo(testParam: string) -> bool;
+                testOpTwo(testParam: string) -> bool
             }
         ";
 

--- a/tests/custom_tests.rs
+++ b/tests/custom_tests.rs
@@ -14,9 +14,9 @@ mod custom {
         // Arrange
         let slice = format!(
             "
-                encoding = {encoding};
-                module Test;
-                custom ACustomType;
+                encoding = {encoding}
+                module Test
+                custom ACustomType
             "
         );
 

--- a/tests/diagnostic_output_tests.rs
+++ b/tests/diagnostic_output_tests.rs
@@ -10,11 +10,11 @@ mod output {
     #[test]
     fn output_to_json() {
         let slice = r#"
-        module  Foo;
+        module  Foo
 
         interface I {
             /// @param x: this is an x
-            op();
+            op()
         }
 
         enum E {}
@@ -47,16 +47,16 @@ mod output {
     #[test]
     fn output_to_console() {
         let slice = r#"
-        module  Foo;
+        module  Foo
 
         interface I {
             /// @param x: this is an x
-            op1();
+            op1()
 
             op2(x:
     tag(1)
                     int32, y: tag(2) bool?,
-            );
+            )
         }
 
         enum E {}
@@ -108,11 +108,11 @@ error [E010]: invalid enum 'E': enums must contain at least one enumerator
     #[test]
     fn allow_warnings_flag_with_no_args() {
         let slice = r#"
-        module  Foo;
+        module  Foo
 
         interface I {
             /// @param x: this is an x
-            op();
+            op()
         }
 
         "#;
@@ -139,12 +139,12 @@ error [E010]: invalid enum 'E': enums must contain at least one enumerator
     #[test]
     fn allow_warnings_flag_with_args() {
         let slice = r#"
-        module  Foo;
+        module  Foo
 
         interface I {
             /// @param x: this is an x
             /// @returns: this is a return
-            op();
+            op()
         }
 
         "#;
@@ -176,8 +176,8 @@ error [E010]: invalid enum 'E': enums must contain at least one enumerator
     fn notes_with_same_span_as_diagnostic_suppressed() {
         // Arrange
         let slice = "\
-            encoding = 2;
-            module Foo;
+            encoding = 2
+            module Foo
         ";
 
         // Disable ANSI codes.
@@ -210,9 +210,9 @@ error [E010]: invalid enum 'E': enums must contain at least one enumerator
         let expected = "\
 error: foo
  --> string-0:1:1\n  |
-1 | encoding = 2;
-  | -------------
-2 |             module Foo;
+1 | encoding = 2
+  | ------------
+2 |             module Foo
   | -
   |
     = note: bar

--- a/tests/dictionaries/key_type.rs
+++ b/tests/dictionaries/key_type.rs
@@ -9,8 +9,8 @@ use test_case::test_case;
 fn optionals_are_disallowed() {
     // Arrange
     let slice = "
-        module Test;
-        typealias Dict = dictionary<int32?, int8>;
+        module Test
+        typealias Dict = dictionary<int32?, int8>
     ";
 
     // Act
@@ -39,8 +39,8 @@ fn allowed_primitive_types(key_type: &str) {
     // Arrange
     let slice = format!(
         "
-            module Test;
-            typealias Dict = dictionary<{key_type}, int8>;
+            module Test
+            typealias Dict = dictionary<{key_type}, int8>
         "
     );
 
@@ -59,8 +59,8 @@ fn disallowed_primitive_types(key_type: &str) {
     // Arrange
     let slice = format!(
         "
-            module Test;
-            typealias Dict = dictionary<{key_type}, int8>;
+            module Test
+            typealias Dict = dictionary<{key_type}, int8>
         "
     );
 
@@ -80,8 +80,8 @@ fn collections_are_disallowed(key_type: &str, key_kind: &str) {
     // Arrange
     let slice = format!(
         "
-            module Test;
-            typealias Dict = dictionary<{key_type}, int8>;
+            module Test
+            typealias Dict = dictionary<{key_type}, int8>
         "
     );
 
@@ -96,14 +96,14 @@ fn collections_are_disallowed(key_type: &str, key_kind: &str) {
 }
 
 #[test_case("MyEnum", "unchecked enum MyEnum {}" ; "enums")]
-#[test_case("MyCustom", "custom MyCustom;" ; "custom_types")]
+#[test_case("MyCustom", "custom MyCustom" ; "custom_types")]
 fn allowed_constructed_types(key_type: &str, key_type_def: &str) {
     // Arrange
     let slice = format!(
         "
-            module Test;
+            module Test
             {key_type_def}
-            typealias Dict = dictionary<{key_type}, int8>;
+            typealias Dict = dictionary<{key_type}, int8>
         "
     );
 
@@ -122,10 +122,10 @@ fn disallowed_constructed_types(key_type: &str, key_type_def: &str, key_kind: &s
     let file_encoding = if key_kind == "class" { "1" } else { "2" };
     let slice = format!(
         "
-            encoding = {file_encoding};
-            module Test;
+            encoding = {file_encoding}
+            module Test
             {key_type_def}
-            typealias Dict = dictionary<{key_type}, int8>;
+            typealias Dict = dictionary<{key_type}, int8>
         "
     );
 
@@ -144,11 +144,11 @@ fn disallowed_constructed_types(key_type: &str, key_type_def: &str, key_kind: &s
 fn non_compact_structs_are_disallowed() {
     // Arrange
     let slice = "
-        module Test;
+        module Test
 
         struct MyStruct {}
 
-        typealias Dict = dictionary<MyStruct, int8>;
+        typealias Dict = dictionary<MyStruct, int8>
     ";
 
     // Act
@@ -163,18 +163,18 @@ fn non_compact_structs_are_disallowed() {
 fn compact_struct_with_allowed_members_is_allowed() {
     // Arrange
     let slice = "
-        module Test;
+        module Test
 
         compact struct Inner {
-            i32: int32,
+            i32: int32
         }
 
         compact struct Outer {
-            b: bool,
-            i: Inner,
+            b: bool
+            i: Inner
         }
 
-        typealias Dict = dictionary<Outer, int8>;
+        typealias Dict = dictionary<Outer, int8>
     ";
 
     // Act
@@ -188,20 +188,20 @@ fn compact_struct_with_allowed_members_is_allowed() {
 fn compact_struct_with_disallowed_members_is_disallowed() {
     // Arrange
     let slice = "
-        module Test;
+        module Test
 
         compact struct Inner {
-            i32: int32,
-            f32: float32, // disallowed key type
+            i32: int32
+            f32: float32 // disallowed key type
         }
 
         compact struct Outer {
-            seq: sequence<int8>, // disallowed key type
-            i: Inner, // disallowed key type
-            s: string,
+            seq: sequence<int8> // disallowed key type
+            i: Inner // disallowed key type
+            s: string
         }
 
-        typealias Dict = dictionary<Outer, int8>;
+        typealias Dict = dictionary<Outer, int8>
     ";
 
     // Act

--- a/tests/dictionaries/value_type.rs
+++ b/tests/dictionaries/value_type.rs
@@ -8,10 +8,10 @@ use slice::diagnostics::{Error, ErrorKind};
 fn invalid_dictionary_values_produce_error() {
     // Arrange
     let slice = "
-    module Foo;
+    module Foo
     struct Bar {
-         i: dictionary<int32, dictionary<float32, bool>>,
-         j: dictionary<int32, sequence<dictionary<float64, bool>>>,
+         i: dictionary<int32, dictionary<float32, bool>>
+         j: dictionary<int32, sequence<dictionary<float64, bool>>>
     }
     ";
 

--- a/tests/encoding_tests.rs
+++ b/tests/encoding_tests.rs
@@ -16,7 +16,7 @@ mod encodings {
         // Arrange
         let slice = format!(
             "
-                encoding = {value};
+                encoding = {value}
             "
         );
 
@@ -31,7 +31,7 @@ mod encodings {
     fn invalid_encodings_fail() {
         // Arrange
         let slice = "
-            encoding = 3;
+            encoding = 3
         ";
 
         // Act
@@ -46,15 +46,15 @@ mod encodings {
     fn encoding_must_be_first() {
         // Arrange
         let slice = "
-            module Test;
-            encoding = 2;
+            module Test
+            encoding = 2
         ";
 
         // Act
         let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
-        let expected = Error::new(ErrorKind::Syntax{message: "expected one of '[', 'class', 'compact', 'custom', 'doc comment', 'enum', 'exception', 'interface', 'module', 'struct', 'typealias', or 'unchecked', but found 'encoding'".to_owned()});
+        let expected = Error::new(ErrorKind::Syntax{message: "expected one of '[', 'class', 'compact', 'custom', 'doc comment', 'enum', 'exception', 'interface', 'module', '<newline>', 'struct', 'typealias', or 'unchecked', but found 'encoding'".to_owned()});
         assert_errors!(diagnostics, [&expected]);
     }
 }

--- a/tests/enums/container.rs
+++ b/tests/enums/container.rs
@@ -10,11 +10,11 @@ use test_case::test_case;
 fn enumerator_default_values() {
     // Arrange
     let slice = "
-        module Test;
+        module Test
         enum E {
-            A,
-            B,
-            C,
+            A
+            B
+            C
         }
     ";
 
@@ -32,11 +32,11 @@ fn enumerator_default_values() {
 fn subsequent_unsigned_value_is_incremented_previous_value() {
     // Arrange
     let slice = "
-        module Test;
+        module Test
         enum E {
-            A = 2,
-            B,
-            C,
+            A = 2
+            B
+            C
         }
         ";
 
@@ -53,11 +53,11 @@ fn subsequent_unsigned_value_is_incremented_previous_value() {
 fn implicit_enumerator_values_overflow_cleanly() {
     // Arrange
     let slice = "
-        module Test;
+        module Test
         enum E {
-            A,
-            B = 170141183460469231731687303715884105727, // i128::MAX
-            C,
+            A
+            B = 170141183460469231731687303715884105727 // i128::MAX
+            C
         }
     ";
 
@@ -86,10 +86,10 @@ fn implicit_enumerator_values_overflow_cleanly() {
 fn enumerator_values_can_be_out_of_order() {
     // Arrange
     let slice = "
-            module Test;
+            module Test
             enum E {
-                A = 2,
-                B = 1,
+                A = 2
+                B = 1
             }
         ";
 
@@ -106,9 +106,9 @@ fn validate_backing_type_out_of_bounds() {
     let out_of_bounds_value = i16::MAX as i128 + 1;
     let slice = format!(
         "
-            module Test;
+            module Test
             enum E: int16 {{
-                A = {out_of_bounds_value},
+                A = {out_of_bounds_value}
             }}
         "
     );
@@ -133,10 +133,10 @@ fn validate_backing_type_bounds() {
     let max = i16::MAX;
     let slice = format!(
         "
-            module Test;
+            module Test
             enum E: int16 {{
-                A = {min},
-                B = {max},
+                A = {min}
+                B = {max}
             }}
         "
     );
@@ -155,7 +155,7 @@ fn invalid_underlying_type(underlying_type: &str) {
     // Arrange
     let slice = format!(
         "
-            module Test;
+            module Test
             enum E: {underlying_type} {{
                 A
             }}
@@ -173,15 +173,15 @@ fn invalid_underlying_type(underlying_type: &str) {
     assert_errors!(diagnostics, [&expected]);
 }
 
-#[test_case("10", "expected one of '[', '}', 'doc comment', or 'identifier', but found '10'"; "numeric identifier")]
+#[test_case("10", "expected one of ')', '::', '[', '[[', '{', '}', 'AnyClass', 'bool', 'class', 'compact', 'custom', 'dictionary', 'doc comment', 'encoding', 'enum', 'exception', 'float32', 'float64', 'idempotent', 'identifier', 'int16', 'int32', 'int64', 'int8', 'interface', 'module', '<newline>', 'sequence', 'ServiceAddress', 'stream', 'string', 'string literal', 'struct', 'tag', 'typealias', 'uint16', 'uint32', 'uint64', 'uint8', 'unchecked', 'varint32', 'varint62', 'varuint32', or 'varuint62', but found '10'"; "numeric identifier")]
 #[test_case("😊", "unknown symbol '😊'"; "unicode identifier")]
 fn enumerator_invalid_identifiers(identifier: &str, expected: &str) {
     // Arrange
     let slice = format!(
         "
-            module Test;
+            module Test
             enum E {{
-                {identifier},
+                {identifier}
             }}
         "
     );
@@ -197,7 +197,7 @@ fn enumerator_invalid_identifiers(identifier: &str, expected: &str) {
 fn optional_underlying_types_fail() {
     // Arrange
     let slice = "
-        module Test;
+        module Test
 
         enum E: int32? {
             A = 1
@@ -218,11 +218,11 @@ fn optional_underlying_types_fail() {
 fn enumerators_must_be_unique() {
     // Arrange
     let slice = "
-        module Test;
+        module Test
 
         enum E {
-            A = 1,
-            B = 1,
+            A = 1
+            B = 1
         }
     ";
 
@@ -241,10 +241,10 @@ fn can_be_unchecked(enum_definition: &str, expected_result: bool) {
     // Arrange
     let slice = format!(
         "
-            module Test;
+            module Test
             {enum_definition} E {{
-                A,
-                B,
+                A
+                B
             }}
         "
     );
@@ -260,7 +260,7 @@ fn can_be_unchecked(enum_definition: &str, expected_result: bool) {
 #[test]
 fn checked_enums_can_not_be_empty() {
     let slice = "
-        module Test;
+        module Test
 
         enum E {}
     ";
@@ -277,7 +277,7 @@ fn checked_enums_can_not_be_empty() {
 fn unchecked_enums_can_be_empty() {
     // Arrange
     let slice = "
-        module Test;
+        module Test
 
         unchecked enum E {}
     ";
@@ -294,13 +294,13 @@ fn unchecked_enums_can_be_empty() {
 fn enumerators_support_different_base_literals() {
     // Arrange
     let slice = "
-        module Test;
+        module Test
 
         enum E {
-            B = 0b1001111,
-            D = 128,
-            H = 0xA4FD,
-            N = -0xbc81,
+            B = 0b1001111
+            D = 128
+            H = 0xA4FD
+            N = -0xbc81
         }
     ";
 
@@ -318,11 +318,11 @@ fn enumerators_support_different_base_literals() {
 fn duplicate_enumerators_are_disallowed_across_different_bases() {
     // Arrange
     let slice = "
-        module Test;
+        module Test
 
         enum E {
-            B = 0b1001111,
-            D = 79,
+            B = 0b1001111
+            D = 79
         }
     ";
 
@@ -344,13 +344,13 @@ mod slice1 {
     fn enumerators_cannot_contain_negative_values() {
         // Arrange
         let slice = "
-            encoding = 1;
-            module Test;
+            encoding = 1
+            module Test
 
             enum E {
-                A = -1,
-                B = -2,
-                C = -3,
+                A = -1
+                B = -2
+                C = -3
             }
         ";
 
@@ -388,11 +388,11 @@ mod slice1 {
         let value = i32::MAX as i128 + 1;
         let slice = format!(
             "
-                encoding = 1;
-                module Test;
+                encoding = 1
+                module Test
 
                 enum E {{
-                    A = {value},
+                    A = {value}
                 }}
             "
         );
@@ -421,12 +421,12 @@ mod slice2 {
     fn enumerators_can_contain_negative_values() {
         // Arrange
         let slice = "
-            module Test;
+            module Test
 
             enum E: int32 {
-                A = -1,
-                B = -2,
-                C = -3,
+                A = -1
+                B = -2
+                C = -3
             }
         ";
 
@@ -441,12 +441,12 @@ mod slice2 {
     fn enumerators_can_contain_values() {
         // Arrange
         let slice = "
-            module Test;
+            module Test
 
             enum E: int16 {
-                A = 1,
-                B = 2,
-                C = 3,
+                A = 1
+                B = 2
+                C = 3
             }
         ";
 
@@ -473,12 +473,12 @@ mod slice2 {
     #[test]
     fn explicit_enumerator_value_kinds() {
         let slice = "
-        module Test;
+        module Test
 
         enum A {
-            u = 1,
-            v = 2,
-            w = 3,
+            u = 1
+            v = 2
+            w = 3
         }
         ";
 

--- a/tests/enums/encoding.rs
+++ b/tests/enums/encoding.rs
@@ -14,8 +14,8 @@ mod slice1 {
     fn underlying_types_fail() {
         // Arrange
         let slice = "
-            encoding = 1;
-            module Test;
+            encoding = 1
+            module Test
 
             unchecked enum E : int32 {}
         ";
@@ -58,7 +58,7 @@ mod slice2 {
         // Arrange
         let slice = &format!(
             "
-                module Test;
+                module Test
 
                 unchecked enum E : {valid_type} {{}}
             "

--- a/tests/enums/tags.rs
+++ b/tests/enums/tags.rs
@@ -9,11 +9,11 @@ use crate::helpers::parsing_helpers::parse_for_diagnostics;
 fn cannot_contain_tags() {
     // Arrange
     let slice = "
-        module Test;
+        module Test
 
         enum E: int32 {
-            A = 1,
-            B: tag(10) = 2,
+            A = 1
+            B: tag(10) = 2
         }
     ";
 

--- a/tests/exceptions/container.rs
+++ b/tests/exceptions/container.rs
@@ -10,12 +10,12 @@ use slice::grammar::*;
 fn can_contain_data_members() {
     // Arrange
     let slice = "
-        module Test;
+        module Test
 
         exception E {
-            i: int32,
-            s: string,
-            b: bool,
+            i: int32
+            s: string
+            b: bool
         }
     ";
 
@@ -48,7 +48,7 @@ fn can_contain_data_members() {
 fn can_be_empty() {
     // Arrange
     let slice = "
-        module Test;
+        module Test
 
         exception E {}
     ";
@@ -65,12 +65,12 @@ fn can_be_empty() {
 fn cannot_redefine_data_members() {
     // Arrange
     let slice = "
-        encoding = 1;
-        module Test;
+        encoding = 1
+        module Test
 
         exception E {
-            a: int32,
-            a: string,
+            a: int32
+            a: string
         }
     ";
 

--- a/tests/exceptions/encoding.rs
+++ b/tests/exceptions/encoding.rs
@@ -14,13 +14,13 @@ mod slice1 {
     fn can_not_be_data_members() {
         // Arrange
         let slice = "
-            encoding = 1;
-            module Test;
+            encoding = 1
+            module Test
 
             exception E {}
 
             compact struct S {
-                e: E,
+                e: E
             }
         ";
 
@@ -49,7 +49,7 @@ mod slice2 {
     fn inheritance_fails() {
         // Arrange
         let slice = "
-            module Test;
+            module Test
 
             exception A {}
 
@@ -67,7 +67,7 @@ mod slice2 {
         })
         .add_note("file is using the Slice2 encoding by default", None)
         .add_note(
-            "to use a different encoding, specify it at the top of the slice file\nex: 'encoding = 1;'",
+            "to use a different encoding, specify it at the top of the slice file\nex: 'encoding = 1'",
             None,
         )
         .add_note("exception inheritance is only supported by the Slice1 encoding", None);
@@ -81,12 +81,12 @@ mod slice2 {
     fn can_be_data_members() {
         // Arrange
         let slice = "
-            module Test;
+            module Test
 
             exception E {}
 
             struct S {
-                e: E,
+                e: E
             }
         ";
 
@@ -102,19 +102,19 @@ mod slice2 {
     fn slice1_only_exceptions_cannot_be_thrown_from_slice2_operation() {
         // Arrange
         let slice1 = "
-            encoding = 1;
-            module Test;
+            encoding = 1
+            module Test
 
             exception E {
-                a: AnyClass,
+                a: AnyClass
             }
         ";
 
         let slice2 = "
-            module Test;
+            module Test
 
             interface I {
-                op() throws E;
+                op() throws E
             }
         ";
 
@@ -133,10 +133,10 @@ mod slice2 {
     fn cannot_throw_any_exception() {
         // Arrange
         let slice = "
-            module Test;
+            module Test
 
             interface I {
-                op() throws AnyException;
+                op() throws AnyException
             }
         ";
 

--- a/tests/exceptions/inheritance.rs
+++ b/tests/exceptions/inheritance.rs
@@ -10,8 +10,8 @@ use slice::slice_file::Span;
 fn supports_single_inheritance() {
     // Arrange
     let slice = "
-        encoding = 1;
-        module Test;
+        encoding = 1
+        module Test
 
         exception E1 {}
 
@@ -30,8 +30,8 @@ fn supports_single_inheritance() {
 fn does_not_support_multiple_inheritance() {
     // Arrange
     let slice = "
-        encoding = 1;
-        module Test;
+        encoding = 1
+        module Test
 
         exception E1 {}
 
@@ -56,8 +56,8 @@ fn does_not_support_multiple_inheritance() {
 fn must_inherit_from_exception() {
     // Arrange
     let slice = "
-        encoding = 1;
-        module Test;
+        encoding = 1
+        module Test
 
         class C {}
 
@@ -79,8 +79,8 @@ fn must_inherit_from_exception() {
 fn data_member_shadowing_is_disallowed() {
     // Arrange
     let slice = "
-        encoding = 1;
-        module Test;
+        encoding = 1
+        module Test
 
         exception I {
             i: int32
@@ -106,8 +106,8 @@ fn data_member_shadowing_is_disallowed() {
 fn inherits_correct_data_members() {
     // Arrange
     let slice = "
-        encoding = 1;
-        module Test;
+        encoding = 1
+        module Test
 
         exception A {
             a: int32

--- a/tests/exceptions/mod.rs
+++ b/tests/exceptions/mod.rs
@@ -11,12 +11,12 @@ use slice::grammar::{Exception, NamedSymbol, Operation, Throws};
 #[test]
 fn throws_specific_exception() {
     let slice = "
-        module Test;
+        module Test
 
         exception E {}
 
         interface I {
-            op() throws E;
+            op() throws E
         }
     ";
 
@@ -36,10 +36,10 @@ fn throws_specific_exception() {
 #[test]
 fn throws_nothing() {
     let slice = "
-        module Test;
+        module Test
 
         interface I {
-            op();
+            op()
         }
     ";
 
@@ -52,11 +52,11 @@ fn throws_nothing() {
 #[test]
 fn throws_any_exception() {
     let slice = "
-        encoding = 1;
-        module Test;
+        encoding = 1
+        module Test
 
         interface I {
-            op() throws AnyException;
+            op() throws AnyException
         }
     ";
 

--- a/tests/exceptions/tags.rs
+++ b/tests/exceptions/tags.rs
@@ -7,11 +7,11 @@ use slice::grammar::*;
 fn can_contain_tags() {
     // Arrange
     let slice = "
-        module Test;
+        module Test
         exception E {
-            i: int32,
-            s: string,
-            b: tag(10) bool?,
+            i: int32
+            s: string
+            b: tag(10) bool?
         }
     ";
 

--- a/tests/files/test.slice
+++ b/tests/files/test.slice
@@ -1,9 +1,9 @@
 // Copyright (c) ZeroC, Inc.
 
-module Test;
+module Test
 
 interface I {
-    myOp();
+    myOp()
 }
 
 struct A {

--- a/tests/identifier_tests.rs
+++ b/tests/identifier_tests.rs
@@ -9,7 +9,7 @@ use slice::grammar::{Enum, Exception, Interface, Struct};
 fn escaped_keywords() {
     // Arrange
     let slice = r#"
-        module \module;
+        module \module
         interface \interface {}
         exception \exception {}
         struct \struct {}
@@ -30,7 +30,7 @@ fn escaped_keywords() {
 fn escaped_identifiers() {
     // Arrange
     let slice = r#"
-        module \MyModule;
+        module \MyModule
         interface \MyInterface {}
         exception \MyException {}
         struct \MyStruct {}

--- a/tests/interfaces/encoding.rs
+++ b/tests/interfaces/encoding.rs
@@ -9,17 +9,17 @@ use slice::grammar::Encoding;
 fn operation_members_are_compatible_with_encoding() {
     // Arrange
     let slice1 = "
-        encoding = 1;
-        module Test;
+        encoding = 1
+        module Test
 
         class C {}
     ";
     let slice2 = "
-        encoding = 2;
-        module Test;
+        encoding = 2
+        module Test
 
         interface I {
-            op(c: C);
+            op(c: C)
         }
     ";
 
@@ -39,10 +39,10 @@ fn operation_members_are_compatible_with_encoding() {
 #[test]
 fn any_exception_cannot_be_used_without_slice1() {
     let slice = "
-        module Test;
+        module Test
 
         interface I {
-            op() throws AnyException;
+            op() throws AnyException
         }
     ";
 
@@ -61,12 +61,11 @@ mod slice1 {
     #[test]
     fn operations_can_throw_any_exception() {
         let slice = "
-            encoding = 1;
-
-            module Test;
+            encoding = 1
+            module Test
 
             interface I {
-                op() throws AnyException;
+                op() throws AnyException
             }
         ";
 

--- a/tests/interfaces/inheritance.rs
+++ b/tests/interfaces/inheritance.rs
@@ -9,7 +9,7 @@ use slice::grammar::*;
 fn supports_single_inheritance() {
     // Arrange
     let slice = "
-        module Test;
+        module Test
 
         interface I {}
 
@@ -36,7 +36,7 @@ fn supports_single_inheritance() {
 fn supports_multiple_inheritance() {
     // Arrange
     let slice = "
-        module Test;
+        module Test
 
         interface I {}
 
@@ -71,8 +71,8 @@ fn supports_multiple_inheritance() {
 fn must_inherit_from_interface() {
     // Arrange
     let slice = "
-        encoding = 1;
-        module Test;
+        encoding = 1
+        module Test
 
         class C {}
 
@@ -94,14 +94,14 @@ fn must_inherit_from_interface() {
 fn operation_shadowing_is_disallowed() {
     // Arrange
     let slice = "
-        module Test;
+        module Test
 
         interface I {
-            op();
+            op()
         }
 
         interface J : I {
-            op();
+            op()
         }
     ";
     let expected = Error::new(ErrorKind::Shadows {
@@ -120,20 +120,20 @@ fn operation_shadowing_is_disallowed() {
 fn inherits_correct_operations() {
     // Arrange
     let slice = "
-        module Test;
+        module Test
 
         interface A {
-            opA();
+            opA()
         }
 
         interface B : A {
-            opB();
+            opB()
         }
 
         interface C : A {}
 
         interface D : B, C {
-            opD();
+            opD()
         }
     ";
 

--- a/tests/interfaces/mod.rs
+++ b/tests/interfaces/mod.rs
@@ -13,7 +13,7 @@ use slice::grammar::*;
 fn can_have_no_operations() {
     // Arrange
     let slice = "
-        module Test;
+        module Test
 
         interface I {}
     ";
@@ -31,10 +31,10 @@ fn can_have_no_operations() {
 fn can_have_self_referencing_operations() {
     // Arrange
     let slice = "
-        module Test;
+        module Test
 
         interface I {
-            myOp() -> I;
+            myOp() -> I
         }
     ";
 
@@ -49,10 +49,10 @@ fn can_have_self_referencing_operations() {
 fn can_have_one_operation() {
     // Arrange
     let slice = "
-        module Test;
+        module Test
 
         interface I {
-            op1();
+            op1()
         }
     ";
 
@@ -68,12 +68,12 @@ fn can_have_one_operation() {
 fn can_have_multiple_operation() {
     // Arrange
     let slice = "
-        module Test;
+        module Test
 
         interface I {
-            op1();
-            op2();
-            op3();
+            op1()
+            op2()
+            op3()
         }
     ";
 
@@ -89,12 +89,12 @@ fn can_have_multiple_operation() {
 fn cannot_redefine_operations() {
     // Arrange
     let slice = "
-        encoding = 1;
-        module Test;
+        encoding = 1
+        module Test
 
         interface I {
-            op();
-            op();
+            op()
+            op()
         }
     ";
 

--- a/tests/interfaces/operations.rs
+++ b/tests/interfaces/operations.rs
@@ -10,10 +10,10 @@ use test_case::test_case;
 fn can_have_no_parameters() {
     // Arrange
     let slice = "
-        module Test;
+        module Test
 
         interface I {
-            op();
+            op()
         }
     ";
 
@@ -29,10 +29,10 @@ fn can_have_no_parameters() {
 fn can_have_no_return_type() {
     // Arrange
     let slice = "
-        module Test;
+        module Test
 
         interface I {
-            op(a: int32);
+            op(a: int32)
         }
     ";
 
@@ -48,10 +48,10 @@ fn can_have_no_return_type() {
 fn can_contain_tags() {
     // Arrange
     let slice = "
-        module Test;
+        module Test
 
         interface I {
-            op(a: tag(1) int32?);
+            op(a: tag(1) int32?)
         }
     ";
 
@@ -68,10 +68,10 @@ fn can_contain_tags() {
 fn parameter_and_return_can_have_the_same_tag() {
     // Arrange
     let slice = "
-        module Test;
+        module Test
 
         interface I {
-            op(a: tag(1) int32?) -> tag(1) string?;
+            op(a: tag(1) int32?) -> tag(1) string?
         }
     ";
 
@@ -90,10 +90,10 @@ fn parameter_and_return_can_have_the_same_tag() {
 fn can_have_parameters() {
     // Arrange
     let slice = "
-        module Test;
+        module Test
 
         interface I {
-            op(a: int32, b: string, c: varuint62);
+            op(a: int32, b: string, c: varuint62)
         }
     ";
 
@@ -126,10 +126,10 @@ fn can_have_parameters() {
 fn can_have_return_value() {
     // Arrange
     let slice = "
-        module Test;
+        module Test
 
         interface I {
-            op() -> string;
+            op() -> string
         }
     ";
 
@@ -152,10 +152,10 @@ fn can_have_return_value() {
 fn can_have_return_tuple() {
     // Arrange
     let slice = "
-        module Test;
+        module Test
 
         interface I {
-            op() -> (r1: string, r2: bool);
+            op() -> (r1: string, r2: bool)
         }
     ";
 
@@ -182,10 +182,10 @@ fn can_have_return_tuple() {
 #[test]
 fn operations_can_omit_throws_clause() {
     let slice = "
-        module Test;
+        module Test
 
         interface I {
-            op();
+            op()
         }
     ";
 
@@ -200,12 +200,12 @@ fn operations_can_omit_throws_clause() {
 #[test]
 fn operations_can_throw_specific_exceptions() {
     let slice = "
-        module Test;
+        module Test
 
         exception E {}
 
         interface I {
-            op() throws E;
+            op() throws E
         }
     ";
 
@@ -224,12 +224,12 @@ fn operations_can_throw_specific_exceptions() {
 fn operations_can_only_throw_exceptions() {
     // Arrange
     let slice = "
-        module Test;
+        module Test
 
         struct S {}
 
         interface I {
-            op() throws S;
+            op() throws S
         }
     ";
 
@@ -250,10 +250,10 @@ fn return_tuple_must_contain_two_or_more_elements(return_tuple: &str) {
     // Arrange
     let slice = format!(
         "
-            module Test;
+            module Test
 
             interface I {{
-                op() -> {return_tuple};
+                op() -> {return_tuple}
             }}
         "
     );
@@ -276,10 +276,10 @@ mod streams {
     fn can_have_streamed_parameter_and_return() {
         // Arrange
         let slice = "
-            module Test;
+            module Test
 
             interface I {
-                op(a: stream uint32) -> stream uint32;
+                op(a: stream uint32) -> stream uint32
             }
         ";
 
@@ -299,10 +299,10 @@ mod streams {
     fn operation_can_have_at_most_one_streamed_parameter() {
         // Arrange
         let slice = "
-            module Test;
+            module Test
 
             interface I {
-                op(s: stream varuint62, s2: stream string);
+                op(s: stream varuint62, s2: stream string)
             }
         ";
 
@@ -323,10 +323,10 @@ mod streams {
     fn stream_parameter_must_be_last() {
         // Arrange
         let slice = "
-            module Test;
+            module Test
 
             interface I {
-                op(s: stream varuint62, i: int32);
+                op(s: stream varuint62, i: int32)
             }
         ";
 

--- a/tests/mixed_encoding_tests.rs
+++ b/tests/mixed_encoding_tests.rs
@@ -11,34 +11,34 @@ use slice::grammar::Encoding;
 fn valid_mixed_encoding_works() {
     // Arrange
     let encoding1_slice = "
-        encoding = 1;
-        module Test;
+        encoding = 1
+        module Test
 
         compact struct ACompactStruct {
-            data: int32,
+            data: int32
         }
 
         enum AnEnum {
-            A,
-            B,
+            A
+            B
         }
 
         interface AnInterface {
-            op() -> AnEnum;
+            op() -> AnEnum
         }
 
         exception AnException {
-            message: string,
+            message: string
         }
     ";
     let encoding2_slice = "
-        encoding = 2;
-        module Test;
+        encoding = 2
+        module Test
         struct AStruct {
-            e: AnEnum,
-            i: AnInterface,
-            c: ACompactStruct,
-            ex: AnException,
+            e: AnEnum
+            i: AnInterface
+            c: ACompactStruct
+            ex: AnException
         }
     ";
 
@@ -53,21 +53,21 @@ fn valid_mixed_encoding_works() {
 fn invalid_mixed_encoding_fails() {
     // Arrange
     let encoding2_slice = "
-        encoding = 2;
-        module Test;
+        encoding = 2
+        module Test
 
-        custom ACustomType;
+        custom ACustomType
 
         compact struct ACompactStruct {
-            data: int32?,
+            data: int32?
         }
     ";
     let encoding1_slice = "
-        encoding = 1;
-        module Test;
+        encoding = 1
+        module Test
         compact struct AStruct {
-            c: ACustomType,
-            s: ACompactStruct,
+            c: ACustomType
+            s: ACompactStruct
         }
     ";
 

--- a/tests/module_tests.rs
+++ b/tests/module_tests.rs
@@ -11,7 +11,7 @@ mod module {
     use test_case::test_case;
 
     #[test_case("{}", false; "normal")]
-    #[test_case(";", true; "file_scoped")]
+    #[test_case("", true; "file_scoped")]
     fn can_be_defined(content: &str, expected: bool) {
         // Arrange
         let slice = format!("module Test {content}");
@@ -78,7 +78,7 @@ mod module {
     fn is_required() {
         // Arrange
         let slice = "
-            custom C;
+            custom C
         ";
 
         // Act
@@ -86,7 +86,7 @@ mod module {
 
         // Assert
         assert_errors!(diagnostics, [
-            "expected one of '[', '[[', 'doc comment', 'encoding', or 'module', but found 'custom'"
+            "expected one of '[', '[[', 'doc comment', 'encoding', 'module', or '<newline>', but found 'custom'"
         ]);
     }
 
@@ -94,7 +94,7 @@ mod module {
     fn file_level_modules_can_not_contain_sub_modules() {
         // Arrange
         let slice = "
-            module A;
+            module A
 
             module B {}
 
@@ -120,7 +120,7 @@ mod module {
     fn nested_file_level_modules_can_not_contain_sub_modules() {
         // Arrange
         let slice = "
-            module A::B::C::D;
+            module A::B::C::D
 
             module E {}
         ";

--- a/tests/parser_tests.rs
+++ b/tests/parser_tests.rs
@@ -49,7 +49,7 @@ fn string_literals_cannot_contain_newlines() {
     let slice = r#"
         [foo("attribute
         test")]
-        module Test;
+        module Test
     "#;
 
     // Act

--- a/tests/preprocessor_tests.rs
+++ b/tests/preprocessor_tests.rs
@@ -12,11 +12,11 @@ use test_case::test_case;
 fn command_line_defined_symbols() {
     // Arrange
     let slice = "
-        module Test;
+        module Test
 
         # if Foo
         interface I {
-            op();
+            op()
         }
         # endif
         ";
@@ -38,7 +38,7 @@ fn undefined_preprocessor_directive_blocks_are_consumed() {
     // Arrange
     let slice = "
             #if Foo
-            module Test;
+            module Test
             interface I {}
             #endif
         ";
@@ -69,7 +69,7 @@ fn preprocessor_define_symbol() {
         #define Foo
         #if Foo
         // Foo is defined
-        module Test;
+        module Test
         interface I {}
         #endif
     ";
@@ -89,7 +89,7 @@ fn preprocessor_undefine_symbol() {
         #undef Foo
         #if Foo
         // Foo is defined
-        module Test;
+        module Test
         interface I {}
         #endif
     ";
@@ -110,7 +110,7 @@ fn preprocessor_define_symbol_multiples_times() {
         #define Foo
         #if Foo
         // Foo is defined
-        module Test;
+        module Test
         interface I {}
         #endif
     ";
@@ -133,25 +133,25 @@ fn preprocessor_conditional_compilation(define: &str, interface: &str) {
         #if Foo
 
         // Foo is defined
-        module Test;
+        module Test
         interface I {{}}
 
         # elif Bar
 
         // Bar is defined
-        module Test;
+        module Test
         interface J {{}}
 
         # elif Baz
 
         // Baz is defined
-        module Test;
+        module Test
         interface K {{}}
 
         # else
 
         // Fizz is defined
-        module Test;
+        module Test
         interface X {{}}
 
         #endif
@@ -173,7 +173,7 @@ fn preprocessor_not_expressions() {
     let slice = "
         #define Foo
         #if !Foo
-        module Test;
+        module Test
         interface I {}
         #endif
     ";
@@ -192,7 +192,7 @@ fn preprocessor_and_expressions() {
         #define Foo
         #define Bar
         #if Foo && Bar
-        module Test;
+        module Test
         interface I {}
         #endif
     ";
@@ -210,7 +210,7 @@ fn preprocessor_or_expressions() {
     let slice = "
         #define Foo
         #if Foo || Bar
-        module Test;
+        module Test
         interface I {}
         #endif
     ";
@@ -228,7 +228,7 @@ fn preprocessor_grouped_expressions() {
     let slice = "
         #define Foo
         #if (Foo || Bar) && (Fizz || Buzz)
-        module Test;
+        module Test
         interface I {}
         #endif
     ";
@@ -247,7 +247,7 @@ fn preprocessor_nested_expressions() {
         #define Bar
         #define Baz
         #if (Foo && (Bar || Baz))
-        module Test;
+        module Test
         interface I {}
         #endif
     ";
@@ -322,7 +322,7 @@ fn preprocessor_ignores_comments() {
     let slice = "
         #define Foo // define Bar
         #if Bar // This is a comment
-        module Test;
+        module Test
         interface I {}
         #endif // This is another comment
         // Hello

--- a/tests/primitives/encoding.rs
+++ b/tests/primitives/encoding.rs
@@ -23,11 +23,11 @@ mod slice1 {
         // Test setup
         let slice = &format!(
             "
-                encoding = 1;
-                module Test;
+                encoding = 1
+                module Test
 
                 compact struct S {{
-                    v: {value},
+                    v: {value}
                 }}
             "
         );
@@ -60,11 +60,11 @@ mod slice1 {
         // Arrange
         let slice = &format!(
             "
-            encoding = 1;
-            module Test;
+            encoding = 1
+            module Test
 
             compact struct S {{
-                v: {value},
+                v: {value}
             }}
         "
         );
@@ -91,10 +91,10 @@ mod slice2 {
     fn unsupported_types_fail() {
         // Arrange
         let slice = "
-            module Test;
+            module Test
 
             compact struct S {
-                v: AnyClass,
+                v: AnyClass
             }
         ";
 
@@ -108,7 +108,7 @@ mod slice2 {
         })
         .add_note("file is using the Slice2 encoding by default", None)
         .add_note(
-            "to use a different encoding, specify it at the top of the slice file\nex: 'encoding = 1;'",
+            "to use a different encoding, specify it at the top of the slice file\nex: 'encoding = 1'",
             None,
         )
         .add_note("classes are only supported by the Slice1 encoding", None);
@@ -139,10 +139,10 @@ mod slice2 {
         // Arrange
         let slice = format!(
             "
-            module Test;
+            module Test
 
             compact struct S {{
-                v: {value},
+                v: {value}
             }}"
         );
 
@@ -174,10 +174,10 @@ mod slice2 {
         // Arrange
         let slice = format!(
             "
-                module Test;
+                module Test
 
                 struct MyStruct {{
-                    myVar: {value},
+                    myVar: {value}
                 }}
             "
         );

--- a/tests/primitives/mod.rs
+++ b/tests/primitives/mod.rs
@@ -22,16 +22,16 @@ use test_case::test_case;
 #[test_case("float32", Primitive::Float32, None; "float32")]
 #[test_case("float64", Primitive::Float64, None; "float64")]
 #[test_case("string", Primitive::String, None; "string")]
-#[test_case("AnyClass", Primitive::AnyClass, Some("encoding = 1;"); "AnyClass")]
+#[test_case("AnyClass", Primitive::AnyClass, Some("encoding = 1"); "AnyClass")]
 fn type_parses(slice_component: &str, expected: Primitive, encoding: Option<&str>) {
     // Arrange
     let encoding = encoding.unwrap_or("");
     let slice = format!(
         "
             {encoding}
-            module Test;
+            module Test
 
-            typealias P = {slice_component};
+            typealias P = {slice_component}
         "
     );
 

--- a/tests/scope_resolution_tests.rs
+++ b/tests/scope_resolution_tests.rs
@@ -13,7 +13,7 @@ mod scope_resolution {
     fn file_scoped_modules_can_not_contain_sub_modules() {
         // Arrange
         let slice = "
-            module T;
+            module T
             module S {}
         ";
 
@@ -33,19 +33,19 @@ mod scope_resolution {
         // Arrange
         let slice = "
             module A {
-                typealias S = int32;
+                typealias S = int32
 
                 module B {
                     struct S {
-                        v: string,
+                        v: string
                     }
                 }
 
                 struct C {
-                    s1: S,
-                    s2: A::S,
-                    s3: B::S,
-                    s4: A::B::S,
+                    s1: S
+                    s2: A::S
+                    s3: B::S
+                    s4: A::B::S
                 }
             }
         ";
@@ -70,16 +70,16 @@ mod scope_resolution {
         // Arrange
         let slice = "
             module A {
-                typealias S = int32;
+                typealias S = int32
 
                 module B {
-                    typealias S = string;
+                    typealias S = string
 
                     struct C {
-                        s1: S,
-                        s2: B::S,
-                        s3: A::B::S,
-                        s4: A::S,
+                        s1: S
+                        s2: B::S
+                        s3: A::B::S
+                        s4: A::S
                     }
                 }
             }
@@ -105,20 +105,20 @@ mod scope_resolution {
         // Arrange
         let slice = "
             module A {
-                typealias S = int32;
+                typealias S = int32
 
                 module B {
 
                     struct S {
-                        v: string,
+                        v: string
                     }
 
                     module B {
 
                         struct C {
-                            s1: S,
-                            s2: B::S,
-                            s3: A::S,
+                            s1: S
+                            s2: B::S
+                            s3: A::S
                         }
                     }
                 }
@@ -144,23 +144,23 @@ mod scope_resolution {
         let slice = "
             module A {
                 module B {
-                    typealias S = string;
+                    typealias S = string
 
                     module A {
                         module B {
-                            typealias S = int32;
+                            typealias S = int32
 
                             struct C {
-                                s1: A::B::S,
-                                s2: ::A::B::S,
+                                s1: A::B::S
+                                s2: ::A::B::S
                             }
                         }
                     }
                 }
 
                 struct C {
-                    s1: A::B::S,
-                    s2: ::A::B::S,
+                    s1: A::B::S
+                    s2: ::A::B::S
                 }
             }
         ";
@@ -196,7 +196,7 @@ mod scope_resolution {
                 interface B {}
 
                 struct S {
-                    b: B,
+                    b: B
                 }
             }
         ";
@@ -220,7 +220,7 @@ mod scope_resolution {
                 module B {
                     module C {
                         struct S {
-                            c: C,
+                            c: C
                         }
                     }
                 }
@@ -246,7 +246,7 @@ mod scope_resolution {
         let slice = "
             module A {
                 struct C {
-                    b: Nested::C,
+                    b: Nested::C
                 }
             }
         ";

--- a/tests/sequence_tests.rs
+++ b/tests/sequence_tests.rs
@@ -13,8 +13,8 @@ mod sequences {
     fn can_contain_primitive_types() {
         // Arrange
         let slice = "
-            module Test;
-            typealias Seq = sequence<int8>;
+            module Test
+            typealias Seq = sequence<int8>
         ";
 
         // Act
@@ -37,8 +37,8 @@ mod sequences {
     fn sequences_containing_dictionaries_get_validated() {
         // Arrange
         let slice = "
-            module Test;
-            typealias Seq = sequence<dictionary<int32, dictionary<float32, float32>>>;
+            module Test
+            typealias Seq = sequence<dictionary<int32, dictionary<float32, float32>>>
         ";
 
         // Act

--- a/tests/structs/container.rs
+++ b/tests/structs/container.rs
@@ -12,12 +12,12 @@ mod structs {
     fn can_contain_data_members() {
         // Arrange
         let slice = "
-            module Test;
+            module Test
 
             struct S {
-                i: int32,
-                s: string,
-                b: bool,
+                i: int32
+                s: string
+                b: bool
             }
         ";
 
@@ -50,7 +50,7 @@ mod structs {
     fn can_be_empty() {
         // Arrange
         let slice = "
-            module Test;
+            module Test
 
             struct S {}
         ";
@@ -67,11 +67,11 @@ mod structs {
     fn cannot_redefine_data_members() {
         // Arrange
         let slice = "
-            module Test;
+            module Test
 
             struct S {
-                a: int32,
-                a: string,
+                a: int32
+                a: string
             }
         ";
 
@@ -98,7 +98,7 @@ mod compact_structs {
     fn must_not_be_empty() {
         // Arrange
         let slice = "
-            module Test;
+            module Test
 
             compact struct S {}
         ";

--- a/tests/structs/encoding.rs
+++ b/tests/structs/encoding.rs
@@ -13,8 +13,8 @@ mod slice1 {
     fn unsupported_fail() {
         // Arrange
         let slice = "
-            encoding = 1;
-            module Test;
+            encoding = 1
+            module Test
 
             struct A {}
         ";
@@ -48,10 +48,10 @@ mod slice2 {
     fn slice1_types_fail() {
         // Arrange
         let slice = "
-            module Test;
+            module Test
 
             struct A {
-                c: AnyClass,
+                c: AnyClass
             }
         ";
 
@@ -65,7 +65,7 @@ mod slice2 {
         })
         .add_note("file is using the Slice2 encoding by default", None)
         .add_note(
-            "to use a different encoding, specify it at the top of the slice file\nex: 'encoding = 1;'",
+            "to use a different encoding, specify it at the top of the slice file\nex: 'encoding = 1'",
             None,
         );
 
@@ -78,11 +78,11 @@ mod slice2 {
     fn slice2_types_succeed() {
         // Arrange
         let slice = "
-            module Test;
+            module Test
 
             struct A {
-                i: int32,
-                s: string?,
+                i: int32
+                s: string?
             }
         ";
 

--- a/tests/structs/tags.rs
+++ b/tests/structs/tags.rs
@@ -9,12 +9,12 @@ mod structs {
     fn can_contain_tags() {
         // Arrange
         let slice = "
-            module Test;
+            module Test
 
             struct S {
-                i: int32,
-                s: string,
-                b: tag(10) bool?,
+                i: int32
+                s: string
+                b: tag(10) bool?
             }
         ";
 
@@ -37,12 +37,12 @@ mod compact_structs {
     fn cannot_contain_tags() {
         // Arrange
         let slice = "
-            module Test;
+            module Test
 
             compact struct S {
-                i: int32,
-                s: string,
-                b: tag(10) bool?,
+                i: int32
+                s: string
+                b: tag(10) bool?
             }
         ";
 

--- a/tests/tag_tests.rs
+++ b/tests/tag_tests.rs
@@ -14,12 +14,12 @@ mod tags {
     fn tagged_data_members_must_be_optional() {
         // Arrange
         let slice = "
-            encoding = 1;
-            module Test;
+            encoding = 1
+            module Test
             class C {
-                i: int32,
-                s: string,
-                b: tag(10) bool,
+                i: int32
+                s: string
+                b: tag(10) bool
             }
         ";
 
@@ -37,10 +37,10 @@ mod tags {
     fn tagged_parameters_must_be_optional() {
         // Arrange
         let slice = "
-            encoding = 1;
-            module Test;
+            encoding = 1
+            module Test
             interface I {
-                op(myParam: tag(10) int32);
+                op(myParam: tag(10) int32)
             }
         ";
 
@@ -58,10 +58,10 @@ mod tags {
     fn non_tagged_optional_types_fail() {
         // Arrange
         let slice = "
-            encoding = 1;
-            module Test;
+            encoding = 1
+            module Test
             interface I {
-                myOp(a: int32?);
+                myOp(a: int32?)
             }
         ";
 
@@ -81,10 +81,10 @@ mod tags {
     fn tagged_parameters_must_be_after_required_parameters() {
         // Arrange
         let slice = "
-            encoding = 1;
-            module Test;
+            encoding = 1
+            module Test
             interface I {
-                op(p1: int32, p2: tag(10) int32?, p3: int32, p4: int32, p5: tag(20) int32?);
+                op(p1: int32, p2: tag(10) int32?, p3: int32, p4: int32, p5: tag(20) int32?)
             }
         ";
 
@@ -107,13 +107,13 @@ mod tags {
     fn cannot_tag_a_class() {
         // Arrange
         let slice = "
-            encoding = 1;
-            module Test;
+            encoding = 1
+            module Test
 
             class C {}
 
             interface I {
-                op(c: tag(1) C?);
+                op(c: tag(1) C?)
             }
         ";
 
@@ -131,17 +131,17 @@ mod tags {
     fn cannot_tag_a_container_that_contains_a_class() {
         // Arrange
         let slice = "
-            encoding = 1;
-            module Test;
+            encoding = 1
+            module Test
 
             class C {}
 
             compact struct S {
-                c: C,
+                c: C
             }
 
             interface I {
-                op(s: tag(1) S?);
+                op(s: tag(1) S?)
             }
         ";
 
@@ -159,9 +159,9 @@ mod tags {
     fn valid_tag() {
         // Arrange
         let slice = "
-            module Test;
+            module Test
             struct S {
-                a: tag(1) int32?,
+                a: tag(1) int32?
             }
         ";
 
@@ -179,10 +179,10 @@ mod tags {
     fn cannot_have_duplicate_tags() {
         // Arrange
         let slice = "
-            module Test;
+            module Test
             struct S {
-                a: tag(1) int32?,
-                b: tag(1) int32?,
+                a: tag(1) int32?
+                b: tag(1) int32?
             }
         ";
 
@@ -204,9 +204,9 @@ mod tags {
         // Arrange
         let slice = format!(
             "
-            module Test;
+            module Test
             interface I {{
-                testOp(a: tag({value}) int32?);
+                testOp(a: tag({value}) int32?)
             }}
             "
         );
@@ -224,9 +224,9 @@ mod tags {
         // Arrange
         let slice = format!(
             "
-                module Test;
+                module Test
                 interface I {{
-                    testOp(a: tag({value}) int32?);
+                    testOp(a: tag({value}) int32?)
                 }}
             "
         );
@@ -243,9 +243,9 @@ mod tags {
     fn cannot_have_tag_with_value_smaller_than_minimum() {
         // Arrange
         let slice = "
-            module Test;
+            module Test
             interface I {
-                testOp(a: tag(-1) int32?);
+                testOp(a: tag(-1) int32?)
             }
         ";
 
@@ -261,9 +261,9 @@ mod tags {
     fn strings_invalid_as_tag_value() {
         // Arrange
         let slice = "
-            module Test;
+            module Test
             interface I {
-                testOp(a: tag(\"test string\") int32?);
+                testOp(a: tag(\"test string\") int32?)
             }
         ";
 

--- a/tests/typealias_tests.rs
+++ b/tests/typealias_tests.rs
@@ -14,19 +14,19 @@ mod typealias {
     #[test_case("class C {}", "C", 1; "classes")]
     #[test_case("interface I {}", "I", 2; "interfaces")]
     #[test_case("enum E { Foo }", "E", 2; "enums")]
-    #[test_case("custom C;", "C", 2; "custom types")]
+    #[test_case("custom C", "C", 2; "custom types")]
     #[test_case("", "bool", 2; "primitives")]
     #[test_case("", "sequence<bool>", 2; "sequences")]
     #[test_case("", "dictionary<bool, bool>", 2; "dictionaries")]
-    #[test_case("typealias T = bool;", "T", 2; "type aliases")]
+    #[test_case("typealias T = bool", "T", 2; "type aliases")]
     fn can_have_type_alias_of(definition: &str, identifier: &str, encoding: i32) {
         // Arrange
         let slice = format!(
             "
-                encoding = {encoding};
-                module Test;
+                encoding = {encoding}
+                module Test
                 {definition}
-                typealias Alias = {identifier};
+                typealias Alias = {identifier}
             "
         );
 
@@ -42,10 +42,10 @@ mod typealias {
     fn can_be_used_as_data_member() {
         // Arrange
         let slice = "
-            module Test;
-            typealias MyDict = dictionary<varint32, sequence<uint8>>;
+            module Test
+            typealias MyDict = dictionary<varint32, sequence<uint8>>
             compact struct S {
-                dict: MyDict,
+                dict: MyDict
             }
         ";
 
@@ -60,10 +60,10 @@ mod typealias {
     fn can_be_used_as_parameter() {
         // Arrange
         let slice = "
-            module Test;
-            typealias MyDict = dictionary<varint32, sequence<uint8>>;
+            module Test
+            typealias MyDict = dictionary<varint32, sequence<uint8>>
             interface I {
-                op(dict: MyDict);
+                op(dict: MyDict)
             }
         ";
 
@@ -78,8 +78,8 @@ mod typealias {
     fn is_resolvable_as_an_entity() {
         // Arrange
         let slice = "
-            module Test;
-            typealias MyInt = varuint32;
+            module Test
+            typealias MyInt = varuint32
         ";
 
         // Act
@@ -99,10 +99,10 @@ mod typealias {
     fn is_resolved_as_the_aliased_type_when_used() {
         // Arrange
         let slice = "
-            module Test;
-            typealias MyInt = varuint32;
+            module Test
+            typealias MyInt = varuint32
             compact struct S {
-                a: MyInt,
+                a: MyInt
             }
         ";
 


### PR DESCRIPTION
This PR makes the following punctuation optional in Slice:
- All semicolons
- Commas in between data members, parameters, and enumerators

Commas in dictionaries, attributes, and inheritance lists are still required.

As a result of this:
- newlines are _only_ allowed at the beginning of a file, after an encoding statement, after a file scoped module declaration, after a brace (open or closed), after a custom type declaration, after a type-alias definition, after an attribute, after a tag, after a doc comment, at the end of an operation, after a parameter, after a data member, after an inheritance list, after a return member, and after an enumerator. It is now a syntax error to put a newline anywhere other than the mentioned places.
- Many syntax errors are now... _difficult to read_. _Valid_ slice is still unambiguous, but with softer grammar rules, it's harder for the parser to know which tokens to recommend could appear when the user makes a syntax error. This is compounded by the fact it's now very easy to cause syntax errors.

It accomplishes this by adding a new `Newline` token to the grammar. This token is returned by the Lexer whenever it sees either `\n` in a source block, or hits the end of a source block (effectively `EOF`). The grammar now accepts this token in places where only punctuation used to be valid.