### PR TITLE
Doc Comments Must Start with Exactly 3 '/' Characters

### DIFF
--- a/src/parsers/slice/lexer.rs
+++ b/src/parsers/slice/lexer.rs
@@ -311,11 +311,17 @@ where
                     // The token is at least '//', indicating a line comment.
                     Some((_, '/')) => {
                         self.advance_buffer(); // Consume the 2nd '/' character.
-                                               // Check there is a 3rd '/' character indicating this a doc comment.
-                        let is_doc_comment = matches!(self.buffer.peek(), Some((_, '/')));
+
+                        // Check if there's a 3rd '/' character indicating this may be a doc comment.
+                        let mut is_doc_comment = matches!(self.buffer.peek(), Some((_, '/')));
                         if is_doc_comment {
                             self.advance_buffer(); // Consume the 3rd '/' character.
+
+                            // Check if there's a 4th '/' character, which would turn this back into a non-doc comment.
+                            // Doc comments must start with _exactly_ 3 '/' characters.
+                            is_doc_comment = !matches!(self.buffer.peek(), Some((_, '/')));
                         }
+
                         let content_start_loc = self.cursor;
                         let comment = self.read_line_comment();
                         match is_doc_comment {

--- a/tests/comment_tests.rs
+++ b/tests/comment_tests.rs
@@ -437,6 +437,26 @@ mod comments {
     }
 
     #[test]
+    fn doc_comments_must_start_with_exactly_3_slashes() {
+        // Arrange
+        let slice = "
+            module Test
+
+            //// This is not a doc comment.
+            struct Foo {}
+        ";
+
+        // Act
+        let ast = parse_for_ast(slice);
+
+        // Assert
+        let struct_def = ast.find_element::<Struct>("Test::Foo").unwrap();
+        let struct_doc = struct_def.comment();
+
+        assert!(struct_doc.is_none());
+    }
+
+    #[test]
     fn doc_comment_linked_identifiers() {
         // Arrange
         let slice = "


### PR DESCRIPTION
This fixes #615.