### PR TITLE
Fully use `Integer`'s Span Field (and Minor Fixes).

### DIFF
--- a/src/parsers/slice/grammar.lalrpop
+++ b/src/parsers/slice/grammar.lalrpop
@@ -316,18 +316,21 @@ Integer: Integer<i128> = {
 
 SignedInteger: Integer<i128> = {
     <i: Integer> => i,
-    "-" <i: Integer> => Integer { value: -i.value, ..i },
+    <l: @L> "-" <mut i: Integer> => Integer {
+        value: -i.value,
+        span: Span { start: l, ..i.span },
+    }
 }
 
 Tag: Integer<u32> = {
-    tag_keyword "(" <l: @L> <i: SignedInteger> <r: @R> ")" => {
-        parse_tag_value(parser, i, Span::new(l, r, parser.file_name))
+    tag_keyword "(" <i: SignedInteger> ")" => {
+        parse_tag_value(parser, i)
     }
 }
 
 CompactId: Integer<u32> = {
-    "(" <l: @L> <i: SignedInteger> <r: @R> ")" => {
-        parse_compact_id_value(parser, i, Span::new(l, r, parser.file_name))
+    "(" <i: SignedInteger> ")" => {
+        parse_compact_id_value(parser, i)
     }
 }
 

--- a/src/parsers/slice/grammar.rs
+++ b/src/parsers/slice/grammar.rs
@@ -616,11 +616,11 @@ fn try_parse_integer(parser: &mut Parser, s: &str, span: Span) -> Integer<i128> 
     Integer { value, span }
 }
 
-fn parse_tag_value(parser: &mut Parser, i: Integer<i128>, span: Span) -> Integer<u32> {
+fn parse_tag_value(parser: &mut Parser, i: Integer<i128>) -> Integer<u32> {
     // Verify that the provided integer is a valid tag id.
     if !RangeInclusive::new(0, i32::MAX as i128).contains(&i.value) {
         Diagnostic::new(Error::TagValueOutOfBounds)
-            .set_span(&span)
+            .set_span(&i.span)
             .report(parser.diagnostic_reporter)
     }
 
@@ -630,11 +630,11 @@ fn parse_tag_value(parser: &mut Parser, i: Integer<i128>, span: Span) -> Integer
     Integer { value, span: i.span }
 }
 
-fn parse_compact_id_value(parser: &mut Parser, i: Integer<i128>, span: Span) -> Integer<u32> {
+fn parse_compact_id_value(parser: &mut Parser, i: Integer<i128>) -> Integer<u32> {
     // Verify that the provided integer is a valid compact id.
     if !RangeInclusive::new(0, i32::MAX as i128).contains(&i.value) {
         Diagnostic::new(Error::CompactIdOutOfBounds)
-            .set_span(&span)
+            .set_span(&i.span)
             .report(parser.diagnostic_reporter)
     }
 

--- a/src/utils/code_gen_util.rs
+++ b/src/utils/code_gen_util.rs
@@ -32,7 +32,7 @@ pub fn get_bit_sequence_size<T: Member>(encoding: Encoding, members: &[&T]) -> u
 
 /// Takes a slice of Member references and returns two vectors. One containing the required members
 /// and the other containing the tagged members. The tagged vector is sorted by its tags.
-pub fn get_sorted_members<'a, T: Member>(members: &[&'a T]) -> (Vec<&'a T>, Vec<&'a T>) {
+pub fn get_sorted_members<'a, T: Member + ?Sized>(members: &[&'a T]) -> (Vec<&'a T>, Vec<&'a T>) {
     let (mut tagged, required): (Vec<&T>, Vec<&T>) = members.iter().partition(|member| member.is_tagged());
     tagged.sort_by_key(|member| member.tag().unwrap());
     (required, tagged)

--- a/tests/tag_tests.rs
+++ b/tests/tag_tests.rs
@@ -181,7 +181,7 @@ mod tags {
         let expected = Diagnostic::new(Error::CannotHaveDuplicateTag {
             identifier: "b".to_owned(),
         })
-        .add_note("The member 'a' has previous used the tag value '1'", None);
+        .add_note("The tag '1' is already being used by member 'a'", None);
 
         check_diagnostics(diagnostics, [expected]);
     }


### PR DESCRIPTION
**Fixed the spans of integer literals to include the negative sign for negative integers.**
(Currently it only covers the numeric characters).

**Fixed a grammatically incorrect error message:**
Original message: "The member 'a' has previous used the tag value '1'"
New message: "The tag '1' is already being used by member 'a'"

**Updated our logic to take advantage of the 'span' baked into `Integer` elements now.**
`Integer` was added in #407, but only enumerators were updated to take full advantage of their introduction.

This also implements #412 which was opened as a 'next-steps' issue for #407.