### PR TITLE
Split the `NamedSymbol` and `ScopedSymbol` Traits.

### DIFF
--- a/src/grammar/traits.rs
+++ b/src/grammar/traits.rs
@@ -21,27 +21,11 @@ pub trait ScopedSymbol: Symbol {
     fn raw_scope(&self) -> &Scope;
 }
 
-pub trait NamedSymbol: ScopedSymbol {
+pub trait NamedSymbol: Symbol {
     fn identifier(&self) -> &str;
     fn raw_identifier(&self) -> &Identifier;
-
-    fn module_scoped_identifier(&self) -> String {
-        let module_scope = self.module_scope().to_owned();
-        if module_scope.is_empty() {
-            self.identifier().to_owned()
-        } else {
-            module_scope + "::" + self.identifier()
-        }
-    }
-
-    fn parser_scoped_identifier(&self) -> String {
-        let parser_scope = self.parser_scope().to_owned();
-        if parser_scope.is_empty() {
-            self.identifier().to_owned()
-        } else {
-            parser_scope + "::" + self.identifier()
-        }
-    }
+    fn module_scoped_identifier(&self) -> String;
+    fn parser_scoped_identifier(&self) -> String;
 }
 
 pub trait Attributable {
@@ -70,7 +54,7 @@ pub trait Attributable {
     }
 }
 
-pub trait Entity: NamedSymbol + Attributable + AsEntities {
+pub trait Entity: ScopedSymbol + NamedSymbol + Attributable + AsEntities {
     fn get_deprecation(&self) -> Option<Option<String>> {
         self.attributes().into_iter().find_map(Attribute::match_deprecated)
     }
@@ -156,6 +140,14 @@ macro_rules! implement_Named_Symbol_for {
 
             fn raw_identifier(&self) -> &Identifier {
                 &self.identifier
+            }
+
+            fn module_scoped_identifier(&self) -> String {
+                util::get_scoped_identifier(self.identifier(), self.module_scope())
+            }
+
+            fn parser_scoped_identifier(&self) -> String {
+                util::get_scoped_identifier(self.identifier(), self.parser_scope())
             }
         }
     };

--- a/src/grammar/util.rs
+++ b/src/grammar/util.rs
@@ -48,6 +48,15 @@ impl Scope {
     }
 }
 
+/// Returns the scoped version of the provided identifier.
+pub fn get_scoped_identifier(identifier: &str, scope: &str) -> String {
+    if scope.is_empty() {
+        identifier.to_owned()
+    } else {
+        scope.to_owned() + "::" + identifier
+    }
+}
+
 /// This enum specifies all the encodings supported by IceRPC.
 ///
 /// These encodings identity the format used to convert Slice types to and from byte streams.

--- a/src/parsers/slice/grammar.rs
+++ b/src/parsers/slice/grammar.rs
@@ -611,7 +611,7 @@ fn parse_doc_comment(parser: &mut Parser, identifier: &str, raw_comment: RawDocC
         // If the doc comment had 0 lines, that just means there is no doc comment.
         None
     } else {
-        let scoped_identifier = parser.current_scope.raw_parser_scope.to_owned() + "::" + identifier;
+        let scoped_identifier = get_scoped_identifier(identifier, &parser.current_scope.raw_parser_scope);
         let comment_parser = CommentParser::new(parser.file_name, &scoped_identifier, parser.diagnostics);
         comment_parser.parse_doc_comment(raw_comment).ok()
     }


### PR DESCRIPTION
Currently, we have this trait heirarchy:
`NamedSymbol` <- `ScopedSymbol` <- `Symbol`
But there's really no reason for `NamedSymbol` to require `ScopedSymbol`, so this PR decouples them.

Now there's `Symbol` and 2 more specific kinds of symbols:
`NamedSymbol` (those with names) & `ScopedSymbol` (those in a scope), and these two have no relation to each other.

---

This change is motivated by the new module restriction.
With the new semantics, modules shouldn't implement `ScopedSymbol` anymore, but they _should_ implement `NamedSymbol`.
They have a a name, but they aren't logically within a scope anymore. Modules _are_ the scopes now.

In the past, modules could totally be within a scope: `module Outer { module Inner {}}` (Inner is within the scope of Outer).