### PR TITLE
Add Tests and Additional Documentation for our Custom Pointers

### DIFF
--- a/src/utils/ptr_util.rs
+++ b/src/utils/ptr_util.rs
@@ -288,7 +288,7 @@ mod tests {
         let (raw_pointer, type_id) = weak_ptr.into_inner();
         let casted_pointer = raw_pointer.map(|ptr| ptr as *const bool);
         // Re-assemble the weak pointer with the casted type.
-        // This is safe and legal to do in Rust, but borrowing this pointer in any way would panic.
+        // This is safe and legal to do in Rust, but borrowing from this pointer in any way would be unsafe.
         let casted_weak_ptr: WeakPtr<bool> = WeakPtr::from_inner((casted_pointer, type_id));
 
         // Act/Assert: asserting that they're equal is the 'act'.


### PR DESCRIPTION
The entire structure of the compiler is built on a pair of custom pointer types that we implemented ourselves:
- `OwnedPtr`: Represents a pointer that owns the data it's pointing to (since all data needs an owner in Rust).
- `WeakPtr`: Represents a pointer that immutably references the data it's pointing to.

Since these two types underlie literally everything else, it would be good to add some tests and documentation to them!
This PR does that.