### PR TITLE
Fix Underlining Missing Last Character of Snippets

### DIFF
--- a/src/slice_file.rs
+++ b/src/slice_file.rs
@@ -163,7 +163,10 @@ impl SliceFile {
             } else {
                 // If the provided range is between 2 locations, underline everything between them.
                 let underline_start = start_pos.saturating_sub(self.line_positions[line_number - 1]);
-                let underline_end = line.len() - (self.line_positions[line_number] - 1).saturating_sub(end_pos);
+                let underline_end = match (self.line_positions[line_number] - 1).checked_sub(end_pos) {
+                    Some(pos) => line.len() - pos, // If the end position is on this line.
+                    None => line.trim_end().len(), // If the end position is past the end of this line.
+                };
                 let underline_length = underline_end - underline_start;
                 let underline = style(format!("{:-<1$}", "", underline_length)).yellow().bold();
                 writeln!(

--- a/tests/diagnostic_output_tests.rs
+++ b/tests/diagnostic_output_tests.rs
@@ -46,21 +46,21 @@ mod output {
 
     #[test]
     fn output_to_console() {
-        let slice = r#"
+        let slice = "
         module Foo
 
         interface I {
             /// @param x: this is an x
-            op1()
+            op1()\r
 
             op2(tag(1)
-    x:
+    x:\r
                     int32, tag(2) y: bool?,
             )
         }
-
-        enum E: int8 {}
-        "#;
+\r
+        enum E: int8 {}\r
+        ";
 
         // Disable ANSI color codes.
         let options = SliceOptions {
@@ -89,7 +89,7 @@ error [E019]: invalid tag on member 'x': tagged members must be optional
    |
 8  |             op2(tag(1)
    |                 ------
-9  |     x:
+9  |     x:\r
    | ------
 10 |                     int32, tag(2) y: bool?,
    | -------------------------
@@ -97,7 +97,7 @@ error [E019]: invalid tag on member 'x': tagged members must be optional
 error [E010]: invalid enum 'E': enums must contain at least one enumerator
  --> string-0:14:9
    |
-14 |         enum E: int8 {}
+14 |         enum E: int8 {}\r
    |         ------
    |
 ";


### PR DESCRIPTION
This PR fixes #555.
I believe the problem was that our logic operates on character indexes, and `\r` and `\n` are both counted as characters by us.

But the function that we were using to iterate over the lines of a snippet (`str::lines`) would match either `\n` or `\r\n` as a single 'newline' character. So `\r\n` would get treated as 1 character by Rust, and 2 characters by us, causing us to be off by a single character.

`str::split_terminator` is equivalent to `str::lines`, except we can tell it it to _only_ match `\n` and leave any `\r` untouched, so they're always counted as a correct number of characters.

----

Question for the reviewers:
1) Can you test this on your computers to make this is correct, and that snippet underlining still works on platforms that don't use `\r\n` newlines?
2) Should we bother testing this? And if so, how?