### PR TITLE
Rewrote README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,21 +10,21 @@
 To build slicec you must have Rust and Cargo installed.
 To install these, we recommend reading the following [guide](https://doc.rust-lang.org/cargo/getting-started/installation.html).
 
-### Building
+## Building
 
 Run the following command to build slicec and its dependencies:
 ```shell
 cargo build
 ```
 
-### Running the tests
+## Running the tests
 
 Run the following command to run the test suite:
 ```shell
 cargo test
 ```
 
-### Generating documentation
+## Generating documentation
 
 To generate documentation for slicec, run the following command:
 ```shell
@@ -37,7 +37,7 @@ Additionally, you can easily view the documentation after generating it with the
 cargo doc --no-deps --document-private-items --open
 ```
 
-### Generating a code coverage report
+## Generating a code coverage report
 
 slicec uses [llvm-cov](https://crates.io/crates/cargo-llvm-cov) to generate coverage reports.
 So, to generate reports you must install it:


### PR DESCRIPTION
This PR rewrites the README to include more up-to-date and cross-platform instructions/information. (See #609)

It also removes the sections about how to invoke the compiler, since this is going to be fundamentally changed by 0.2,
when `slicec` becomes a standalone executable that outputs an encoded AST.
I can add it back if you prefer... I wrote sections for:
- How to use the compiler (with the `compile_from_options` entry function).
- How to run the compiler directly (with `cargo run --example parse ...`).

But I ended up deleting them for the above-mentioned reason.