### PR TITLE
Improve Escape Sequences in String Literals

### DIFF
--- a/src/parsers/slice/grammar.lalrpop
+++ b/src/parsers/slice/grammar.lalrpop
@@ -275,7 +275,7 @@ Attribute: WeakPtr<Attribute> = {
 }
 
 AttributeArgument: String = {
-    <sl: string_literal> => sl.replace('\\', ""),
+    <sl: string_literal> => unescape_string_literal(sl),
     <i: identifier> => i.to_owned(),
 }
 

--- a/src/parsers/slice/grammar.rs
+++ b/src/parsers/slice/grammar.rs
@@ -508,13 +508,17 @@ fn construct_attribute(
 }
 
 fn unescape_string_literal(s: &str) -> String {
+    // Flag that stores whether the next character we read is being escaped.
     let mut is_escaped = false;
     s.chars()
         .filter(|c| {
-            // If `c` is a backslash that isn't escaped, set that the next character is escaped,
-            // and return false to remove the backslash from the string.
-            is_escaped = *c == '\\' && !is_escaped;
-            !is_escaped
+            // If `c` is a backslash, and it isn't already escaped (ie: "\\"), then it is an escape character.
+            let is_escape_character = *c == '\\' && !is_escaped;
+            // Set `is_escaped` accordingly, so we know if the next character is being escaped.
+            is_escaped = is_escape_character;
+
+            // Return false for escape characters to filter them out of the string.
+            !is_escape_character
         })
         .collect()
 }

--- a/src/parsers/slice/grammar.rs
+++ b/src/parsers/slice/grammar.rs
@@ -507,6 +507,18 @@ fn construct_attribute(
     parser.ast.add_element(OwnedPtr::new(attribute))
 }
 
+fn unescape_string_literal(s: &str) -> String {
+    let mut is_escaped = false;
+    s.chars()
+        .filter(|c| {
+            // If `c` is a backslash that isn't escaped, set that the next character is escaped,
+            // and return false to remove the backslash from the string.
+            is_escaped = *c == '\\' && !is_escaped;
+            !is_escaped
+        })
+        .collect()
+}
+
 fn try_parse_integer(parser: &mut Parser, s: &str, span: Span) -> Integer<i128> {
     // Remove any underscores from the integer literal before trying to parse it.
     let sanitized = s.replace('_', "");

--- a/tests/parser_tests.rs
+++ b/tests/parser_tests.rs
@@ -63,7 +63,7 @@ fn string_literals_support_character_escaping() {
     let slice = r#"
         module Test
 
-        [deprecated("This is a \"bad\" type.")]
+        [deprecated("This is a backslash\"\\\"\n.")]
         struct Foo {}
     "#;
 
@@ -73,7 +73,7 @@ fn string_literals_support_character_escaping() {
     // Assert
     let struct_def = ast.find_element::<Struct>("Test::Foo").unwrap();
     let deprecated = struct_def.find_attribute::<attributes::Deprecated>().unwrap();
-    assert_eq!(deprecated.reason, Some("This is a \"bad\" type.".to_owned()))
+    assert_eq!(deprecated.reason, Some("This is a backslash\"\\\"n.".to_owned()))
 }
 
 #[test]


### PR DESCRIPTION
This PR fixes #658 and our escaping logic in general.
Now, whenever you type `\X` in a string literal, it will always be mapped to `X`.
`\\` -> `\`
`\"` -> `"`
`\n` -> `n`
`\8` -> `8`
Slice performs no additional processing, so we don't support special escape sequences like `\n` or `\uxxxx`...
But if a user wants to pass these through to their mapping, they still can with something like `\\n`.