### PR TITLE
Remove Note Indentation

### DIFF
--- a/src/diagnostic_emitter.rs
+++ b/src/diagnostic_emitter.rs
@@ -68,9 +68,8 @@ impl<'a, T: Write> DiagnosticEmitter<'a, T> {
             for note in diagnostic.notes() {
                 writeln!(
                     self.output,
-                    "    {} {}: {:}",
-                    console::style("=").blue().bold(),
-                    console::style("note").bold(),
+                    "{}: {}",
+                    console::style("note").blue().bold(),
                     console::style(&note.message).bold(),
                 )?;
 


### PR DESCRIPTION
This fixes #626, where notes are weirdly indented sometimes.
Now we just don't indent notes, they sit at the start of a line, same as warnings and errors.
I think this is the simplest fix.

#### New note appearance
![image](https://github.com/icerpc/slicec/assets/25963603/0c7b0723-2346-4bff-8e86-5a278b538c6d)
![image](https://github.com/icerpc/slicec/assets/25963603/04cb59f0-bf18-42f7-8beb-1373fc2c3709)
