### PR TITLE
GitHub Actions env var test

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,8 +30,8 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
           restore-keys: |
             ${{ runner.os }}-cargo-
-      - name: 🦇 Echo env variable
-        run: echo $CARGO_REGISTRIES_CRATES_IO_PROTOCOL
+      - name: Rust version
+        run: rustc --version
       - name: 🔨 Build
         run: cargo build -Z sparse-registry
       - name: 🧪 Test


### PR DESCRIPTION
This is a test. Ignore this PR.

Edit: Github runners use rustc 1.67.1 (d5a82bbd2 2023-02-07) by default. Not worth setting the rust toolchain just to use sparse registries for now. Will wait until the runners default to 1.68.