### PR TITLE
Simplify TypeRef validation

### DIFF
--- a/src/validators/dictionary.rs
+++ b/src/validators/dictionary.rs
@@ -3,13 +3,11 @@
 use crate::diagnostics::{Diagnostic, DiagnosticReporter, Error};
 use crate::grammar::*;
 
-pub fn validate(dictionary: &Dictionary, diagnostic_reporter: &mut DiagnosticReporter) {
+pub fn validate_dictionary(dictionary: &Dictionary, diagnostic_reporter: &mut DiagnosticReporter) {
     has_allowed_key_type(dictionary, diagnostic_reporter);
-    super::validate_type_ref(&dictionary.key_type, diagnostic_reporter);
-    super::validate_type_ref(&dictionary.value_type, diagnostic_reporter);
 }
 
-pub fn has_allowed_key_type(dictionary: &Dictionary, diagnostic_reporter: &mut DiagnosticReporter) {
+fn has_allowed_key_type(dictionary: &Dictionary, diagnostic_reporter: &mut DiagnosticReporter) {
     if let Some(e) = check_dictionary_key_type(&dictionary.key_type) {
         e.report(diagnostic_reporter)
     }

--- a/src/validators/sequence.rs
+++ b/src/validators/sequence.rs
@@ -1,8 +1,0 @@
-// Copyright (c) ZeroC, Inc.
-
-use crate::diagnostics::DiagnosticReporter;
-use crate::grammar::Sequence;
-
-pub fn validate(sequence: &Sequence, diagnostic_reporter: &mut DiagnosticReporter) {
-    super::validate_type_ref(&sequence.element_type, diagnostic_reporter);
-}


### PR DESCRIPTION
This PR simplifies `TypeRef` validation by moving the logic to use the new visitor function.