### PR TITLE
Allow Underscores in Interger Literals.

### DIFF
--- a/src/parsers/slice/grammar.rs
+++ b/src/parsers/slice/grammar.rs
@@ -511,12 +511,15 @@ fn try_construct_attribute(
 }
 
 fn try_parse_integer(parser: &mut Parser, s: &str, span: Span) -> Integer<i128> {
+    // Remove any underscores from the integer literal before trying to parse it.
+    let sanitized = s.replace('_', "");
+
     // Check the literal for a base prefix. If present, remove it and set the base.
     // "0b" = binary, "0x" = hexadecimal, otherwise we assume it's decimal.
-    let (literal, base) = match s {
-        _ if s.starts_with("0b") => (&s[2..], 2),
-        _ if s.starts_with("0x") => (&s[2..], 16),
-        _ => (s, 10),
+    let (literal, base) = match sanitized {
+        _ if sanitized.starts_with("0b") => (&sanitized[2..], 2),
+        _ if sanitized.starts_with("0x") => (&sanitized[2..], 16),
+        _ => (sanitized.as_str(), 10),
     };
 
     let value = match i128::from_str_radix(literal, base) {

--- a/src/parsers/slice/lexer.rs
+++ b/src/parsers/slice/lexer.rs
@@ -106,26 +106,12 @@ where
 
     /// Reads, consumes, and returns a string of alphanumeric characters from the buffer.
     /// After calling this function, the next character will be a non-alphanumeric character or `None` (end of buffer).
-    fn read_identifier(&mut self) -> &'input str {
+    fn read_alphanumeric(&mut self) -> &'input str {
         let start_position = self.get_position();
 
         // Loop while the next character in the buffer is alphanumeric or an underscore.
         while matches!(self.buffer.peek(), Some((_, c)) if (c.is_alphanumeric() || *c == '_')) {
             self.advance_buffer(); // Consume the alphanumeric character.
-        }
-
-        let end_position = self.get_position();
-        &self.current_block.content[start_position..end_position]
-    }
-
-    /// Reads, consumes, and returns a string of numeric characters from the buffer.
-    /// After calling this function, the next character will be a non-numeric character or `None` (end of buffer).
-    fn read_integer_literal(&mut self) -> &'input str {
-        let start_position = self.get_position();
-
-        // Loop while the next character in the buffer is alphanumeric (because we support hex literals).
-        while matches!(self.buffer.peek(), Some((_, c)) if c.is_alphanumeric()) {
-            self.advance_buffer(); // Consume the numeric character.
         }
 
         let end_position = self.get_position();
@@ -361,7 +347,7 @@ where
                 self.advance_buffer(); // Consume the '\' character.
                                        // Check if the next character could be the start of an identifier.
                 if matches!(self.buffer.peek(), Some((_, ch)) if ch.is_alphabetic() || *ch == '_') {
-                    let identifier = self.read_identifier();
+                    let identifier = self.read_alphanumeric();
                     Some(Ok((start_location, TokenKind::Identifier(identifier), self.cursor)))
                 } else {
                     // The token is just "\", indicating a syntax error. '\' on its own isn't a valid Slice token.
@@ -375,14 +361,14 @@ where
             _ if c.is_alphabetic() || c == '_' => {
                 let token = if self.attribute_mode {
                     // If we're lexing an attribute, return the identifier as-is, without checking if it's a keyword.
-                    TokenKind::Identifier(self.read_identifier())
+                    TokenKind::Identifier(self.read_alphanumeric())
                 } else {
-                    Self::check_if_keyword(self.read_identifier())
+                    Self::check_if_keyword(self.read_alphanumeric())
                 };
                 Some(Ok((start_location, token, self.cursor)))
             }
             _ if c.is_numeric() => {
-                let integer = self.read_integer_literal();
+                let integer = self.read_alphanumeric();
                 Some(Ok((start_location, TokenKind::IntegerLiteral(integer), self.cursor)))
             }
             _ if c.is_whitespace() => {

--- a/src/parsers/slice/tokens.rs
+++ b/src/parsers/slice/tokens.rs
@@ -19,7 +19,7 @@ pub enum TokenKind<'input> {
 
     /// A string of alphanumeric characters that starts with a number.
     /// We allow alphanumeric characters to support hex literals.
-    IntegerLiteral(&'input str), // "[0-9][a-zA-Z0-9]*"
+    IntegerLiteral(&'input str), // "[0-9][_a-zA-Z0-9]*"
 
     /// A string literal consists of any non-newline characters contained within a pair of unescaped double-quotes.
     /// Note that the value doesn't contain the enclosing quotation marks, only the characters in between them.

--- a/tests/parser_tests.rs
+++ b/tests/parser_tests.rs
@@ -4,6 +4,7 @@ mod test_helpers;
 
 use crate::test_helpers::*;
 use slicec::diagnostics::{Diagnostic, Error};
+use slicec::grammar::Enumerator;
 use slicec::slice_file::Span;
 
 #[test]
@@ -54,6 +55,25 @@ fn string_literals_cannot_contain_newlines() {
     .set_span(&span);
 
     check_diagnostics(diagnostics, [expected]);
+}
+
+#[test]
+fn integer_literals_can_contain_underscores() {
+    // Arrange
+    let slice = "
+        module Test
+
+        enum Foo: int32 {
+            A = 17_000_000
+        }
+    ";
+
+    // Act
+    let ast = parse_for_ast(slice);
+
+    // Assert
+    let enumerator = ast.find_element::<Enumerator>("Test::Foo::A").unwrap();
+    assert_eq!(enumerator.value(), 17_000_000);
 }
 
 // Ensure a syntax error in one file doesn't affect how we parse other files; See: github.com/icerpc/slicec/issues/559.


### PR DESCRIPTION
This fixes #586 by allowing users to write underscores in integer literals.
Integer literals must still start with a numeric character, otherwise the underscore is allowed anywhere else (even trailing) and we always just ignore them.