### PR TITLE
Move Attributes into the AST

### DIFF
--- a/src/ast/node.rs
+++ b/src/ast/node.rs
@@ -83,7 +83,7 @@ macro_rules! generate_node_enum {
 // generate the `Node` enum with variants for every type allowed to be in the AST.
 generate_node_enum! {
     Module, Struct, Class, Exception, Field, Interface, Operation, Parameter, Enum,
-    Enumerator, CustomType, TypeAlias, Sequence, Dictionary, Primitive
+    Enumerator, CustomType, TypeAlias, Sequence, Dictionary, Primitive, Attribute
 }
 
 impl<'a> TryFrom<&'a Node> for WeakPtr<dyn Type> {
@@ -233,3 +233,4 @@ impl_into_node_for!(Sequence);
 impl_into_node_for!(Dictionary);
 // We don't implement it on `Primitive`, because primitive types are baked into the compiler, so we don't need
 // conversion methods for wrapping them into `Node`s.
+impl_into_node_for!(Attribute);

--- a/src/ast/patchers/type_ref_patcher.rs
+++ b/src/ast/patchers/type_ref_patcher.rs
@@ -254,7 +254,7 @@ impl TypeRefPatcher<'_> {
         // While resolving the chain, if we see a type alias already in this vector, a cycle is present.
         let mut type_alias_chain = Vec::new();
 
-        let mut attributes: Vec<Attribute> = Vec::new();
+        let mut attributes: Vec<WeakPtr<Attribute>> = Vec::new();
         let mut current_type_alias = type_alias;
         loop {
             type_alias_chain.push(current_type_alias);
@@ -318,7 +318,7 @@ impl TypeRefPatcher<'_> {
     }
 }
 
-type Patch<T> = (WeakPtr<T>, Vec<Attribute>);
+type Patch<T> = (WeakPtr<T>, Vec<WeakPtr<Attribute>>);
 
 #[derive(Default)]
 enum PatchKind {
@@ -336,7 +336,7 @@ enum PatchKind {
     DictionaryTypes(Option<Patch<dyn Type>>, Option<Patch<dyn Type>>),
 }
 
-fn try_into_patch<'a, T: ?Sized>(node: &'a Node, attributes: Vec<Attribute>) -> Result<Patch<T>, LookupError>
+fn try_into_patch<'a, T: ?Sized>(node: &'a Node, attributes: Vec<WeakPtr<Attribute>>) -> Result<Patch<T>, LookupError>
 where
     &'a Node: TryInto<WeakPtr<T>, Error = LookupError>,
 {

--- a/src/grammar/elements/attribute.rs
+++ b/src/grammar/elements/attribute.rs
@@ -12,7 +12,7 @@ const DEPRECATED: &str = "deprecated";
 const FORMAT: &str = "format";
 const ONEWAY: &str = "oneway";
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub struct Attribute {
     pub kind: AttributeKind,
     pub span: Span,
@@ -75,7 +75,7 @@ impl Attribute {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 pub enum AttributeKind {
     Allow { warning_codes: Vec<String> },
     ClassFormat { format: ClassFormat },
@@ -89,24 +89,10 @@ pub enum AttributeKind {
     Other { directive: String, arguments: Vec<String> },
 }
 
-pub trait LanguageKind {
+pub trait LanguageKind: std::fmt::Debug {
     fn directive(&self) -> &str;
     fn as_any(&self) -> &dyn std::any::Any;
-    fn clone_kind(&self) -> Box<dyn LanguageKind>;
-    fn debug_kind(&self) -> &str;
     fn is_repeatable(&self) -> bool;
-}
-
-impl Clone for Box<dyn LanguageKind> {
-    fn clone(&self) -> Self {
-        self.clone_kind()
-    }
-}
-
-impl std::fmt::Debug for Box<dyn LanguageKind> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        writeln!(f, "{}", self.debug_kind())
-    }
 }
 
 impl AttributeKind {

--- a/src/grammar/elements/class.rs
+++ b/src/grammar/elements/class.rs
@@ -13,7 +13,7 @@ pub struct Class {
     pub base: Option<TypeRef<Class>>,
     pub parent: WeakPtr<Module>,
     pub scope: Scope,
-    pub attributes: Vec<Attribute>,
+    pub attributes: Vec<WeakPtr<Attribute>>,
     pub comment: Option<DocComment>,
     pub span: Span,
     pub(crate) supported_encodings: Option<SupportedEncodings>,

--- a/src/grammar/elements/custom_type.rs
+++ b/src/grammar/elements/custom_type.rs
@@ -10,7 +10,7 @@ pub struct CustomType {
     pub identifier: Identifier,
     pub parent: WeakPtr<Module>,
     pub scope: Scope,
-    pub attributes: Vec<Attribute>,
+    pub attributes: Vec<WeakPtr<Attribute>>,
     pub comment: Option<DocComment>,
     pub span: Span,
     pub(crate) supported_encodings: Option<SupportedEncodings>,

--- a/src/grammar/elements/enum.rs
+++ b/src/grammar/elements/enum.rs
@@ -13,7 +13,7 @@ pub struct Enum {
     pub is_unchecked: bool,
     pub parent: WeakPtr<Module>,
     pub scope: Scope,
-    pub attributes: Vec<Attribute>,
+    pub attributes: Vec<WeakPtr<Attribute>>,
     pub comment: Option<DocComment>,
     pub span: Span,
     pub(crate) supported_encodings: Option<SupportedEncodings>,

--- a/src/grammar/elements/enumerator.rs
+++ b/src/grammar/elements/enumerator.rs
@@ -10,7 +10,7 @@ pub struct Enumerator {
     pub value: EnumeratorValue,
     pub parent: WeakPtr<Enum>,
     pub scope: Scope,
-    pub attributes: Vec<Attribute>,
+    pub attributes: Vec<WeakPtr<Attribute>>,
     pub comment: Option<DocComment>,
     pub span: Span,
 }

--- a/src/grammar/elements/exception.rs
+++ b/src/grammar/elements/exception.rs
@@ -12,7 +12,7 @@ pub struct Exception {
     pub base: Option<TypeRef<Exception>>,
     pub parent: WeakPtr<Module>,
     pub scope: Scope,
-    pub attributes: Vec<Attribute>,
+    pub attributes: Vec<WeakPtr<Attribute>>,
     pub comment: Option<DocComment>,
     pub span: Span,
     pub(crate) supported_encodings: Option<SupportedEncodings>,

--- a/src/grammar/elements/field.rs
+++ b/src/grammar/elements/field.rs
@@ -11,7 +11,7 @@ pub struct Field {
     pub tag: Option<Integer<u32>>,
     pub parent: WeakPtr<dyn Container<WeakPtr<Field>>>,
     pub scope: Scope,
-    pub attributes: Vec<Attribute>,
+    pub attributes: Vec<WeakPtr<Attribute>>,
     pub comment: Option<DocComment>,
     pub span: Span,
 }

--- a/src/grammar/elements/interface.rs
+++ b/src/grammar/elements/interface.rs
@@ -12,7 +12,7 @@ pub struct Interface {
     pub bases: Vec<TypeRef<Interface>>,
     pub parent: WeakPtr<Module>,
     pub scope: Scope,
-    pub attributes: Vec<Attribute>,
+    pub attributes: Vec<WeakPtr<Attribute>>,
     pub comment: Option<DocComment>,
     pub span: Span,
     pub(crate) supported_encodings: Option<SupportedEncodings>,

--- a/src/grammar/elements/module.rs
+++ b/src/grammar/elements/module.rs
@@ -11,7 +11,7 @@ pub struct Module {
     pub is_file_scoped: bool,
     pub parent: Option<WeakPtr<Module>>,
     pub scope: Scope,
-    pub attributes: Vec<Attribute>,
+    pub attributes: Vec<WeakPtr<Attribute>>,
     pub comment: Option<DocComment>,
     pub span: Span,
 }

--- a/src/grammar/elements/operation.rs
+++ b/src/grammar/elements/operation.rs
@@ -14,7 +14,7 @@ pub struct Operation {
     pub encoding: Encoding,
     pub parent: WeakPtr<Interface>,
     pub scope: Scope,
-    pub attributes: Vec<Attribute>,
+    pub attributes: Vec<WeakPtr<Attribute>>,
     pub comment: Option<DocComment>,
     pub span: Span,
 }

--- a/src/grammar/elements/parameter.rs
+++ b/src/grammar/elements/parameter.rs
@@ -13,7 +13,7 @@ pub struct Parameter {
     pub is_returned: bool,
     pub parent: WeakPtr<Operation>,
     pub scope: Scope,
-    pub attributes: Vec<Attribute>,
+    pub attributes: Vec<WeakPtr<Attribute>>,
     pub comment: Option<DocComment>,
     pub span: Span,
 }

--- a/src/grammar/elements/struct.rs
+++ b/src/grammar/elements/struct.rs
@@ -12,7 +12,7 @@ pub struct Struct {
     pub is_compact: bool,
     pub parent: WeakPtr<Module>,
     pub scope: Scope,
-    pub attributes: Vec<Attribute>,
+    pub attributes: Vec<WeakPtr<Attribute>>,
     pub comment: Option<DocComment>,
     pub span: Span,
     pub(crate) supported_encodings: Option<SupportedEncodings>,

--- a/src/grammar/elements/type_alias.rs
+++ b/src/grammar/elements/type_alias.rs
@@ -11,7 +11,7 @@ pub struct TypeAlias {
     pub underlying: TypeRef,
     pub parent: WeakPtr<Module>,
     pub scope: Scope,
-    pub attributes: Vec<Attribute>,
+    pub attributes: Vec<WeakPtr<Attribute>>,
     pub comment: Option<DocComment>,
     pub span: Span,
     pub(crate) supported_encodings: Option<SupportedEncodings>,

--- a/src/grammar/elements/type_ref.rs
+++ b/src/grammar/elements/type_ref.rs
@@ -9,7 +9,7 @@ pub struct TypeRef<T: Element + ?Sized = dyn Type> {
     pub definition: TypeRefDefinition<T>,
     pub is_optional: bool,
     pub scope: Scope,
-    pub attributes: Vec<Attribute>,
+    pub attributes: Vec<WeakPtr<Attribute>>,
     pub span: Span,
 }
 
@@ -21,7 +21,7 @@ impl<T: Element + ?Sized> TypeRef<T> {
         }
     }
 
-    pub(crate) fn patch(&mut self, ptr: WeakPtr<T>, additional_attributes: Vec<Attribute>) {
+    pub(crate) fn patch(&mut self, ptr: WeakPtr<T>, additional_attributes: Vec<WeakPtr<Attribute>>) {
         // Assert that the typeref hasn't already been patched.
         debug_assert!(matches!(&self.definition, TypeRefDefinition::Unpatched(_)));
 
@@ -71,7 +71,7 @@ impl<T: Type + ?Sized> TypeRef<T> {
 impl<T: Element + ?Sized> Attributable for TypeRef<T> {
     fn attributes(&self, include_parent: bool) -> Vec<&Attribute> {
         assert!(!include_parent);
-        self.attributes.iter().collect()
+        self.attributes.iter().map(WeakPtr::borrow).collect()
     }
 
     fn all_attributes(&self) -> Vec<Vec<&Attribute>> {

--- a/src/grammar/traits.rs
+++ b/src/grammar/traits.rs
@@ -167,7 +167,7 @@ macro_rules! implement_Attributable_for {
     ($type:ty) => {
         impl Attributable for $type {
             fn attributes(&self, include_parent: bool) -> Vec<&Attribute> {
-                let mut attributes = self.attributes.iter().collect::<Vec<_>>();
+                let mut attributes = self.attributes.iter().map(WeakPtr::borrow).collect::<Vec<_>>();
 
                 if include_parent {
                     if let Some(parent) = self.parent() {

--- a/src/parsers/slice/grammar.lalrpop
+++ b/src/parsers/slice/grammar.lalrpop
@@ -94,12 +94,12 @@ extern {
 
 // Grammar Rules
 
-pub SliceFile: (Option<FileEncoding>, Vec<Attribute>, Vec<OwnedPtr<Module>>) = {
+pub SliceFile: (Option<FileEncoding>, Vec<WeakPtr<Attribute>>, Vec<OwnedPtr<Module>>) = {
     <sfp: SliceFilePrelude> <flm: FileScopedModule> => (sfp.0, sfp.1, vec![flm]),
     <sfp: SliceFilePrelude> <ms: Module*> => (sfp.0, sfp.1, ms),
 }
 
-SliceFilePrelude: (Option<FileEncoding>, Vec<Attribute>) = {
+SliceFilePrelude: (Option<FileEncoding>, Vec<WeakPtr<Attribute>>) = {
     => (None, Vec::new()),
     <sfp: SliceFilePrelude> <fe: FileEncoding> => handle_file_encoding(parser, sfp, fe),
     <mut sfp: SliceFilePrelude> <fa: FileAttribute> => {
@@ -271,7 +271,7 @@ FileAttribute = "[[" <Attribute> "]]";
 
 LocalAttribute = "[" <Attribute> "]";
 
-Attribute: Attribute = {
+Attribute: WeakPtr<Attribute> = {
     <l: @L> <rsi: RelativelyScopedIdentifier> <aas: ("(" <CommaList<AttributeArgument>> ")")?> <r: @R> => {
         try_construct_attribute(parser, rsi, aas, Span::new(l, r, parser.file_name))
     }
@@ -325,7 +325,7 @@ CompactId: Integer<u32> = {
     }
 }
 
-Prelude: (Vec<(&'input str, Span)>, Vec<Attribute>) = {
+Prelude: (Vec<(&'input str, Span)>, Vec<WeakPtr<Attribute>>) = {
     => (Vec::new(), Vec::new()),
     <mut prelude: Prelude> <l: @L> <comment: doc_comment> <r: @R> => {
         prelude.0.push((comment, Span::new(l, r, parser.file_name)));

--- a/src/parsers/slice/grammar.rs
+++ b/src/parsers/slice/grammar.rs
@@ -75,9 +75,9 @@ type RawDocComment<'a> = Vec<(&'a str, Span)>;
 
 fn handle_file_encoding(
     parser: &mut Parser,
-    (old_encoding, attributes): (Option<FileEncoding>, Vec<Attribute>),
+    (old_encoding, attributes): (Option<FileEncoding>, Vec<WeakPtr<Attribute>>),
     encoding: FileEncoding,
-) -> (Option<FileEncoding>, Vec<Attribute>) {
+) -> (Option<FileEncoding>, Vec<WeakPtr<Attribute>>) {
     // The file encoding can only be set once.
     if let Some(old_file_encoding) = old_encoding {
         let old_span = old_file_encoding.span();
@@ -107,7 +107,7 @@ fn construct_file_encoding(parser: &mut Parser, i: Identifier, span: Span) -> Fi
 
 fn construct_module(
     parser: &mut Parser,
-    (raw_comment, attributes): (RawDocComment, Vec<Attribute>),
+    (raw_comment, attributes): (RawDocComment, Vec<WeakPtr<Attribute>>),
     identifier: Identifier,
     definitions: Vec<Node>,
     is_file_scoped: bool,
@@ -176,7 +176,7 @@ fn construct_module(
 
 fn construct_struct(
     parser: &mut Parser,
-    (raw_comment, attributes): (RawDocComment, Vec<Attribute>),
+    (raw_comment, attributes): (RawDocComment, Vec<WeakPtr<Attribute>>),
     is_compact: bool,
     identifier: Identifier,
     fields: Vec<OwnedPtr<Field>>,
@@ -203,7 +203,7 @@ fn construct_struct(
 
 fn construct_exception(
     parser: &mut Parser,
-    (raw_comment, attributes): (RawDocComment, Vec<Attribute>),
+    (raw_comment, attributes): (RawDocComment, Vec<WeakPtr<Attribute>>),
     identifier: Identifier,
     base_type: Option<TypeRef>,
     fields: Vec<OwnedPtr<Field>>,
@@ -232,7 +232,7 @@ fn construct_exception(
 
 fn construct_class(
     parser: &mut Parser,
-    (raw_comment, attributes): (RawDocComment, Vec<Attribute>),
+    (raw_comment, attributes): (RawDocComment, Vec<WeakPtr<Attribute>>),
     identifier: Identifier,
     compact_id: Option<Integer<u32>>,
     base_type: Option<TypeRef>,
@@ -263,7 +263,7 @@ fn construct_class(
 
 pub fn construct_field(
     parser: &mut Parser,
-    (raw_comment, attributes): (RawDocComment, Vec<Attribute>),
+    (raw_comment, attributes): (RawDocComment, Vec<WeakPtr<Attribute>>),
     identifier: Identifier,
     tag: Option<Integer<u32>>,
     data_type: TypeRef,
@@ -284,7 +284,7 @@ pub fn construct_field(
 
 fn construct_interface(
     parser: &mut Parser,
-    (raw_comment, attributes): (RawDocComment, Vec<Attribute>),
+    (raw_comment, attributes): (RawDocComment, Vec<WeakPtr<Attribute>>),
     identifier: Identifier,
     bases: Option<Vec<TypeRef>>,
     operations: Vec<OwnedPtr<Operation>>,
@@ -318,7 +318,7 @@ fn construct_interface(
 #[allow(clippy::too_many_arguments)]
 fn construct_operation(
     parser: &mut Parser,
-    (raw_comment, attributes): (RawDocComment, Vec<Attribute>),
+    (raw_comment, attributes): (RawDocComment, Vec<WeakPtr<Attribute>>),
     is_idempotent: bool,
     identifier: Identifier,
     parameters: Vec<OwnedPtr<Parameter>>,
@@ -364,7 +364,7 @@ fn construct_operation(
 
 fn construct_parameter(
     parser: &mut Parser,
-    (raw_comment, attributes): (RawDocComment, Vec<Attribute>),
+    (raw_comment, attributes): (RawDocComment, Vec<WeakPtr<Attribute>>),
     identifier: Identifier,
     tag: Option<Integer<u32>>,
     is_streamed: bool,
@@ -423,7 +423,7 @@ fn check_return_tuple(parser: &mut Parser, return_tuple: &Vec<OwnedPtr<Parameter
 
 fn construct_enum(
     parser: &mut Parser,
-    (raw_comment, attributes): (RawDocComment, Vec<Attribute>),
+    (raw_comment, attributes): (RawDocComment, Vec<WeakPtr<Attribute>>),
     is_unchecked: bool,
     identifier: Identifier,
     underlying_type: Option<TypeRef>,
@@ -457,7 +457,7 @@ fn construct_enum(
 
 fn construct_enumerator(
     parser: &mut Parser,
-    (raw_comment, attributes): (RawDocComment, Vec<Attribute>),
+    (raw_comment, attributes): (RawDocComment, Vec<WeakPtr<Attribute>>),
     identifier: Identifier,
     enumerator_value: Option<Integer<i128>>,
     span: Span,
@@ -488,7 +488,7 @@ fn construct_enumerator(
 
 fn construct_custom_type(
     parser: &mut Parser,
-    (raw_comment, attributes): (RawDocComment, Vec<Attribute>),
+    (raw_comment, attributes): (RawDocComment, Vec<WeakPtr<Attribute>>),
     identifier: Identifier,
     span: Span,
 ) -> OwnedPtr<CustomType> {
@@ -506,7 +506,7 @@ fn construct_custom_type(
 
 fn construct_type_alias(
     parser: &mut Parser,
-    (raw_comment, attributes): (RawDocComment, Vec<Attribute>),
+    (raw_comment, attributes): (RawDocComment, Vec<WeakPtr<Attribute>>),
     identifier: Identifier,
     underlying: TypeRef,
     span: Span,
@@ -526,7 +526,7 @@ fn construct_type_alias(
 
 fn construct_type_ref(
     parser: &Parser,
-    attributes: Vec<Attribute>,
+    attributes: Vec<WeakPtr<Attribute>>,
     definition: TypeRefDefinition,
     is_optional: bool,
     span: Span,
@@ -567,13 +567,13 @@ fn try_construct_attribute(
     directive: Identifier,
     arguments: Option<Vec<String>>,
     span: Span,
-) -> Attribute {
-    Attribute::new(
+) -> WeakPtr<Attribute> {
+    parser.ast.add_element(OwnedPtr::new(Attribute::new(
         parser.diagnostic_reporter,
         &directive.value,
         arguments.unwrap_or_default(),
         span,
-    )
+    )))
 }
 
 fn try_parse_integer(parser: &mut Parser, s: &str, span: Span) -> Integer<i128> {

--- a/src/parsers/slice/parser.rs
+++ b/src/parsers/slice/parser.rs
@@ -5,7 +5,7 @@ use super::lexer::Lexer;
 use crate::ast::Ast;
 use crate::diagnostics::DiagnosticReporter;
 use crate::grammar::*;
-use crate::utils::ptr_util::OwnedPtr;
+use crate::utils::ptr_util::{OwnedPtr, WeakPtr};
 
 /// Helper macro for generating parsing functions.
 macro_rules! implement_parse_function {
@@ -38,7 +38,7 @@ impl<'a> Parser<'a> {
     implement_parse_function!(
         parse_slice_file,
         SliceFileParser,
-        (Option<FileEncoding>, Vec<Attribute>, Vec<OwnedPtr<Module>>),
+        (Option<FileEncoding>, Vec<WeakPtr<Attribute>>, Vec<OwnedPtr<Module>>),
     );
 
     pub fn new(file_name: &'a str, ast: &'a mut Ast, diagnostic_reporter: &'a mut DiagnosticReporter) -> Self {

--- a/src/slice_file.rs
+++ b/src/slice_file.rs
@@ -50,7 +50,7 @@ pub struct SliceFile {
     pub relative_path: String,
     pub raw_text: String,
     pub contents: Vec<WeakPtr<Module>>,
-    pub attributes: Vec<Attribute>,
+    pub attributes: Vec<WeakPtr<Attribute>>,
     pub encoding: Option<FileEncoding>,
     pub is_source: bool,
     line_positions: Vec<usize>,
@@ -183,7 +183,7 @@ impl SliceFile {
 impl Attributable for SliceFile {
     fn attributes(&self, include_parent: bool) -> Vec<&Attribute> {
         assert!(!include_parent);
-        self.attributes.iter().collect()
+        self.attributes.iter().map(WeakPtr::borrow).collect()
     }
 
     fn all_attributes(&self) -> Vec<Vec<&Attribute>> {

--- a/tests/attribute_tests.rs
+++ b/tests/attribute_tests.rs
@@ -635,7 +635,7 @@ mod attributes {
             // Assert
             let operation = ast.find_element::<Operation>("Test::I::op").unwrap();
 
-            match &operation.attributes[0].kind {
+            match &operation.attributes[0].borrow().kind {
                 AttributeKind::Other { arguments, .. } => {
                     for (i, v) in arguments.iter().enumerate() {
                         assert_eq!(v, expected.get(i).unwrap().to_owned());
@@ -683,7 +683,7 @@ mod attributes {
             let module = ast.find_element::<Module>("Test").unwrap();
             assert_eq!(module.attributes.len(), 1);
             assert!(matches!(
-                &module.attributes[0].kind,
+                &module.attributes[0].borrow().kind,
                 AttributeKind::Other { directive, .. } if directive == "custom",
             ));
         }


### PR DESCRIPTION
This PR implements #430.
I think it makes everything _slightly_ simpler over all, but am on the fence.
If you think this adds more complexity than it removes, feel free to say so and reject it.

Currently attributes are owned by the Slice entity that they are applied to.
For example, the `Class` struct has a field: `attributes: Vec<Attribute>`, no pointers, just direct ownership.

This PR changes this.
Now attributes are placed into, and owned by the AST. Entities would only hold `WeakPtr`s to their attributes now, signaling this change in ownership. For example the field now becomes: `attributes: Vec<WeakPtr<Attribute>>`.

----

Con: this adds a layer of indirection to the API. Now to access an attribute, you have to call `borrow` on the pointer to go through it. It also makes the types slightly more cluttered, because now they have an extra `WeakPtr` on them.
These downsides are slight, but existent.

Pro: attributes now longer need to be cloneable. This lets us delete the hacky `clone_kind` and `debug_kind` trait functions from `LanguageKind`, and get rid of the `Clone` derives on attribute related structs. Now none of the language elements are cloneable.

More importantly, now that these no longer implement cloneable, it means they no longer need to be `Sized`.
This will probably open up even more simplification, since that restriction bled into much of our attribute API.

----

See the original issue for a more complete explanation.