### PR TITLE
Stop re-exporting private dependencies.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,14 +11,14 @@ edition = "2021"
 
 [dependencies]
 # derive feature allows structs to derive Parser automatically
-clap = { version = "4.2.1", features = ["derive"] }
+clap = { version = "4.2.7", features = ["derive"] }
 console = "0.15.5"
 convert_case = "0.6.0"
 in_definite = "0.2.5"
 lalrpop-util = "0.20.0"
 # derive feature allows structs to derive Serialize automatically
-serde = { version="1.0.159", features = ["derive"] }
-serde_json = "1.0.95"
+serde = { version="1.0.162", features = ["derive"] }
+serde_json = "1.0.96"
 
 [build-dependencies]
 # The default features enable a built-in lexer. We supply our own lexer so we don't need these.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,11 +14,6 @@ pub mod utils;
 pub mod validators;
 pub mod visitor;
 
-// Re-export the `clap`, `convert_case`, and `in_definite` dependencies.
-pub extern crate clap;
-pub extern crate convert_case;
-pub extern crate in_definite;
-
 use command_line::SliceOptions;
 use compilation_state::CompilationState;
 use slice_file::SliceFile;


### PR DESCRIPTION
For the reasons mentioned in #542, this PR removes the re-exports of our private dependencies.
"Private" meaning those that never appear in the public API.

It also updates our dependencies; I checked their changelogs and there are no breaking changes.