### PR TITLE
Deleted Redundant Attribute Errors/Warnings.

### DIFF
--- a/src/diagnostics/errors.rs
+++ b/src/diagnostics/errors.rs
@@ -17,16 +17,6 @@ pub enum Error {
         message: String,
     },
 
-    // ----------------  Attribute Errors ---------------- //
-    /// Used to indicate when the compress attribute cannot be applied.
-    CompressAttributeCannotBeApplied,
-
-    /// Used to indicate when the deprecated attribute cannot be applied.
-    DeprecatedAttributeCannotBeApplied {
-        /// The kind which the deprecated attribute was applied to.
-        kind: String,
-    },
-
     // ---------------- Dictionary Errors ---------------- //
     /// Dictionaries cannot use optional types as keys.
     KeyMustBeNonOptional,
@@ -303,17 +293,6 @@ implement_diagnostic_functions!(
         Syntax,
         format!("{message}"),
         message
-    ),
-    (
-        "E001",
-        CompressAttributeCannotBeApplied,
-        "the compress attribute can only be applied to interfaces and operations"
-    ),
-    (
-        "E002",
-        DeprecatedAttributeCannotBeApplied,
-        format!("the deprecated attribute cannot be applied to {kind}"),
-        kind
     ),
     (
         "E004",

--- a/src/diagnostics/warnings.rs
+++ b/src/diagnostics/warnings.rs
@@ -53,14 +53,6 @@ pub enum Warning {
         deprecation_reason: String,
     },
 
-    /// The user applied an attribute on a type that will result in no changes.
-    InconsequentialUseOfAttribute {
-        /// The attribute that was applied.
-        attribute: String,
-        /// The entity the user applied the attribute to.
-        kind: String,
-    },
-
     /// The doc comment indicated that the operation should throw an invalid type.
     InvalidThrowInDocComment {
         /// The identifier of the type that was indicated to throw.
@@ -119,13 +111,6 @@ implement_diagnostic_functions!(
         format!("'{identifier}' is deprecated {deprecation_reason}"),
         identifier,
         deprecation_reason
-    ),
-    (
-        "W009",
-        InconsequentialUseOfAttribute,
-        format!("'{attribute}' does not have any effect on {kind}"),
-        attribute,
-        kind
     ),
     (
         "W010",

--- a/tests/attribute_tests.rs
+++ b/tests/attribute_tests.rs
@@ -9,6 +9,7 @@ mod attributes {
         use crate::test_helpers::*;
         use slice::diagnostics::{Diagnostic, Error, Warning};
         use slice::grammar::*;
+        use slice::slice_file::Span;
         use test_case::test_case;
 
         #[test_case("Compact", ClassFormat::Compact ; "Compact")]
@@ -142,9 +143,12 @@ mod attributes {
             let diagnostics = parse_for_diagnostics(slice);
 
             // Assert
-            let expected = Diagnostic::new(Error::DeprecatedAttributeCannotBeApplied {
-                kind: "parameter(s)".to_owned(),
-            });
+            let expected = Diagnostic::new(Error::UnexpectedAttribute {
+                attribute: "deprecated".to_owned(),
+            })
+            .set_span(&Span::new((5, 25).into(), (5, 35).into(), "string-0"))
+            .add_note("individual parameters cannot be deprecated", None);
+
             check_diagnostics(diagnostics, [expected]);
         }
 
@@ -339,7 +343,15 @@ mod attributes {
             let diagnostics = parse_for_diagnostics(slice);
 
             // Assert
-            let expected = Diagnostic::new(Error::CompressAttributeCannotBeApplied);
+            let expected = Diagnostic::new(Error::UnexpectedAttribute {
+                attribute: "compress".to_owned(),
+            })
+            .set_span(&Span::new((4, 18).into(), (4, 28).into(), "string-0"))
+            .add_note(
+                "the compress attribute can only be applied to interfaces and operations",
+                None,
+            );
+
             check_diagnostics(diagnostics, [expected]);
         }
 


### PR DESCRIPTION
I'm pruning down the number of attribute related errors/warnings we have before I change them all into warnings,
this PR specifically implements #481.

It does this by deleting the following:
- CompressAttributeCannotBeApplied
- DeprecatedAttributeCannotBeApplied
- InconsequentialUseOfAttribute

Instead, all of these have been replaced by the more generic `UnexpectedAttribute`.
This is far more sustainable than having a separate error for each possible attribute,
and it's more symmetric since `UnexpectedAttribute` is what `slicec-cs` emits when an attribute was wrongly applied to something.

There is a slight regression: `InconsequentialUseOfAttribute` was a warning, but it's been replaced with `UnexpectedAttribute` which is an error. This is fine because my next PR will demote all of these errors into warnings anyways. Hence this regression will only be temporary.

Note: I didn't bother updating the error codes because it's a pain and introduces noise.
Once we're ready to ship, we can go through and fix them all in one shot I figure.