### PR TITLE
Removed 'AST' from Validator Functions.

### DIFF
--- a/src/validators/comments.rs
+++ b/src/validators/comments.rs
@@ -1,6 +1,5 @@
 // Copyright (c) ZeroC, Inc.
 
-use crate::ast::Ast;
 use crate::diagnostics::{Diagnostic, DiagnosticReporter, Warning};
 use crate::grammar::*;
 use crate::validators::{ValidationChain, Validator};
@@ -67,7 +66,7 @@ fn operation_missing_throws(operation: &Operation, diagnostic_reporter: &mut Dia
     }
 }
 
-fn only_operations_can_throw(commentable: &dyn Commentable, _: &Ast, diagnostic_reporter: &mut DiagnosticReporter) {
+fn only_operations_can_throw(commentable: &dyn Commentable, diagnostic_reporter: &mut DiagnosticReporter) {
     let supported_on = ["operation"];
     if let Some(comment) = commentable.comment() {
         if !supported_on.contains(&commentable.kind()) && !comment.throws.is_empty() {


### PR DESCRIPTION
This PR removes the 'ast' parameter from all of our validator functions, because it wasn't used anywhere.
I'm opening this PR in case anyone knows why we have it: maybe we'll need it for some future validation?
Or had that validation, but it got deleted somewhere along the refactoring?

It's probably just an oddity from our Validator setup, but figured I'd ask to make sure : v)

PS: sorry if this steps on anyone's toes.
This was originally part of my PR for removing doc comments from params and modules, but I split it off to avoid merge conflicts.