### PR TITLE
Simplify 'TypeRefPatcher'.

### DIFF
--- a/src/ast/node.rs
+++ b/src/ast/node.rs
@@ -56,6 +56,15 @@ macro_rules! generate_node_enum {
             }
         }
 
+        impl<'a> From<&'a Node> for &'a dyn Element {
+            /// Unwraps a node to a dynamically typed reference of a Slice [Element].
+            fn from(node: &'a Node) -> &'a dyn Element {
+                match node {
+                    $(Node::$variant(ptr) => ptr.borrow(),)*
+                }
+            }
+        }
+
         // Generate methods for unwrapping nodes to `&OwnedPtr`s.
         $(generate_try_from_node_impl!($variant, &'a Node, &'a OwnedPtr<$variant>, std::convert::identity);)*
 
@@ -74,6 +83,33 @@ macro_rules! generate_node_enum {
 generate_node_enum! {
     Module, Struct, Class, Exception, DataMember, Interface, Operation, Parameter, Enum,
     Enumerator, CustomType, TypeAlias, Sequence, Dictionary, Primitive
+}
+
+impl<'a> TryFrom<&'a Node> for WeakPtr<dyn Type> {
+    type Error = Error;
+
+    /// Attempts to unwrap a node to a [`WeakPtr`] of a Slice [Type].
+    ///
+    /// If the Slice element held by the node implements [Type], this succeeds and returns a pointer to the entity,
+    /// otherwise this fails and returns an error message.
+    fn try_from(node: &'a Node) -> Result<WeakPtr<dyn Type>, Self::Error> {
+        match node {
+            Node::Struct(struct_ptr) => Ok(downgrade_as!(struct_ptr, dyn Type)),
+            Node::Class(class_ptr) => Ok(downgrade_as!(class_ptr, dyn Type)),
+            Node::Exception(exception_ptr) => Ok(downgrade_as!(exception_ptr, dyn Type)),
+            Node::Interface(interface_ptr) => Ok(downgrade_as!(interface_ptr, dyn Type)),
+            Node::Enum(enum_ptr) => Ok(downgrade_as!(enum_ptr, dyn Type)),
+            Node::CustomType(custom_type_ptr) => Ok(downgrade_as!(custom_type_ptr, dyn Type)),
+            Node::TypeAlias(type_alias_ptr) => Ok(downgrade_as!(type_alias_ptr, dyn Type)),
+            Node::Sequence(sequence_ptr) => Ok(downgrade_as!(sequence_ptr, dyn Type)),
+            Node::Dictionary(dictionary_ptr) => Ok(downgrade_as!(dictionary_ptr, dyn Type)),
+            Node::Primitive(primitive_ptr) => Ok(downgrade_as!(primitive_ptr, dyn Type)),
+            _ => Err(Error::new(ErrorKind::TypeMismatch {
+                expected: "Type".to_owned(),
+                actual: node.to_string().to_case(Case::Lower),
+            })),
+        }
+    }
 }
 
 impl<'a> TryFrom<&'a Node> for &'a dyn Type {

--- a/src/utils/ptr_util.rs
+++ b/src/utils/ptr_util.rs
@@ -169,3 +169,25 @@ macro_rules! upcast_weak_as {
         WeakPtr::from_inner((data.map(|ptr| ptr as *const $new_type), type_id))
     }};
 }
+
+impl<'a, T: ?Sized, U: ?Sized> PartialEq<&'a T> for OwnedPtr<U> {
+    fn eq(&self, other: &&'a T) -> bool {
+        // Convert this pointer's box and the other borrow to raw pointers, then strip their typing, and convert any
+        // DST fat pointers to thin pointers to avoid checking their v-tables (which can be transient).
+        let self_ptr = (&*self.data as *const U).cast::<()>();
+        let other_ptr = (*other as *const T).cast::<()>();
+        // Check if the data pointers point to the same location in memory.
+        std::ptr::eq(self_ptr, other_ptr)
+    }
+}
+
+impl<'a, T: ?Sized, U: ?Sized> PartialEq<&'a T> for WeakPtr<U> {
+    fn eq(&self, other: &&'a T) -> bool {
+        // Convert the other borrow to a raw pointer, then strip it and this pointer's typing, and convert any
+        // DST fat pointers to thin pointers to avoid checking their v-tables (which can be transient).
+        let Some(self_ptr) = self.data else { return false; };
+        let other_ptr = (*other as *const T).cast::<()>();
+        // Check if the data pointers point to the same location in memory.
+        std::ptr::eq(self_ptr.cast::<()>(), other_ptr)
+    }
+}


### PR DESCRIPTION
This PR accidentally fixes #385 by deleting it.

Currently, the TypeRefPatcher goes through all the `TypeRef`s (where a type is used), and gives them pointers to the actual type.
It takes the identifier the user wrote, and looks it up in the AST. There are 2 ways this can happen (ignoring errors):
1) We find anything other than a type-alias.
We get an AST `Node`, and can directly get a correctly typed pointer from it. Easy.

2) We find a type-alias.
We unwrap the AST `Node` to a typealias, clone the alias's pointer, and massage it into the type we want. Annoying.
For nested typealiases, we resolve down to the bottom-most type-alias.

### What Changed?

This PR adds the ability to lookup nodes in the AST _by pointer_, currently, you can only lookup by identifier.
This lets us delete most of path #⁠2. Instead of massaging the pointer, we can lookup the AST `Node` with it pointer, then jump back into path #⁠1.

### What Actually Changed? (TL;DR)

1) Implements pointer equality for our custom pointers: `my_ptr == other`. It also works between a pointer and a reference.
The semantics are that 2 things are equal if they point to the same address in memory (the semantics of `std::ptr::eq`).
I had people review it on the rust forums: https://users.rust-lang.org/t/comparing-addresses-between-fat-and-thin-pointers/

2) I moved some of the conversions functions from `type_ref_patcher` into `node`.
These could useful to other modules, and that's where all the other conversions are anyways.

3) Deletes the `TryIntoPatch` trait used by the patcher. We needed a common type for pointers and nodes.
Now that we only have to deal with nodes, this common type is useless; the functions can just take `Node`s now.