### PR TITLE
Let Clap Parse Arguments to the 'allow' CLI Option

### DIFF
--- a/src/diagnostics/diagnostic_reporter.rs
+++ b/src/diagnostics/diagnostic_reporter.rs
@@ -25,19 +25,14 @@ pub struct DiagnosticReporter {
 
 impl DiagnosticReporter {
     pub fn new(slice_options: &SliceOptions) -> Self {
-        let mut diagnostic_reporter = DiagnosticReporter {
+        DiagnosticReporter {
             diagnostics: Vec::new(),
             error_count: 0,
             warning_count: 0,
             diagnostic_format: slice_options.diagnostic_format,
             disable_color: slice_options.disable_color,
             allowed_warnings: slice_options.allowed_warnings.clone(),
-        };
-
-        // Validate any arguments passed to `--allow` on the command line.
-        attributes::validate_allow_arguments(&slice_options.allowed_warnings, None, &mut diagnostic_reporter);
-
-        diagnostic_reporter
+        }
     }
 
     /// Checks if any errors have been reported during compilation.

--- a/src/grammar/attributes/allow.rs
+++ b/src/grammar/attributes/allow.rs
@@ -12,7 +12,36 @@ impl Allow {
         debug_assert_eq!(directive, Self::directive());
 
         check_that_arguments_were_provided(args, Self::directive(), span, reporter);
-        validate_allow_arguments(args, Some(span), reporter);
+
+        for arg in args {
+            let mut is_valid = Warning::ALLOWABLE_WARNING_IDENTIFIERS.contains(&arg.as_str());
+
+            // The `DuplicateFile` lint can't be configured by attributes because it's a command-line specific warning.
+            if arg == "DuplicateFile" {
+                is_valid = false;
+            }
+
+            // Emit an error if the argument wasn't valid.
+            if !is_valid {
+                // TODO we should emit a link to the warnings page when we write it!
+                let mut error = Diagnostic::new(Error::ArgumentNotSupported {
+                    argument: arg.to_owned(),
+                    directive: "allow".to_owned(),
+                })
+                .set_span(span);
+
+                // Check if the argument only differs in case from a valid one.
+                let suggestion = Warning::ALLOWABLE_WARNING_IDENTIFIERS
+                    .iter()
+                    .find(|identifier| identifier.eq_ignore_ascii_case(arg));
+                if let Some(identifier) = suggestion {
+                    let message = format!("attribute arguments are case sensitive, perhaps you meant '{identifier}'?");
+                    error = error.add_note(message, None);
+                }
+
+                error.report(reporter);
+            }
+        }
 
         let allowed_warnings = args.clone();
         Allow { allowed_warnings }
@@ -26,41 +55,3 @@ impl Allow {
 }
 
 implement_attribute_kind_for!(Allow, "allow", true);
-
-// This is a standalone function because it's used by both the `allow` attribute, and the `--allow` CLI option.
-pub fn validate_allow_arguments(arguments: &[String], span: Option<&Span>, reporter: &mut DiagnosticReporter) {
-    for argument in arguments {
-        let argument_str = &argument.as_str();
-        let mut is_valid = Warning::ALLOWABLE_WARNING_IDENTIFIERS.contains(argument_str);
-
-        // We don't allow `DuplicateFile` to be suppressed by attributes, because it's a command-line specific warning.
-        // This check works because `span` is `None` for command line flags.
-        if argument == "DuplicateFile" && span.is_some() {
-            is_valid = false;
-        }
-
-        // Emit an error if the argument wasn't valid.
-        if !is_valid {
-            // TODO we should emit a link to the warnings page when we write it!
-            let mut error = Diagnostic::new(Error::ArgumentNotSupported {
-                argument: argument.to_owned(),
-                directive: "allow".to_owned(),
-            });
-
-            if let Some(unwrapped_span) = span {
-                error = error.set_span(unwrapped_span);
-            }
-
-            // Check if the argument only differs in case from a valid one.
-            let suggestion = Warning::ALLOWABLE_WARNING_IDENTIFIERS
-                .iter()
-                .find(|identifier| identifier.eq_ignore_ascii_case(argument_str));
-            if let Some(identifier) = suggestion {
-                let message = format!("attribute arguments are case sensitive, perhaps you meant '{identifier}'?");
-                error = error.add_note(message, None);
-            }
-
-            error.report(reporter);
-        }
-    }
-}

--- a/src/slice_options.rs
+++ b/src/slice_options.rs
@@ -1,5 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
+use crate::diagnostics::Warning;
 use clap::ArgAction::Append;
 use clap::{Parser, ValueEnum};
 use serde::Serialize;
@@ -25,7 +26,7 @@ pub struct SliceOptions {
     pub defined_symbols: Vec<String>,
 
     /// Instruct the compiler to allow (not emit) the specified warning.
-    #[arg(short = 'A', long = "allow", value_name="WARNING", num_args = 1, action = Append)]
+    #[arg(short = 'A', long = "allow", value_name="WARNING", value_parser = Warning::ALLOWABLE_WARNING_IDENTIFIERS, num_args = 1, action = Append)]
     pub allowed_warnings: Vec<String>,
 
     /// Validate input files without generating code for them.


### PR DESCRIPTION
This PR fixes #614 by making Clap aware of what arguments can be passed to `--allow`.
A side-effect of this is that Clap now also handles the parsing of these arguments.

This actually makes our code cleaner, since we don't have to do this parsing ourselves anymore,
but means that if a user mis-types an argument, they'll get a Clap error, instead of one of our errors.
See #429.