### PR TITLE
Made the CLI options more consistent.

### DIFF
--- a/src/slice_options.rs
+++ b/src/slice_options.rs
@@ -37,7 +37,7 @@ pub struct SliceOptions {
     #[arg(short = 'O', long, value_name = "DIRECTORY")]
     pub output_dir: Option<String>,
 
-    /// Specify how the compiler should emit errors and warnings.
+    /// Set which format to emit errors and warnings with.
     #[arg(long, value_name = "FORMAT", value_enum, default_value_t = DiagnosticFormat::Human, ignore_case = true)]
     pub diagnostic_format: DiagnosticFormat,
 


### PR DESCRIPTION
This PR improves the CLI options.
- Their attributes are in a consistent order
- We treat all options as case-insensitive (the ones that we directly parse at least).
- All the possible values we emit are in `snake-case` now.

This is what the user will see when they type `--help` with these changes:
```
Usage: parse [OPTIONS] <SOURCES>...

Arguments:
  <SOURCES>...
          List of Slice files to compile

Options:
  -R <REFERENCE>
          Add a directory or Slice file to the list of references

  -D <SYMBOL>
          Define a preprocessor symbol

  -A, --allow <LINT_NAME>
          Instruct the compiler to allow the specified lint

      --dry-run
          Validate input files without generating code for them

  -O, --output-dir <DIRECTORY>
          Set the output directory for the generated code. Defaults to the current working directory

      --diagnostic-format <FORMAT>
          Specify what format the compiler should use to emit errors and warnings
          
          [default: human]

          Possible values:
          - human: Diagnostics are printed to the console in an easily readable format with source code snippets when possible
          - json: Diagnostics will be serialized as JSON objects and printed to the console, one diagnostic per line

      --disable-color
          Disable ANSI color codes in diagnostic output

  -h, --help
          Print help (see a summary with '-h')
```

And after https://github.com/icerpc/icerpc-csharp/pull/3514 is merged, `slicec-cs` will also have this in it's help:
```
      --rpc <RPC_PROVIDER>
          Specify which RPC framework the generated code will be used with
          
          [default: icerpc]

          Possible values:
          - none:   No RPC framework is being used. With this set, the generated code is purely for encoding and decoding data
          - icerpc: IceRPC is being used. With this set, a `using IceRPC.Slice` statement is added to the preamble of any generated code
```