### PR TITLE
Tags are Applied to Fields/Parameters, Not their Types

### DIFF
--- a/src/parsers/slice/grammar.lalrpop
+++ b/src/parsers/slice/grammar.lalrpop
@@ -156,7 +156,7 @@ Class: OwnedPtr<Class> = {
 }
 
 Field: OwnedPtr<Field> = {
-    <p: Prelude> <l: @L> <i: Identifier> ":" <t: Tag?> <tr: TypeRef> <r: @R> => {
+    <p: Prelude> <l: @L> <t: Tag?> <i: Identifier> ":" <tr: TypeRef> <r: @R> => {
         construct_field(parser, p, i, t, tr, Span::new(l, r, parser.file_name))
     }
 }
@@ -174,14 +174,14 @@ Operation: OwnedPtr<Operation> = {
 }
 
 Parameter: OwnedPtr<Parameter> = {
-    <p: Prelude> <l: @L> <i: Identifier> ":" <pm: ParameterModifier> <tr: TypeRef> <r: @R> => {
-        construct_parameter(parser, p, i, pm, tr, Span::new(l, r, parser.file_name))
+    <p: Prelude> <l: @L> <t: Tag?> <i: Identifier> ":" <s: stream_keyword?> <tr: TypeRef> <r: @R> => {
+        construct_parameter(parser, p, i, t, s.is_some(), tr, Span::new(l, r, parser.file_name))
     }
 }
 
 ReturnType: Vec<OwnedPtr<Parameter>> = {
-    <l: @L> <pm: ParameterModifier> <tr: TypeRef> <r: @R> => {
-        construct_single_return_type(parser, pm, tr, Span::new(l, r, parser.file_name))
+    <l: @L> <t: Tag?> <s: stream_keyword?> <tr: TypeRef> <r: @R> => {
+        construct_single_return_type(parser, t, s.is_some(), tr, Span::new(l, r, parser.file_name))
     },
     <l: @L> "(" <ps: UndelimitedList<Parameter>> ")" <r: @R> => {
         check_return_tuple(parser, &ps, Span::new(l, r, parser.file_name));
@@ -195,12 +195,6 @@ ExceptionSpecification: Throws = {
         Throws::Specific(exception)
     },
     throws_keyword any_exception_keyword => Throws::AnyException,
-}
-
-ParameterModifier: (bool, Option<Integer<u32>>) = {
-    => (false, None),
-    stream_keyword => (true, None),
-    Tag => (false, Some(<>)),
 }
 
 Enum: OwnedPtr<Enum> = {

--- a/src/parsers/slice/grammar.rs
+++ b/src/parsers/slice/grammar.rs
@@ -366,7 +366,8 @@ fn construct_parameter(
     parser: &mut Parser,
     (raw_comment, attributes): (RawDocComment, Vec<Attribute>),
     identifier: Identifier,
-    (is_streamed, tag): (bool, Option<Integer<u32>>),
+    tag: Option<Integer<u32>>,
+    is_streamed: bool,
     data_type: TypeRef,
     span: Span,
 ) -> OwnedPtr<Parameter> {
@@ -387,7 +388,8 @@ fn construct_parameter(
 
 fn construct_single_return_type(
     parser: &Parser,
-    (is_streamed, tag): (bool, Option<Integer<u32>>),
+    tag: Option<Integer<u32>>,
+    is_streamed: bool,
     data_type: TypeRef,
     span: Span,
 ) -> Vec<OwnedPtr<Parameter>> {

--- a/tests/classes/tags.rs
+++ b/tests/classes/tags.rs
@@ -13,7 +13,7 @@ fn can_contain_tags() {
         class C {
             i: int32
             s: string
-            b: tag(10) bool?
+            tag(10) b: bool?
         }
     ";
 

--- a/tests/diagnostic_output_tests.rs
+++ b/tests/diagnostic_output_tests.rs
@@ -53,9 +53,9 @@ mod output {
             /// @param x: this is an x
             op1()
 
-            op2(x:
-    tag(1)
-                    int32, y: tag(2) bool?,
+            op2(tag(1)
+    x:
+                    int32, tag(2) y: bool?,
             )
         }
 
@@ -87,11 +87,11 @@ warning [W003]: doc comment has a param tag for 'x', but there is no parameter b
 error [E019]: invalid tag on member 'x': tagged members must be optional
  --> string-0:8:17
    |
-8  |             op2(x:
-   |                 --
-9  |     tag(1)
-   | ----------
-10 |                     int32, y: tag(2) bool?,
+8  |             op2(tag(1)
+   |                 ------
+9  |     x:
+   | ------
+10 |                     int32, tag(2) y: bool?,
    | -------------------------
    |
 error [E010]: invalid enum 'E': enums must contain at least one enumerator

--- a/tests/encoding_tests.rs
+++ b/tests/encoding_tests.rs
@@ -46,7 +46,7 @@ mod encodings {
         let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
-        let expected = Diagnostic::new(Error::Syntax{message: "expected one of '(', ')', ',', '::', '>', '?', '[', ']', ']]', '{', '}', 'class', 'compact', 'custom', 'doc comment', 'enum', 'exception', 'idempotent', 'identifier', 'interface', 'module', 'struct', 'throws', 'typealias', or 'unchecked', but found 'encoding'".to_owned()});
+        let expected = Diagnostic::new(Error::Syntax{message: "expected one of '(', ')', ',', '::', '>', '?', '[', ']', ']]', '{', '}', 'class', 'compact', 'custom', 'doc comment', 'enum', 'exception', 'idempotent', 'identifier', 'interface', 'module', 'struct', 'tag', 'throws', 'typealias', or 'unchecked', but found 'encoding'".to_owned()});
         check_diagnostics(diagnostics, [expected]);
     }
 }

--- a/tests/exceptions/tags.rs
+++ b/tests/exceptions/tags.rs
@@ -11,7 +11,7 @@ fn can_contain_tags() {
         exception E {
             i: int32
             s: string
-            b: tag(10) bool?
+            tag(10) b: bool?
         }
     ";
 

--- a/tests/interfaces/operations.rs
+++ b/tests/interfaces/operations.rs
@@ -50,7 +50,7 @@ fn can_contain_tags() {
         module Test
 
         interface I {
-            op(a: tag(1) int32?)
+            op(tag(1) a: int32?)
         }
     ";
 
@@ -70,7 +70,7 @@ fn parameter_and_return_can_have_the_same_tag() {
         module Test
 
         interface I {
-            op(a: tag(1) int32?) -> tag(1) string?
+            op(tag(1) a: int32?) -> tag(1) string?
         }
     ";
 

--- a/tests/structs/tags.rs
+++ b/tests/structs/tags.rs
@@ -14,7 +14,7 @@ mod structs {
             struct S {
                 i: int32
                 s: string
-                b: tag(10) bool?
+                tag(10) b: bool?
             }
         ";
 
@@ -41,7 +41,7 @@ mod compact_structs {
             compact struct S {
                 i: int32
                 s: string
-                b: tag(10) bool?
+                tag(10) b: bool?
             }
         ";
 

--- a/tests/tag_tests.rs
+++ b/tests/tag_tests.rs
@@ -18,7 +18,7 @@ mod tags {
             class C {
                 i: int32
                 s: string
-                b: tag(10) bool
+                tag(10) b: bool
             }
         ";
 
@@ -39,7 +39,7 @@ mod tags {
             encoding = Slice1
             module Test
             interface I {
-                op(myParam: tag(10) int32)
+                op(tag(10) myParam: int32)
             }
         ";
 
@@ -83,7 +83,7 @@ mod tags {
             encoding = Slice1
             module Test
             interface I {
-                op(p1: int32, p2: tag(10) int32?, p3: int32, p4: int32, p5: tag(20) int32?)
+                op(p1: int32, tag(10) p2: int32?, p3: int32, p4: int32, tag(20) p5: int32?)
             }
         ";
 
@@ -112,7 +112,7 @@ mod tags {
             class C {}
 
             interface I {
-                op(c: tag(1) C?)
+                op(tag(1) c: C?)
             }
         ";
 
@@ -140,7 +140,7 @@ mod tags {
             }
 
             interface I {
-                op(s: tag(1) S?)
+                op(tag(1) s: S?)
             }
         ";
 
@@ -160,7 +160,7 @@ mod tags {
         let slice = "
             module Test
             struct S {
-                a: tag(1) int32?
+                tag(1) a: int32?
             }
         ";
 
@@ -180,8 +180,8 @@ mod tags {
         let slice = "
             module Test
             struct S {
-                a: tag(1) int32?
-                b: tag(1) int32?
+                tag(1) a: int32?
+                tag(1) b: int32?
             }
         ";
 
@@ -206,7 +206,7 @@ mod tags {
             "
             module Test
             interface I {{
-                testOp(a: tag({value}) int32?)
+                testOp(tag({value}) a: int32?)
             }}
             "
         );
@@ -223,7 +223,7 @@ mod tags {
             "
                 module Test
                 interface I {{
-                    testOp(a: tag({value}) int32?)
+                    testOp(tag({value}) a: int32?)
                 }}
             "
         );
@@ -242,7 +242,7 @@ mod tags {
         let slice = "
             module Test
             interface I {
-                testOp(a: tag(-1) int32?)
+                testOp(tag(-1) a: int32?)
             }
         ";
 
@@ -260,7 +260,7 @@ mod tags {
         let slice = "
             module Test
             interface I {
-                testOp(a: tag(\"test string\") int32?)
+                testOp(tag(\"test string\") a: int32?)
             }
         ";
 


### PR DESCRIPTION
Logically, tags should apply to an entire data member or parameter, not just the type.

But our current syntax suggests otherwise, because we require tags to be placed on the type:
```
op(param: tag(1) bool?)
```

This PR changes the syntax of tags according to Option 1 of https://github.com/zeroc-ice/slicec/issues/478
Now tags appear in front of parameters, fields, and return members,
```
op(tag(1) param: bool?)
```
Although for single return types, the syntax remains unchanged, since they have no identifier:
```
op() -> tag(1) bool?
```