### PR TITLE
Remove Restriction on Tagged Parameter Ordering

### DIFF
--- a/src/diagnostics/errors.rs
+++ b/src/diagnostics/errors.rs
@@ -126,12 +126,6 @@ pub enum Error {
         parameter_identifier: String,
     },
 
-    /// The required parameters of an operation did not precede the optional parameters.
-    RequiredMustPrecedeOptional {
-        /// The identifier of the parameter that caused the error.
-        parameter_identifier: String,
-    },
-
     /// Return tuples for an operation must contain at least two element.
     ReturnTuplesMustContainAtLeastTwoElements,
 
@@ -359,12 +353,6 @@ implement_diagnostic_functions!(
         CannotHaveDuplicateTag,
         format!("invalid tag on member '{identifier}': tags must be unique"),
         identifier
-    ),
-    (
-        "E015",
-        RequiredMustPrecedeOptional,
-        format!("invalid parameter '{parameter_identifier}': required parameters must precede tagged parameters"),
-        parameter_identifier
     ),
     (
         "E016",

--- a/src/validators/tag.rs
+++ b/src/validators/tag.rs
@@ -10,7 +10,6 @@ pub fn tag_validators() -> ValidationChain {
         Validator::Members(tagged_members_cannot_use_classes),
         Validator::Members(tags_are_unique),
         Validator::Struct(compact_structs_cannot_contain_tags),
-        Validator::Parameters(parameter_order),
     ]
 }
 
@@ -40,25 +39,6 @@ fn tags_are_unique(members: Vec<&dyn Member>, diagnostic_reporter: &mut Diagnost
             )
             .report(diagnostic_reporter);
         };
-    });
-}
-
-/// Validate that tagged parameters must follow the required parameters.
-fn parameter_order(parameters: &[&Parameter], diagnostic_reporter: &mut DiagnosticReporter) {
-    // Folding is used to have an accumulator called `seen` that is set to true once a tagged
-    // parameter is found. If `seen` is true on a successive iteration and the parameter has
-    // no tag then we have a required parameter after a tagged parameter.
-    parameters.iter().fold(false, |seen, parameter| match parameter.tag {
-        Some(_) => true,
-        None if seen => {
-            Diagnostic::new(Error::RequiredMustPrecedeOptional {
-                parameter_identifier: parameter.identifier().to_owned(),
-            })
-            .set_span(parameter.data_type.span())
-            .report(diagnostic_reporter);
-            true
-        }
-        None => false,
     });
 }
 

--- a/tests/tag_tests.rs
+++ b/tests/tag_tests.rs
@@ -77,7 +77,7 @@ mod tags {
     }
 
     #[test]
-    fn tagged_parameters_must_be_after_required_parameters() {
+    fn tagged_parameters_can_be_in_any_order() {
         // Arrange
         let slice = "
             encoding = Slice1
@@ -87,19 +87,8 @@ mod tags {
             }
         ";
 
-        // Act
-        let diagnostics = parse_for_diagnostics(slice);
-
-        // Assert
-        let expected = [
-            Diagnostic::new(Error::RequiredMustPrecedeOptional {
-                parameter_identifier: "p3".to_owned(),
-            }),
-            Diagnostic::new(Error::RequiredMustPrecedeOptional {
-                parameter_identifier: "p4".to_owned(),
-            }),
-        ];
-        check_diagnostics(diagnostics, expected);
+        // Act/Assert
+        assert_parses(slice);
     }
 
     #[test]


### PR DESCRIPTION
This PR implements the `slicec` side of #515 by removing the validation function and tests ensuring tags come after required parameters.