### PR TITLE
Support Scoped Exceptions in 'throws' doc-comments Tags.

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -95,7 +95,7 @@ impl Ast {
     }
 
     /// Returns a reference to the AST [node](Node) with the provided identifier, if one exists.
-    /// The identifier must be globally scoped, since this method performs no scope resolution.
+    /// The identifier must be fully qualified, since this performs no scope resolution, but cannot begin with '::'.
     ///
     /// Anonymous types (those without identifiers) cannot be looked up. This only includes sequences and dictionaries.
     /// Primitive types can be looked up by their Slice keywords. Care should be taken when looking up modules (which
@@ -199,7 +199,7 @@ impl Ast {
     }
 
     /// Returns a reference to a Slice element with the provided identifier and specified type, if one exists.
-    /// The identifier must be globally scoped, since this method performs no scope resolution.
+    /// The identifier must be fully qualified, since this performs no scope resolution, but cannot begin with '::'.
     ///
     /// Anonymous types (those without identifiers) cannot be looked up. This only includes sequences and dictionaries.
     /// Primitive types can be looked up by their Slice keywords. Care should be taken when looking up modules (which

--- a/src/parsers/comments/grammar.lalrpop
+++ b/src/parsers/comments/grammar.lalrpop
@@ -77,7 +77,7 @@ ReturnsBlock: ReturnsTag = {
 }
 
 ThrowsBlock: ThrowsTag = {
-    <l: @L> throws_keyword <identifier: Identifier> <message: Section> <r: @R> => {
+    <l: @L> throws_keyword <identifier: ScopedIdentifier> <message: Section> <r: @R> => {
         let span = Span::new(l, r, comment_parser.file_name);
         let thrown_type = TypeRefDefinition::Unpatched(identifier);
         ThrowsTag { thrown_type, message, span }


### PR DESCRIPTION
This PR fixes #661 (and a slightly confusing doc comment).