### PR TITLE
Dramatically Simplify Sequence and Dictionary Validation

### DIFF
--- a/src/validators/dictionary.rs
+++ b/src/validators/dictionary.rs
@@ -2,26 +2,16 @@
 
 use crate::diagnostics::{Diagnostic, DiagnosticReporter, Error};
 use crate::grammar::*;
-use crate::validators::{ValidationChain, Validator};
 
-pub fn dictionary_validators() -> ValidationChain {
-    vec![
-        Validator::Dictionaries(has_allowed_key_type),
-        Validator::Dictionaries(has_allowed_value_type),
-    ]
+pub fn validate(dictionary: &Dictionary, diagnostic_reporter: &mut DiagnosticReporter) {
+    has_allowed_key_type(dictionary, diagnostic_reporter);
+    super::validate_type_ref(&dictionary.key_type, diagnostic_reporter);
+    super::validate_type_ref(&dictionary.value_type, diagnostic_reporter);
 }
 
-pub fn has_allowed_key_type(dictionaries: &[&Dictionary], diagnostic_reporter: &mut DiagnosticReporter) {
-    for dictionary in dictionaries {
-        if let Some(e) = check_dictionary_key_type(&dictionary.key_type) {
-            e.report(diagnostic_reporter)
-        }
-    }
-}
-
-pub fn has_allowed_value_type(dictionaries: &[&Dictionary], diagnostic_reporter: &mut DiagnosticReporter) {
-    for dictionary in dictionaries {
-        check_dictionary_value_type(&dictionary.value_type, diagnostic_reporter);
+pub fn has_allowed_key_type(dictionary: &Dictionary, diagnostic_reporter: &mut DiagnosticReporter) {
+    if let Some(e) = check_dictionary_key_type(&dictionary.key_type) {
+        e.report(diagnostic_reporter)
     }
 }
 
@@ -90,26 +80,5 @@ fn formatted_kind(definition: &dyn Type) -> String {
         Types::Exception(e) => format!("{} '{}'", e.kind(), e.identifier()),
         Types::Interface(i) => format!("{} '{}'", i.kind(), i.identifier()),
         _ => kind.to_owned(),
-    }
-}
-
-fn check_dictionary_value_type(type_ref: &TypeRef, diagnostic_reporter: &mut DiagnosticReporter) {
-    let definition = type_ref.definition();
-    match definition.concrete_type() {
-        Types::Sequence(s) => {
-            if let Types::Dictionary(dictionary) = s.element_type.concrete_type() {
-                if let Some(e) = check_dictionary_key_type(&dictionary.key_type) {
-                    e.report(diagnostic_reporter)
-                };
-                check_dictionary_value_type(&dictionary.value_type, diagnostic_reporter);
-            }
-        }
-        Types::Dictionary(dictionary) => {
-            if let Some(e) = check_dictionary_key_type(&dictionary.key_type) {
-                e.report(diagnostic_reporter)
-            };
-            check_dictionary_value_type(&dictionary.value_type, diagnostic_reporter);
-        }
-        _ => (),
     }
 }

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -15,27 +15,14 @@ use crate::ast::Ast;
 use crate::compilation_result::{CompilationData, CompilationResult};
 use crate::diagnostics::{Diagnostic, DiagnosticReporter, Error};
 use crate::grammar::*;
-use crate::utils::ptr_util::WeakPtr;
 use crate::visitor::Visitor;
 use std::collections::HashMap;
-
-// Re-export the contents of the validators submodules directly into the validators module. This is
-// for convenience, so users don't need to worry about the submodule structure while importing.
-pub use self::attribute::*;
-pub use self::comments::*;
-pub use self::dictionary::*;
-pub use self::enums::*;
-pub use self::identifiers::*;
-pub use self::miscellaneous::*;
-pub use self::sequence::*;
-pub use self::tag::*;
 
 pub type ValidationChain = Vec<Validator>;
 
 pub enum Validator {
     Attributes(fn(&dyn Entity, &mut DiagnosticReporter)),
     DocComments(fn(&dyn Entity, &Ast, &mut DiagnosticReporter)),
-    Dictionaries(fn(&[&Dictionary], &mut DiagnosticReporter)),
     Enums(fn(&Enum, &mut DiagnosticReporter)),
     Entities(fn(&dyn Entity, &mut DiagnosticReporter)),
     Members(fn(Vec<&dyn Member>, &mut DiagnosticReporter)),
@@ -45,7 +32,6 @@ pub enum Validator {
     Operations(fn(&Operation, &mut DiagnosticReporter)),
     Parameters(fn(&[&Parameter], &mut DiagnosticReporter)),
     Struct(fn(&Struct, &mut DiagnosticReporter)),
-    Sequences(fn(&[&Sequence], &mut DiagnosticReporter)),
     TypeAlias(fn(&TypeAlias, &mut DiagnosticReporter)),
 }
 
@@ -117,6 +103,14 @@ fn validate_module_contents(data: &mut CompilationData) {
     }
 }
 
+fn validate_type_ref(type_ref: &TypeRef, diagnostic_reporter: &mut DiagnosticReporter) {
+    match type_ref.concrete_type() {
+        Types::Dictionary(dictionary) => dictionary::validate(dictionary, diagnostic_reporter),
+        Types::Sequence(sequence) => sequence::validate(sequence, diagnostic_reporter),
+        _ => {}
+    }
+}
+
 struct ValidatorVisitor<'a> {
     ast: &'a Ast,
     diagnostic_reporter: &'a mut DiagnosticReporter,
@@ -126,14 +120,12 @@ struct ValidatorVisitor<'a> {
 impl<'a> ValidatorVisitor<'a> {
     pub fn new(ast: &'a Ast, diagnostic_reporter: &'a mut DiagnosticReporter) -> Self {
         let validation_functions = [
-            attribute_validators(),
-            comments_validators(),
-            dictionary_validators(),
-            enum_validators(),
-            identifier_validators(),
-            miscellaneous_validators(),
-            sequence_validators(),
-            tag_validators(),
+            attribute::attribute_validators(),
+            comments::comments_validators(),
+            enums::enum_validators(),
+            identifiers::identifier_validators(),
+            miscellaneous::miscellaneous_validators(),
+            tag::tag_validators(),
         ]
         .into_iter()
         .flatten()
@@ -177,65 +169,10 @@ impl<T: Member> AsMemberVecExt for Vec<&T> {
     }
 }
 
-fn container_dictionaries<T>(container: &dyn Container<WeakPtr<T>>) -> Vec<&Dictionary>
-where
-    T: Member,
-{
-    container
-        .contents()
-        .iter()
-        .filter_map(|member| match member.borrow().data_type().concrete_type() {
-            Types::Dictionary(dictionary) => Some(dictionary),
-            _ => None,
-        })
-        .collect()
-}
-
-fn member_dictionaries<T>(members: Vec<&T>) -> Vec<&Dictionary>
-where
-    T: Member,
-{
-    members
-        .iter()
-        .filter_map(|member| match member.data_type().concrete_type() {
-            Types::Dictionary(dictionary) => Some(dictionary),
-            _ => None,
-        })
-        .collect()
-}
-
-fn container_sequences<T>(container: &dyn Container<WeakPtr<T>>) -> Vec<&Sequence>
-where
-    T: Member,
-{
-    container
-        .contents()
-        .iter()
-        .filter_map(|member| match member.borrow().data_type().concrete_type() {
-            Types::Sequence(sequence) => Some(sequence),
-            _ => None,
-        })
-        .collect()
-}
-
-fn member_sequences<T>(members: Vec<&T>) -> Vec<&Sequence>
-where
-    T: Member,
-{
-    members
-        .iter()
-        .filter_map(|member| match member.data_type().concrete_type() {
-            Types::Sequence(sequence) => Some(sequence),
-            _ => None,
-        })
-        .collect()
-}
-
 impl<'a> Visitor for ValidatorVisitor<'a> {
     fn visit_class_start(&mut self, class: &Class) {
         self.validate(|validator, ast, diagnostic_reporter| match validator {
             Validator::Attributes(function) => function(class, diagnostic_reporter),
-            Validator::Dictionaries(function) => function(&container_dictionaries(class), diagnostic_reporter),
             Validator::DocComments(function) => function(class, ast, diagnostic_reporter),
             Validator::Entities(function) => function(class, diagnostic_reporter),
             Validator::Identifiers(function) => function(class.fields().get_identifiers(), diagnostic_reporter),
@@ -245,7 +182,6 @@ impl<'a> Visitor for ValidatorVisitor<'a> {
                 diagnostic_reporter,
             ),
             Validator::Members(function) => function(class.fields().as_member_vec(), diagnostic_reporter),
-            Validator::Sequences(function) => function(&container_sequences(class), diagnostic_reporter),
             _ => {}
         });
     }
@@ -279,7 +215,6 @@ impl<'a> Visitor for ValidatorVisitor<'a> {
     fn visit_exception_start(&mut self, exception: &Exception) {
         self.validate(|validator, ast, diagnostic_reporter| match validator {
             Validator::Attributes(function) => function(exception, diagnostic_reporter),
-            Validator::Dictionaries(function) => function(&container_dictionaries(exception), diagnostic_reporter),
             Validator::DocComments(function) => function(exception, ast, diagnostic_reporter),
             Validator::Entities(function) => function(exception, diagnostic_reporter),
             Validator::Identifiers(function) => function(exception.fields().get_identifiers(), diagnostic_reporter),
@@ -289,8 +224,6 @@ impl<'a> Visitor for ValidatorVisitor<'a> {
                 diagnostic_reporter,
             ),
             Validator::Members(function) => function(exception.fields().as_member_vec(), diagnostic_reporter),
-            Validator::Sequences(function) => function(&container_sequences(exception), diagnostic_reporter),
-
             _ => {}
         });
     }
@@ -324,10 +257,6 @@ impl<'a> Visitor for ValidatorVisitor<'a> {
     fn visit_operation_start(&mut self, operation: &Operation) {
         self.validate(|validator, ast, diagnostic_reporter| match validator {
             Validator::Attributes(function) => function(operation, diagnostic_reporter),
-            Validator::Dictionaries(function) => {
-                function(&member_dictionaries(operation.parameters()), diagnostic_reporter);
-                function(&member_dictionaries(operation.return_members()), diagnostic_reporter);
-            }
             Validator::DocComments(function) => function(operation, ast, diagnostic_reporter),
             Validator::Entities(function) => function(operation, diagnostic_reporter),
             Validator::Members(function) => {
@@ -339,16 +268,12 @@ impl<'a> Visitor for ValidatorVisitor<'a> {
                 function(operation.parameters().as_slice(), diagnostic_reporter);
                 function(operation.return_members().as_slice(), diagnostic_reporter);
             }
-            Validator::Sequences(function) => {
-                function(&member_sequences(operation.parameters()), diagnostic_reporter);
-                function(&member_sequences(operation.return_members()), diagnostic_reporter);
-            }
-
             _ => {}
         });
     }
 
     fn visit_parameter(&mut self, parameter: &Parameter) {
+        validate_type_ref(&parameter.data_type, self.diagnostic_reporter);
         self.validate(|validator, _ast, diagnostic_reporter| {
             if let Validator::Attributes(function) = validator {
                 function(parameter, diagnostic_reporter)
@@ -359,18 +284,17 @@ impl<'a> Visitor for ValidatorVisitor<'a> {
     fn visit_struct_start(&mut self, struct_def: &Struct) {
         self.validate(|validator, ast, diagnostic_reporter| match validator {
             Validator::Attributes(function) => function(struct_def, diagnostic_reporter),
-            Validator::Dictionaries(function) => function(&container_dictionaries(struct_def), diagnostic_reporter),
             Validator::DocComments(function) => function(struct_def, ast, diagnostic_reporter),
             Validator::Entities(function) => function(struct_def, diagnostic_reporter),
             Validator::Identifiers(function) => function(struct_def.fields().get_identifiers(), diagnostic_reporter),
             Validator::Members(function) => function(struct_def.fields().as_member_vec(), diagnostic_reporter),
             Validator::Struct(function) => function(struct_def, diagnostic_reporter),
-            Validator::Sequences(function) => function(&container_sequences(struct_def), diagnostic_reporter),
             _ => {}
         });
     }
 
     fn visit_field(&mut self, field: &Field) {
+        validate_type_ref(&field.data_type, self.diagnostic_reporter);
         self.validate(|validator, _ast, diagnostic_reporter| {
             if let Validator::Attributes(function) = validator {
                 function(field, diagnostic_reporter)
@@ -379,20 +303,11 @@ impl<'a> Visitor for ValidatorVisitor<'a> {
     }
 
     fn visit_type_alias(&mut self, type_alias: &TypeAlias) {
+        validate_type_ref(&type_alias.underlying, self.diagnostic_reporter);
         self.validate(|validator, ast, diagnostic_reporter| match validator {
             Validator::Attributes(function) => function(type_alias, diagnostic_reporter),
-            Validator::Dictionaries(function) => {
-                if let Types::Dictionary(dictionary) = type_alias.underlying.concrete_type() {
-                    function(&[dictionary], diagnostic_reporter)
-                }
-            }
             Validator::DocComments(function) => function(type_alias, ast, diagnostic_reporter),
             Validator::Entities(function) => function(type_alias, diagnostic_reporter),
-            Validator::Sequences(function) => {
-                if let Types::Sequence(sequence) = type_alias.underlying.concrete_type() {
-                    function(&[sequence], diagnostic_reporter)
-                }
-            }
             Validator::TypeAlias(function) => function(type_alias, diagnostic_reporter),
             _ => {}
         });

--- a/src/validators/sequence.rs
+++ b/src/validators/sequence.rs
@@ -1,25 +1,8 @@
 // Copyright (c) ZeroC, Inc.
 
 use crate::diagnostics::DiagnosticReporter;
-use crate::grammar::*;
-use crate::validators::dictionary::{has_allowed_key_type, has_allowed_value_type};
-use crate::validators::{ValidationChain, Validator};
+use crate::grammar::Sequence;
 
-pub fn sequence_validators() -> ValidationChain {
-    vec![Validator::Sequences(has_allowed_contents)]
-}
-
-fn has_allowed_contents(sequences: &[&Sequence], diagnostic_reporter: &mut DiagnosticReporter) {
-    sequences.iter().for_each(|s| validate_contents(s, diagnostic_reporter));
-}
-
-fn validate_contents(sequence: &Sequence, diagnostic_reporter: &mut DiagnosticReporter) {
-    match sequence.element_type.concrete_type() {
-        Types::Dictionary(dictionary) => {
-            has_allowed_key_type(&[dictionary], diagnostic_reporter);
-            has_allowed_value_type(&[dictionary], diagnostic_reporter);
-        }
-        Types::Sequence(sequence) => validate_contents(sequence, diagnostic_reporter),
-        _ => {}
-    }
+pub fn validate(sequence: &Sequence, diagnostic_reporter: &mut DiagnosticReporter) {
+    super::validate_type_ref(&sequence.element_type, diagnostic_reporter);
 }


### PR DESCRIPTION
This is my first pass at cleaning up the validators, starting with the place it was needed most: sequences and dictionaries.

I don't fully understand the current implementation due to it's complexity.
But I am confident that my code fully validates sequences and dictionaries.

Now, whenever we come across a type that holds a `TypeRef` (fields, parameters, type aliases, sequences. and dictionaries), we bypass all the complicated validation closures, and call `validate_type_ref` on it. This function checks if the underlying type is a sequence or a dictionary, and calls the appropriate validation function on it. That's it. In the future all the type attributes should probably be checked from this function as well (See #250), but one step at a time.

None of the actual validation logic is changed, this PR just simplifies the ways in which we called them.