### PR TITLE
Add Support for Enums with Associated Fields

### DIFF
--- a/src/diagnostics/errors.rs
+++ b/src/diagnostics/errors.rs
@@ -550,7 +550,7 @@ implement_diagnostic_functions!(
     (
         "E054",
         EnumeratorCannotDeclareAssociatedFields,
-        format!("invalid enumerator '{enumerator_identifier}': associated fields cannot be declared within enums that specify underlying types"),
+        format!("invalid enumerator '{enumerator_identifier}': associated fields cannot be declared within enums that specify an underlying type"),
         enumerator_identifier
     )
 );

--- a/src/diagnostics/errors.rs
+++ b/src/diagnostics/errors.rs
@@ -74,6 +74,16 @@ pub enum Error {
         enumerator_value: i128,
     },
 
+    /// Enumerators cannot declare explicit values when their enclosing enum doesn't have an underlying type.
+    EnumeratorCannotDeclareExplicitValue {
+        enumerator_identifier: String,
+    },
+
+    /// Enumerators cannot declare associated fields when their enclosing enum has an underlying type.
+    EnumeratorCannotDeclareAssociatedFields {
+        enumerator_identifier: String,
+    },
+
     /// Enums cannot have optional underlying types.
     CannotUseOptionalUnderlyingType {
         /// The identifier of the enum.
@@ -530,6 +540,18 @@ implement_diagnostic_functions!(
         "E052",
         ExceptionSpecificationNotSupported,
         "exceptions can only be thrown by operations defined in Slice1 mode"
+    ),
+    (
+        "E053",
+        EnumeratorCannotDeclareExplicitValue,
+        format!("invalid enumerator '{enumerator_identifier}': explicit values can only be declared within enums that specify an underlying type"),
+        enumerator_identifier
+    ),
+    (
+        "E054",
+        EnumeratorCannotDeclareAssociatedFields,
+        format!("invalid enumerator '{enumerator_identifier}': associated fields cannot be declared within enums that specify underlying types"),
+        enumerator_identifier
     )
 );
 

--- a/src/diagnostics/errors.rs
+++ b/src/diagnostics/errors.rs
@@ -544,7 +544,7 @@ implement_diagnostic_functions!(
     (
         "E053",
         EnumeratorCannotDeclareExplicitValue,
-        format!("invalid enumerator '{enumerator_identifier}': explicit values can only be declared within enums that specify underlying types"),
+        format!("invalid enumerator '{enumerator_identifier}': explicit values can only be declared within enums that specify an underlying type"),
         enumerator_identifier
     ),
     (

--- a/src/diagnostics/errors.rs
+++ b/src/diagnostics/errors.rs
@@ -544,7 +544,7 @@ implement_diagnostic_functions!(
     (
         "E053",
         EnumeratorCannotDeclareExplicitValue,
-        format!("invalid enumerator '{enumerator_identifier}': explicit values can only be declared within enums that specify an underlying type"),
+        format!("invalid enumerator '{enumerator_identifier}': explicit values can only be declared within enums that specify underlying types"),
         enumerator_identifier
     ),
     (

--- a/src/grammar/elements/enumerator.rs
+++ b/src/grammar/elements/enumerator.rs
@@ -8,6 +8,7 @@ use crate::utils::ptr_util::WeakPtr;
 pub struct Enumerator {
     pub identifier: Identifier,
     pub value: EnumeratorValue,
+    pub associated_fields: Vec<WeakPtr<Field>>,
     pub parent: WeakPtr<Enum>,
     pub scope: Scope,
     pub attributes: Vec<WeakPtr<Attribute>>,
@@ -22,6 +23,10 @@ impl Enumerator {
             EnumeratorValue::Explicit(integer) => integer.value,
         }
     }
+
+    pub fn associated_fields(&self) -> Vec<&Field> {
+        self.contents()
+    }
 }
 
 #[derive(Debug)]
@@ -35,3 +40,4 @@ implement_Attributable_for!(@Contained Enumerator);
 implement_Entity_for!(Enumerator);
 implement_Commentable_for!(Enumerator);
 implement_Contained_for!(Enumerator, Enum);
+implement_Container_for!(Enumerator, Field, associated_fields);

--- a/src/grammar/elements/enumerator.rs
+++ b/src/grammar/elements/enumerator.rs
@@ -8,7 +8,7 @@ use crate::utils::ptr_util::WeakPtr;
 pub struct Enumerator {
     pub identifier: Identifier,
     pub value: EnumeratorValue,
-    pub associated_fields: Vec<WeakPtr<Field>>,
+    pub associated_fields: Option<Vec<WeakPtr<Field>>>,
     pub parent: WeakPtr<Enum>,
     pub scope: Scope,
     pub attributes: Vec<WeakPtr<Attribute>>,
@@ -24,8 +24,10 @@ impl Enumerator {
         }
     }
 
-    pub fn associated_fields(&self) -> Vec<&Field> {
-        self.contents()
+    pub fn associated_fields(&self) -> Option<Vec<&Field>> {
+        self.associated_fields
+            .as_ref()
+            .map(|fields| fields.iter().map(WeakPtr::borrow).collect())
     }
 }
 
@@ -35,9 +37,14 @@ pub enum EnumeratorValue {
     Explicit(Integer<i128>),
 }
 
+impl Container<Field> for Enumerator {
+    fn contents(&self) -> Vec<&Field> {
+        self.associated_fields().unwrap_or_default()
+    }
+}
+
 implement_Element_for!(Enumerator, "enumerator");
 implement_Attributable_for!(@Contained Enumerator);
 implement_Entity_for!(Enumerator);
 implement_Commentable_for!(Enumerator);
 implement_Contained_for!(Enumerator, Enum);
-implement_Container_for!(Enumerator, Field, associated_fields);

--- a/src/parsers/slice/grammar.lalrpop
+++ b/src/parsers/slice/grammar.lalrpop
@@ -201,8 +201,8 @@ Enum: OwnedPtr<Enum> = {
 }
 
 Enumerator: OwnedPtr<Enumerator> = {
-    <p: Prelude> <l: @L> <i: Identifier> <si: ("=" <SignedInteger>)?> <r: @R> => {
-        construct_enumerator(parser, p, i, si, Span::new(l, r, parser.file_name))
+    <p: Prelude> <l: @L> <i: ContainerIdentifier> <afs: ("(" <UndelimitedList<Field>> ")")?> <si: ("=" <SignedInteger>)?> <r: @R> ContainerEnd => {
+        construct_enumerator(parser, p, i, afs, si, Span::new(l, r, parser.file_name))
     },
 }
 

--- a/src/parsers/slice/lexer.rs
+++ b/src/parsers/slice/lexer.rs
@@ -29,7 +29,7 @@ where
     /// This is what the lexer actually operates on, by peeking at and consuming codepoints from this buffer.
     buffer: Peekable<CharIndices<'input>>,
 
-    /// The lexer's current [`Location`](crate::slice_file::Location) in the slice file.
+    /// The lexer's current [location](crate::slice_file::Location) in the slice file.
     /// Used to tag tokens with their starting and ending locations in the source input.
     ///
     /// Since source blocks can be non-adjacent (separated by a preprocessor directive) in a slice file,

--- a/src/parsers/slice/parser.rs
+++ b/src/parsers/slice/parser.rs
@@ -38,7 +38,7 @@ pub struct Parser<'a> {
     pub(super) diagnostics: &'a mut Diagnostics,
     pub(super) current_scope: Scope,
     pub(super) compilation_mode: CompilationMode,
-    pub(super) last_enumerator_value: Option<i128>,
+    pub(super) previous_enumerator_value: Option<i128>,
 }
 
 impl<'a> Parser<'a> {
@@ -60,7 +60,7 @@ impl<'a> Parser<'a> {
             diagnostics,
             compilation_mode: CompilationMode::default(),
             current_scope: Scope::default(),
-            last_enumerator_value: None,
+            previous_enumerator_value: None,
         }
     }
 }

--- a/src/patchers/encoding_patcher.rs
+++ b/src/patchers/encoding_patcher.rs
@@ -421,7 +421,7 @@ impl ComputeSupportedEncodings for Enum {
 
         for enumerator in self.enumerators() {
             // Enums with associated fields are not allowed in Slice1 mode.
-            if !enumerator.associated_fields().is_empty() {
+            if enumerator.associated_fields().is_some() {
                 supported_encodings.disable(Encoding::Slice1);
                 if compilation_mode == CompilationMode::Slice1 {
                     return Some("enumerators declared in Slice1 mode cannot have associated fields");

--- a/src/utils/file_util.rs
+++ b/src/utils/file_util.rs
@@ -63,7 +63,7 @@ pub fn resolve_files_from(options: &SliceOptions, diagnostics: &mut Diagnostics)
     // Report a lint violation for duplicate source files (any that duplicate another source file not a reference file).
     for source_file in source_files {
         let path = source_file.path.clone();
-        // Insert will return replace and return the previous value if the key already exists.
+        // Insert will replace and return the previous value if the key already exists.
         // We use this to allow replacing references with sources.
         if let Some(is_source) = file_paths.insert(source_file, true) {
             // Only report an error if the file was previously a source file.

--- a/src/validators/enums.rs
+++ b/src/validators/enums.rs
@@ -138,13 +138,13 @@ fn nonempty_if_checked(enum_def: &Enum, diagnostics: &mut Diagnostics) {
     }
 }
 
-/// Validate that enumerators don't specify any associated fields.
+/// Validate that this enum's enumerators don't specify any associated fields.
 /// This function should only be called for enums with underlying types.
 fn cannot_contain_associated_fields(enum_def: &Enum, diagnostics: &mut Diagnostics) {
     debug_assert!(enum_def.underlying.is_some());
 
     for enumerator in enum_def.enumerators() {
-        if !enumerator.associated_fields().is_empty() {
+        if enumerator.associated_fields().is_some() {
             Diagnostic::new(Error::EnumeratorCannotDeclareAssociatedFields {
                 enumerator_identifier: enumerator.identifier().to_owned(),
             })
@@ -158,7 +158,7 @@ fn cannot_contain_associated_fields(enum_def: &Enum, diagnostics: &mut Diagnosti
     }
 }
 
-/// Validate that enumerators don't specify any explicit values.
+/// Validate that this enum's enumerators don't specify any explicit values.
 /// This function should only be called for enums without underlying types.
 fn cannot_contain_explicit_values(enum_def: &Enum, diagnostics: &mut Diagnostics) {
     debug_assert!(enum_def.underlying.is_none());

--- a/src/validators/mod.rs
+++ b/src/validators/mod.rs
@@ -93,6 +93,8 @@ impl<'a> Visitor for ValidatorVisitor<'a> {
     fn visit_enumerator(&mut self, enumerator: &Enumerator) {
         validate_common_doc_comments(enumerator, self.diagnostics);
         validate_attributes(enumerator, self.diagnostics);
+
+        validate_members(enumerator.contents(), self.diagnostics);
     }
 
     fn visit_exception(&mut self, exception: &Exception) {

--- a/tests/enums/container.rs
+++ b/tests/enums/container.rs
@@ -39,7 +39,7 @@ mod associated_fields {
             module Test
             enum E {
                 A
-                B = 7,
+                B = 7
                 C
             }
         ";
@@ -81,7 +81,7 @@ mod associated_fields {
             enum E {
                 A
                 B(b: bool)
-                C(i: int32, tag(2) s: string)
+                C(i: int32, tag(2) s: string?)
                 D()
             }
         ";
@@ -109,7 +109,7 @@ mod associated_fields {
 
     #[test_case("unchecked enum", true ; "unchecked")]
     #[test_case("enum", false ; "checked")]
-    fn can_be_unchecked(enum_definition: &str, expected: bool) {
+    fn test_presence_of_unchecked(enum_definition: &str, expected: bool) {
         // Arrange
         let slice = format!(
             "
@@ -198,7 +198,7 @@ mod underlying_type {
             module Test
             enum E: uint8 {
                 A
-                B(b: bool),
+                B(b: bool)
                 C
             }
         ";
@@ -350,7 +350,7 @@ mod underlying_type {
     }
 
     #[test]
-    fn enumerators_have_unique_values() {
+    fn enumerators_must_have_unique_values() {
         // Arrange
         let slice = "
             module Test
@@ -373,7 +373,7 @@ mod underlying_type {
 
     #[test_case("unchecked enum", true ; "unchecked")]
     #[test_case("enum", false ; "checked")]
-    fn can_be_unchecked(enum_definition: &str, expected: bool) {
+    fn test_presence_of_unchecked(enum_definition: &str, expected: bool) {
         // Arrange
         let slice = format!(
             "
@@ -430,7 +430,7 @@ mod underlying_type {
     }
 
     #[test]
-    fn enumerators_support_different_base_literals() {
+    fn enumerator_values_support_different_base_literals() {
         // Arrange
         let slice = "
             module Test

--- a/tests/enums/container.rs
+++ b/tests/enums/container.rs
@@ -5,167 +5,6 @@ use slicec::diagnostics::{Diagnostic, Error};
 use slicec::grammar::*;
 use test_case::test_case;
 
-#[test]
-fn enumerator_default_values() {
-    // Arrange
-    let slice = "
-        module Test
-        enum E : uint8 {
-            A
-            B
-            C
-        }
-    ";
-
-    // Act
-    let ast = parse_for_ast(slice);
-
-    // Assert
-    let enumerators = ast.find_element::<Enum>("Test::E").unwrap().enumerators();
-    assert_eq!(enumerators[0].value(), 0);
-    assert_eq!(enumerators[1].value(), 1);
-    assert_eq!(enumerators[2].value(), 2);
-}
-
-#[test]
-fn subsequent_unsigned_value_is_incremented_previous_value() {
-    // Arrange
-    let slice = "
-        module Test
-        enum E : uint8 {
-            A = 2
-            B
-            C
-        }
-        ";
-
-    // Act
-    let ast = parse_for_ast(slice);
-
-    // Assert
-    let enumerators = ast.find_element::<Enum>("Test::E").unwrap().enumerators();
-    assert_eq!(enumerators[1].value(), 3);
-    assert_eq!(enumerators[2].value(), 4);
-}
-
-#[test]
-fn implicit_enumerator_values_overflow_cleanly() {
-    // Arrange
-    let slice = "
-        module Test
-        enum E : varint32 {
-            A
-            B = 170141183460469231731687303715884105727 // i128::MAX
-            C
-        }
-    ";
-
-    // Act
-    let diagnostics = parse_for_diagnostics(slice);
-
-    // Assert
-    let expected = [
-        Diagnostic::new(Error::EnumeratorValueOutOfBounds {
-            enumerator_identifier: "B".to_owned(),
-            value: i128::MAX,
-            min: -2147483648,
-            max: 2147483647,
-        }),
-        Diagnostic::new(Error::EnumeratorValueOutOfBounds {
-            enumerator_identifier: "C".to_owned(),
-            value: i128::MIN,
-            min: -2147483648,
-            max: 2147483647,
-        }),
-    ];
-    check_diagnostics(diagnostics, expected);
-}
-
-#[test]
-fn enumerator_values_can_be_out_of_order() {
-    // Arrange
-    let slice = "
-            module Test
-            enum E : uint8 {
-                A = 2
-                B = 1
-            }
-        ";
-
-    // Act/Assert
-    assert_parses(slice);
-}
-
-#[test]
-fn validate_backing_type_out_of_bounds() {
-    // Arranges
-    let out_of_bounds_value = i16::MAX as i128 + 1;
-    let slice = format!(
-        "
-            module Test
-            enum E : int16 {{
-                A = {out_of_bounds_value}
-            }}
-        "
-    );
-
-    // Act
-    let diagnostics = parse_for_diagnostics(slice);
-
-    // Assert
-    let expected = Diagnostic::new(Error::EnumeratorValueOutOfBounds {
-        enumerator_identifier: "A".to_owned(),
-        value: out_of_bounds_value,
-        min: -32768_i128,
-        max: 32767_i128,
-    });
-    check_diagnostics(diagnostics, [expected]);
-}
-
-#[test]
-fn validate_backing_type_bounds() {
-    // Arranges
-    let min = i16::MIN;
-    let max = i16::MAX;
-    let slice = format!(
-        "
-            module Test
-            enum E : int16 {{
-                A = {min}
-                B = {max}
-            }}
-        "
-    );
-
-    // Act/Assert
-    assert_parses(slice);
-}
-
-#[test_case("string"; "string")]
-#[test_case("float32"; "float32")]
-#[test_case("float64"; "float64")]
-fn invalid_underlying_type(underlying_type: &str) {
-    // Arrange
-    let slice = format!(
-        "
-            module Test
-            enum E : {underlying_type} {{
-                A
-            }}
-        "
-    );
-
-    // Act
-    let diagnostics = parse_for_diagnostics(slice);
-
-    // Assert
-    let expected = Diagnostic::new(Error::EnumUnderlyingTypeNotSupported {
-        enum_identifier: "E".to_owned(),
-        kind: Some(underlying_type.to_owned()),
-    });
-    check_diagnostics(diagnostics, [expected]);
-}
-
 #[test_case("10", "expected one of '[', '}', 'doc comment', or 'identifier', but found '10'"; "numeric identifier")]
 #[test_case("😊", "unknown symbol '😊'"; "unicode identifier")]
 fn enumerator_invalid_identifiers(identifier: &str, expected_message: &str) {
@@ -189,190 +28,19 @@ fn enumerator_invalid_identifiers(identifier: &str, expected_message: &str) {
     check_diagnostics(diagnostics, [expected]);
 }
 
-#[test]
-fn optional_underlying_types_fail() {
-    // Arrange
-    let slice = "
-        module Test
-
-        enum E : int32? {
-            A = 1
-        }
-    ";
-
-    // Act
-    let diagnostics = parse_for_diagnostics(slice);
-
-    // Assert
-    let expected = Diagnostic::new(Error::CannotUseOptionalUnderlyingType {
-        enum_identifier: "E".to_owned(),
-    });
-    check_diagnostics(diagnostics, [expected]);
-}
-
-#[test]
-fn enumerators_must_be_unique() {
-    // Arrange
-    let slice = "
-        module Test
-
-        enum E : uint8 {
-            A = 1
-            B = 1
-        }
-    ";
-
-    // Act
-    let diagnostics = parse_for_diagnostics(slice);
-
-    // Assert
-    let expected = Diagnostic::new(Error::DuplicateEnumeratorValue { enumerator_value: 1 })
-        .add_note("the value was previously used by 'A' here:", None);
-
-    check_diagnostics(diagnostics, [expected]);
-}
-
-#[test_case("unchecked enum", true ; "unchecked")]
-#[test_case("enum", false ; "checked")]
-fn can_be_unchecked(enum_definition: &str, expected: bool) {
-    // Arrange
-    let slice = format!(
-        "
-            module Test
-            {enum_definition} E : uint8 {{
-                A
-                B
-            }}
-        "
-    );
-
-    // Act
-    let ast = parse_for_ast(slice);
-
-    // Assert
-    let enum_def = ast.find_element::<Enum>("Test::E").unwrap();
-    assert_eq!(enum_def.is_unchecked, expected);
-}
-
-#[test]
-fn checked_enums_can_not_be_empty() {
-    // Arrange
-    let slice = "
-        module Test
-
-        enum E : uint8 {}
-    ";
-
-    // Act
-    let diagnostics = parse_for_diagnostics(slice);
-
-    // Assert
-    let expected = Diagnostic::new(Error::MustContainEnumerators {
-        enum_identifier: "E".to_owned(),
-    });
-    check_diagnostics(diagnostics, [expected]);
-}
-
-#[test]
-fn unchecked_enums_can_be_empty() {
-    // Arrange
-    let slice = "
-        module Test
-
-        unchecked enum E : uint8 {}
-    ";
-
-    // Act
-    let ast = parse_for_ast(slice);
-
-    // Assert
-    let enum_def = ast.find_element::<Enum>("Test::E").unwrap();
-    assert_eq!(enum_def.enumerators.len(), 0);
-}
-
-#[test]
-fn enumerators_support_different_base_literals() {
-    // Arrange
-    let slice = "
-        module Test
-
-        enum E : varint32 {
-            B = 0b1001111
-            D = 128
-            H = 0xA4FD
-            N = -0xbc81
-        }
-    ";
-
-    // Act
-    let ast = parse_for_ast(slice);
-
-    // Assert
-    assert_eq!(ast.find_element::<Enumerator>("Test::E::B").unwrap().value(), 0b1001111);
-    assert_eq!(ast.find_element::<Enumerator>("Test::E::D").unwrap().value(), 128);
-    assert_eq!(ast.find_element::<Enumerator>("Test::E::H").unwrap().value(), 0xA4FD);
-    assert_eq!(ast.find_element::<Enumerator>("Test::E::N").unwrap().value(), -0xbc81);
-}
-
-#[test]
-fn duplicate_enumerators_are_disallowed_across_different_bases() {
-    // Arrange
-    let slice = "
-        module Test
-
-        enum E : uint16 {
-            B = 0b1001111
-            D = 79
-        }
-    ";
-
-    // Act
-    let diagnostics = parse_for_diagnostics(slice);
-
-    // Assert
-    let expected = Diagnostic::new(Error::DuplicateEnumeratorValue { enumerator_value: 79 });
-    check_diagnostics(diagnostics, [expected]);
-}
-
-#[test]
-fn cannot_redefine_enumerators() {
-    // Arrange
-    let slice = "
-        module Test
-
-        enum E : uint32 {
-            A, A
-        }
-    ";
-
-    // Act
-    let diagnostics = parse_for_diagnostics(slice);
-
-    // Assert
-    let expected = Diagnostic::new(Error::Redefinition {
-        identifier: "A".to_string(),
-    })
-    .add_note("'A' was previously defined here", None);
-
-    check_diagnostics(diagnostics, [expected]);
-}
-
-mod slice1 {
-
-    use crate::test_helpers::*;
-    use slicec::diagnostics::{Diagnostic, Error};
+mod associated_fields {
+    use super::*;
+    use test_case::test_case;
 
     #[test]
-    fn enumerators_cannot_contain_negative_values() {
+    fn explicit_values_are_not_allowed() {
         // Arrange
         let slice = "
-            mode = Slice1
             module Test
-
             enum E {
-                A = -1
-                B = -2
-                C = -3
+                A
+                B = 7,
+                C
             }
         ";
 
@@ -380,41 +48,266 @@ mod slice1 {
         let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
-        const MAX_VALUE: i128 = i32::MAX as i128;
+        let expected = Diagnostic::new(Error::EnumeratorCannotDeclareExplicitValue {
+            enumerator_identifier: "B".to_owned(),
+        });
+        check_diagnostics(diagnostics, [expected]);
+    }
+
+    #[test]
+    fn associated_fields_are_scoped_correctly() {
+        // Arrange
+        let slice = "
+            module Test
+
+            enum Foo {
+                Bar(baz: Sequence<bool>)
+            }
+        ";
+
+        // Act
+        let ast = parse_for_ast(slice);
+
+        // Assert
+        assert!(ast.find_element::<Field>("Test::Foo::Bar::baz").is_ok());
+    }
+
+    #[test]
+    fn associated_fields_are_parsed_correctly() {
+        // Arrange
+        let slice = "
+            module Test
+
+            enum E {
+                A
+                B(b: bool)
+                C(i: int32, tag(2) s: string)
+            }
+        ";
+
+        // Act
+        let ast = parse_for_ast(slice);
+
+        // Assert
+        let a = ast.find_element::<Enumerator>("Test::E::A").unwrap();
+        assert!(matches!(a.value, EnumeratorValue::Implicit(0)));
+        assert!(a.associated_fields().is_empty());
+
+        let b = ast.find_element::<Enumerator>("Test::E::B").unwrap();
+        assert!(matches!(b.value, EnumeratorValue::Implicit(1)));
+        assert!(b.associated_fields().len() == 1);
+
+        let c = ast.find_element::<Enumerator>("Test::E::C").unwrap();
+        assert!(matches!(c.value, EnumeratorValue::Implicit(2)));
+        assert!(c.associated_fields().len() == 2);
+    }
+
+    #[test_case("unchecked enum", true ; "unchecked")]
+    #[test_case("enum", false ; "checked")]
+    fn can_be_unchecked(enum_definition: &str, expected: bool) {
+        // Arrange
+        let slice = format!(
+            "
+                module Test
+                {enum_definition} E {{
+                    A
+                    B
+                }}
+            "
+        );
+
+        // Act
+        let ast = parse_for_ast(slice);
+
+        // Assert
+        let enum_def = ast.find_element::<Enum>("Test::E").unwrap();
+        assert_eq!(enum_def.is_unchecked, expected);
+    }
+
+    #[test]
+    fn checked_enums_can_not_be_empty() {
+        // Arrange
+        let slice = "
+            module Test
+
+            enum E {}
+        ";
+
+        // Act
+        let diagnostics = parse_for_diagnostics(slice);
+
+        // Assert
+        let expected = Diagnostic::new(Error::MustContainEnumerators {
+            enum_identifier: "E".to_owned(),
+        });
+        check_diagnostics(diagnostics, [expected]);
+    }
+
+    #[test]
+    fn unchecked_enums_can_be_empty() {
+        // Arrange
+        let slice = "
+            module Test
+
+            unchecked enum E {}
+        ";
+
+        // Act
+        let ast = parse_for_ast(slice);
+
+        // Assert
+        let enum_def = ast.find_element::<Enum>("Test::E").unwrap();
+        assert_eq!(enum_def.enumerators.len(), 0);
+    }
+
+    #[test]
+    fn cannot_redefine_enumerators() {
+        // Arrange
+        let slice = "
+            module Test
+
+            enum E  { A, A }
+        ";
+
+        // Act
+        let diagnostics = parse_for_diagnostics(slice);
+
+        // Assert
+        let expected = Diagnostic::new(Error::Redefinition {
+            identifier: "A".to_string(),
+        })
+        .add_note("'A' was previously defined here", None);
+
+        check_diagnostics(diagnostics, [expected]);
+    }
+}
+
+mod underlying_type {
+    use super::*;
+    use test_case::test_case;
+
+    #[test]
+    fn associated_fields_are_not_allowed() {
+        // Arrange
+        let slice = "
+            module Test
+            enum E: uint8 {
+                A
+                B(b: bool),
+                C
+            }
+        ";
+
+        // Act
+        let diagnostics = parse_for_diagnostics(slice);
+
+        // Assert
+        let expected = Diagnostic::new(Error::EnumeratorCannotDeclareAssociatedFields {
+            enumerator_identifier: "B".to_owned(),
+        });
+        check_diagnostics(diagnostics, [expected]);
+    }
+
+    #[test]
+    fn enumerator_default_values() {
+        // Arrange
+        let slice = "
+            module Test
+            enum E : uint8 {
+                A
+                B
+                C
+            }
+        ";
+
+        // Act
+        let ast = parse_for_ast(slice);
+
+        // Assert
+        let enumerators = ast.find_element::<Enum>("Test::E").unwrap().enumerators();
+        assert_eq!(enumerators[0].value(), 0);
+        assert_eq!(enumerators[1].value(), 1);
+        assert_eq!(enumerators[2].value(), 2);
+    }
+
+    #[test]
+    fn subsequent_unsigned_value_is_incremented_previous_value() {
+        // Arrange
+        let slice = "
+            module Test
+            enum E : uint8 {
+                A = 2
+                B
+                C
+            }
+            ";
+
+        // Act
+        let ast = parse_for_ast(slice);
+
+        // Assert
+        let enumerators = ast.find_element::<Enum>("Test::E").unwrap().enumerators();
+        assert_eq!(enumerators[1].value(), 3);
+        assert_eq!(enumerators[2].value(), 4);
+    }
+
+    #[test]
+    fn implicit_enumerator_values_overflow_cleanly() {
+        // Arrange
+        let slice = "
+            module Test
+            enum E : varint32 {
+                A
+                B = 170141183460469231731687303715884105727 // i128::MAX
+                C
+            }
+        ";
+
+        // Act
+        let diagnostics = parse_for_diagnostics(slice);
+
+        // Assert
         let expected = [
             Diagnostic::new(Error::EnumeratorValueOutOfBounds {
-                enumerator_identifier: "A".to_owned(),
-                value: -1,
-                min: 0,
-                max: MAX_VALUE,
-            }),
-            Diagnostic::new(Error::EnumeratorValueOutOfBounds {
                 enumerator_identifier: "B".to_owned(),
-                value: -2,
-                min: 0,
-                max: MAX_VALUE,
+                value: i128::MAX,
+                min: -2147483648,
+                max: 2147483647,
             }),
             Diagnostic::new(Error::EnumeratorValueOutOfBounds {
                 enumerator_identifier: "C".to_owned(),
-                value: -3,
-                min: 0,
-                max: MAX_VALUE,
+                value: i128::MIN,
+                min: -2147483648,
+                max: 2147483647,
             }),
         ];
         check_diagnostics(diagnostics, expected);
     }
 
     #[test]
-    fn enumerators_cannot_contain_out_of_bounds_values() {
+    fn enumerator_values_can_be_out_of_order() {
         // Arrange
-        let value = i32::MAX as i128 + 1;
+        let slice = "
+                module Test
+                enum E : uint8 {
+                    A = 2
+                    B = 1
+                }
+            ";
+
+        // Act/Assert
+        assert_parses(slice);
+    }
+
+    #[test]
+    fn validate_backing_type_out_of_bounds() {
+        // Arranges
+        let out_of_bounds_value = i16::MAX as i128 + 1;
         let slice = format!(
             "
-                mode = Slice1
                 module Test
-
-                enum E {{
-                    A = {value}
+                enum E : int16 {{
+                    A = {out_of_bounds_value}
                 }}
             "
         );
@@ -425,47 +318,102 @@ mod slice1 {
         // Assert
         let expected = Diagnostic::new(Error::EnumeratorValueOutOfBounds {
             enumerator_identifier: "A".to_owned(),
-            value,
-            min: 0,
-            max: i32::MAX as i128,
+            value: out_of_bounds_value,
+            min: -32768_i128,
+            max: 32767_i128,
         });
         check_diagnostics(diagnostics, [expected]);
     }
-}
-
-mod slice2 {
-
-    use crate::test_helpers::*;
-    use slicec::grammar::*;
 
     #[test]
-    fn enumerators_can_contain_negative_values() {
-        // Arrange
-        let slice = "
-            module Test
-
-            enum E : int32 {
-                A = -1
-                B = -2
-                C = -3
-            }
-        ";
+    fn validate_backing_type_bounds() {
+        // Arranges
+        let min = i16::MIN;
+        let max = i16::MAX;
+        let slice = format!(
+            "
+                module Test
+                enum E : int16 {{
+                    A = {min}
+                    B = {max}
+                }}
+            "
+        );
 
         // Act/Assert
         assert_parses(slice);
     }
 
     #[test]
-    fn enumerators_can_contain_values() {
+    fn enumerators_have_unique_values() {
         // Arrange
         let slice = "
             module Test
 
-            enum E : int16 {
+            enum E : uint8 {
                 A = 1
-                B = 2
-                C = 3
+                B = 1
             }
+        ";
+
+        // Act
+        let diagnostics = parse_for_diagnostics(slice);
+
+        // Assert
+        let expected = Diagnostic::new(Error::DuplicateEnumeratorValue { enumerator_value: 1 })
+            .add_note("the value was previously used by 'A' here:", None);
+
+        check_diagnostics(diagnostics, [expected]);
+    }
+
+    #[test_case("unchecked enum", true ; "unchecked")]
+    #[test_case("enum", false ; "checked")]
+    fn can_be_unchecked(enum_definition: &str, expected: bool) {
+        // Arrange
+        let slice = format!(
+            "
+                module Test
+                {enum_definition} E : uint8 {{
+                    A
+                    B
+                }}
+            "
+        );
+
+        // Act
+        let ast = parse_for_ast(slice);
+
+        // Assert
+        let enum_def = ast.find_element::<Enum>("Test::E").unwrap();
+        assert_eq!(enum_def.is_unchecked, expected);
+    }
+
+    #[test]
+    fn checked_enums_can_not_be_empty() {
+        // Arrange
+        let slice = "
+            module Test
+
+            enum E : uint8 {}
+        ";
+
+        // Act
+        let diagnostics = parse_for_diagnostics(slice);
+
+        // Assert
+        let expected = Diagnostic::new(Error::MustContainEnumerators {
+            enum_identifier: "E".to_owned(),
+        });
+        check_diagnostics(diagnostics, [expected]);
+    }
+
+    #[test]
+    fn unchecked_enums_can_be_empty() {
+        // Arrange
+        let slice = "
+            module Test
+
+            unchecked enum E : uint8 {}
         ";
 
         // Act
@@ -473,42 +421,229 @@ mod slice2 {
 
         // Assert
         let enum_def = ast.find_element::<Enum>("Test::E").unwrap();
-        let enumerators = enum_def.enumerators();
-
-        assert_eq!(enumerators.len(), 3);
-        assert_eq!(enumerators[0].identifier(), "A");
-        assert_eq!(enumerators[1].identifier(), "B");
-        assert_eq!(enumerators[2].identifier(), "C");
-        assert_eq!(enumerators[0].value(), 1);
-        assert_eq!(enumerators[1].value(), 2);
-        assert_eq!(enumerators[2].value(), 3);
-        assert!(matches!(
-            enum_def.underlying.as_ref().unwrap().definition(),
-            Primitive::Int16,
-        ));
+        assert_eq!(enum_def.enumerators.len(), 0);
     }
 
     #[test]
-    fn explicit_enumerator_value_kinds() {
+    fn enumerators_support_different_base_literals() {
+        // Arrange
         let slice = "
-        module Test
+            module Test
 
-        enum A : uint8 {
-            u = 1
-            v = 2
-            w = 3
-        }
+            enum E : varint32 {
+                B = 0b1001111
+                D = 128
+                H = 0xA4FD
+                N = -0xbc81
+            }
         ";
 
         // Act
         let ast = parse_for_ast(slice);
 
         // Assert
-        let enum_def_a = ast.find_element::<Enum>("Test::A").unwrap();
-        let enumerators_a = enum_def_a.enumerators();
+        assert_eq!(ast.find_element::<Enumerator>("Test::E::B").unwrap().value(), 0b1001111);
+        assert_eq!(ast.find_element::<Enumerator>("Test::E::D").unwrap().value(), 128);
+        assert_eq!(ast.find_element::<Enumerator>("Test::E::H").unwrap().value(), 0xA4FD);
+        assert_eq!(ast.find_element::<Enumerator>("Test::E::N").unwrap().value(), -0xbc81);
+    }
 
-        assert!(matches!(enumerators_a[0].value, EnumeratorValue::Explicit(..)));
-        assert!(matches!(enumerators_a[1].value, EnumeratorValue::Explicit(..)));
-        assert!(matches!(enumerators_a[2].value, EnumeratorValue::Explicit(..)));
+    #[test]
+    fn duplicate_enumerator_values_are_disallowed_across_different_bases() {
+        // Arrange
+        let slice = "
+            module Test
+
+            enum E : uint16 {
+                B = 0b1001111
+                D = 79
+            }
+        ";
+
+        // Act
+        let diagnostics = parse_for_diagnostics(slice);
+
+        // Assert
+        let expected = Diagnostic::new(Error::DuplicateEnumeratorValue { enumerator_value: 79 });
+        check_diagnostics(diagnostics, [expected]);
+    }
+
+    #[test]
+    fn cannot_redefine_enumerators() {
+        // Arrange
+        let slice = "
+            module Test
+
+            enum E : uint32 {
+                A, A
+            }
+        ";
+
+        // Act
+        let diagnostics = parse_for_diagnostics(slice);
+
+        // Assert
+        let expected = Diagnostic::new(Error::Redefinition {
+            identifier: "A".to_string(),
+        })
+        .add_note("'A' was previously defined here", None);
+
+        check_diagnostics(diagnostics, [expected]);
+    }
+
+    mod slice1 {
+
+        use crate::test_helpers::*;
+        use slicec::diagnostics::{Diagnostic, Error};
+
+        #[test]
+        fn enumerators_cannot_contain_negative_values() {
+            // Arrange
+            let slice = "
+                mode = Slice1
+                module Test
+
+                enum E {
+                    A = -1
+                    B = -2
+                    C = -3
+                }
+            ";
+
+            // Act
+            let diagnostics = parse_for_diagnostics(slice);
+
+            // Assert
+            const MAX_VALUE: i128 = i32::MAX as i128;
+            let expected = [
+                Diagnostic::new(Error::EnumeratorValueOutOfBounds {
+                    enumerator_identifier: "A".to_owned(),
+                    value: -1,
+                    min: 0,
+                    max: MAX_VALUE,
+                }),
+                Diagnostic::new(Error::EnumeratorValueOutOfBounds {
+                    enumerator_identifier: "B".to_owned(),
+                    value: -2,
+                    min: 0,
+                    max: MAX_VALUE,
+                }),
+                Diagnostic::new(Error::EnumeratorValueOutOfBounds {
+                    enumerator_identifier: "C".to_owned(),
+                    value: -3,
+                    min: 0,
+                    max: MAX_VALUE,
+                }),
+            ];
+            check_diagnostics(diagnostics, expected);
+        }
+
+        #[test]
+        fn enumerators_cannot_contain_out_of_bound_values() {
+            // Arrange
+            let value = i32::MAX as i128 + 1;
+            let slice = format!(
+                "
+                    mode = Slice1
+                    module Test
+
+                    enum E {{
+                        A = {value}
+                    }}
+                "
+            );
+
+            // Act
+            let diagnostics = parse_for_diagnostics(slice);
+
+            // Assert
+            let expected = Diagnostic::new(Error::EnumeratorValueOutOfBounds {
+                enumerator_identifier: "A".to_owned(),
+                value,
+                min: 0,
+                max: i32::MAX as i128,
+            });
+            check_diagnostics(diagnostics, [expected]);
+        }
+    }
+
+    mod slice2 {
+
+        use crate::test_helpers::*;
+        use slicec::grammar::*;
+
+        #[test]
+        fn enumerators_can_contain_negative_values() {
+            // Arrange
+            let slice = "
+                module Test
+
+                enum E : int32 {
+                    A = -1
+                    B = -2
+                    C = -3
+                }
+            ";
+
+            // Act/Assert
+            assert_parses(slice);
+        }
+
+        #[test]
+        fn enumerators_can_contain_values() {
+            // Arrange
+            let slice = "
+                module Test
+
+                enum E : int16 {
+                    A = 1
+                    B = 2
+                    C = 3
+                }
+            ";
+
+            // Act
+            let ast = parse_for_ast(slice);
+
+            // Assert
+            let enum_def = ast.find_element::<Enum>("Test::E").unwrap();
+            let enumerators = enum_def.enumerators();
+
+            assert_eq!(enumerators.len(), 3);
+            assert_eq!(enumerators[0].identifier(), "A");
+            assert_eq!(enumerators[1].identifier(), "B");
+            assert_eq!(enumerators[2].identifier(), "C");
+            assert_eq!(enumerators[0].value(), 1);
+            assert_eq!(enumerators[1].value(), 2);
+            assert_eq!(enumerators[2].value(), 3);
+            assert!(matches!(
+                enum_def.underlying.as_ref().unwrap().definition(),
+                Primitive::Int16,
+            ));
+        }
+
+        #[test]
+        fn explicit_enumerator_value_kinds() {
+            let slice = "
+            module Test
+
+            enum A : uint8 {
+                u = 1
+                v = 2
+                w = 3
+            }
+            ";
+
+            // Act
+            let ast = parse_for_ast(slice);
+
+            // Assert
+            let enum_def_a = ast.find_element::<Enum>("Test::A").unwrap();
+            let enumerators_a = enum_def_a.enumerators();
+
+            assert!(matches!(enumerators_a[0].value, EnumeratorValue::Explicit(..)));
+            assert!(matches!(enumerators_a[1].value, EnumeratorValue::Explicit(..)));
+            assert!(matches!(enumerators_a[2].value, EnumeratorValue::Explicit(..)));
+        }
     }
 }

--- a/tests/enums/container.rs
+++ b/tests/enums/container.rs
@@ -82,6 +82,7 @@ mod associated_fields {
                 A
                 B(b: bool)
                 C(i: int32, tag(2) s: string)
+                D()
             }
         ";
 
@@ -91,15 +92,19 @@ mod associated_fields {
         // Assert
         let a = ast.find_element::<Enumerator>("Test::E::A").unwrap();
         assert!(matches!(a.value, EnumeratorValue::Implicit(0)));
-        assert!(a.associated_fields().is_empty());
+        assert!(a.associated_fields().is_none());
 
         let b = ast.find_element::<Enumerator>("Test::E::B").unwrap();
         assert!(matches!(b.value, EnumeratorValue::Implicit(1)));
-        assert!(b.associated_fields().len() == 1);
+        assert!(b.associated_fields().unwrap().len() == 1);
 
         let c = ast.find_element::<Enumerator>("Test::E::C").unwrap();
         assert!(matches!(c.value, EnumeratorValue::Implicit(2)));
-        assert!(c.associated_fields().len() == 2);
+        assert!(c.associated_fields().unwrap().len() == 2);
+
+        let d = ast.find_element::<Enumerator>("Test::E::D").unwrap();
+        assert!(matches!(d.value, EnumeratorValue::Implicit(3)));
+        assert!(d.associated_fields().unwrap().len() == 0);
     }
 
     #[test_case("unchecked enum", true ; "unchecked")]

--- a/tests/enums/mod.rs
+++ b/tests/enums/mod.rs
@@ -2,3 +2,76 @@
 
 mod container;
 mod mode_compatibility;
+
+use crate::test_helpers::*;
+use slicec::diagnostics::{Diagnostic, Error};
+use test_case::test_case;
+
+#[test_case("uint8"; "uint8")]
+#[test_case("int16"; "int16")]
+#[test_case("uint16"; "uint16")]
+#[test_case("int32"; "int32")]
+#[test_case("uint32"; "uint32")]
+#[test_case("varint32"; "varint32")]
+#[test_case("varuint32"; "varuint32")]
+#[test_case("varint62"; "varint62")]
+#[test_case("varuint62"; "varuint62")]
+fn supported_numeric_underlying_types_succeed(valid_type: &str) {
+    // Arrange
+    let slice = &format!(
+        "
+            module Test
+
+            unchecked enum E : {valid_type} {{}}
+        "
+    );
+
+    // Act/Assert
+    assert_parses(slice);
+}
+
+#[test_case("string"; "string")]
+#[test_case("float32"; "float32")]
+#[test_case("float64"; "float64")]
+fn invalid_underlying_type(underlying_type: &str) {
+    // Arrange
+    let slice = format!(
+        "
+            module Test
+            enum E : {underlying_type} {{
+                A
+            }}
+        "
+    );
+
+    // Act
+    let diagnostics = parse_for_diagnostics(slice);
+
+    // Assert
+    let expected = Diagnostic::new(Error::EnumUnderlyingTypeNotSupported {
+        enum_identifier: "E".to_owned(),
+        kind: Some(underlying_type.to_owned()),
+    });
+    check_diagnostics(diagnostics, [expected]);
+}
+
+#[test]
+fn optional_underlying_types_fail() {
+    // Arrange
+    let slice = "
+        module Test
+
+        enum E : int32? {
+            A = 1
+        }
+    ";
+
+    // Act
+    let diagnostics = parse_for_diagnostics(slice);
+
+    // Assert
+    let expected = Diagnostic::new(Error::CannotUseOptionalUnderlyingType {
+        enum_identifier: "E".to_owned(),
+    });
+    check_diagnostics(diagnostics, [expected]);
+}

--- a/tests/enums/mod.rs
+++ b/tests/enums/mod.rs
@@ -7,6 +7,7 @@ use crate::test_helpers::*;
 use slicec::diagnostics::{Diagnostic, Error};
 use test_case::test_case;
 
+#[test_case("int8"; "int8")]
 #[test_case("uint8"; "uint8")]
 #[test_case("int16"; "int16")]
 #[test_case("uint16"; "uint16")]
@@ -14,6 +15,8 @@ use test_case::test_case;
 #[test_case("uint32"; "uint32")]
 #[test_case("varint32"; "varint32")]
 #[test_case("varuint32"; "varuint32")]
+#[test_case("int64"; "int64")]
+#[test_case("uint64"; "uint64")]
 #[test_case("varint62"; "varint62")]
 #[test_case("varuint62"; "varuint62")]
 fn supported_numeric_underlying_types_succeed(valid_type: &str) {

--- a/tests/enums/mode_compatibility.rs
+++ b/tests/enums/mode_compatibility.rs
@@ -1,10 +1,33 @@
 // Copyright (c) ZeroC, Inc.
 
-mod slice1 {
+use crate::test_helpers::*;
+use slicec::diagnostics::{Diagnostic, Error};
+use slicec::grammar::CompilationMode;
 
-    use crate::test_helpers::*;
-    use slicec::diagnostics::{Diagnostic, Error};
-    use slicec::grammar::CompilationMode;
+#[test]
+fn slice1_enums_can_be_used_by_slice2_definitions() {
+    // Arrange
+    let slice1 = "
+        mode = Slice1
+        module Test
+
+        enum E {
+            A,
+            B = 4,
+        }
+    ";
+    let slice2 = "
+        module Test
+
+        struct S { e: E}
+    ";
+
+    // Act/Assert: ensure it compiles without emitting any mode compatibility errors.
+    _ = parse_multiple_for_ast(&[slice1, slice2]);
+}
+
+mod slice1 {
+    use super::*;
 
     /// Verifies that underlying types are disallowed in Slice1 mode.
     #[test]
@@ -30,44 +53,17 @@ mod slice1 {
 
         check_diagnostics(diagnostics, [expected]);
     }
-}
 
-mod slice2 {
-
-    use crate::test_helpers::*;
-    use slicec::diagnostics::{Diagnostic, Error};
-    use test_case::test_case;
-
-    #[test_case("uint8"; "uint8")]
-    #[test_case("int16"; "int16")]
-    #[test_case("uint16"; "uint16")]
-    #[test_case("int32"; "int32")]
-    #[test_case("uint32"; "uint32")]
-    #[test_case("varint32"; "varint32")]
-    #[test_case("varuint32"; "varuint32")]
-    #[test_case("varint62"; "varint62")]
-    #[test_case("varuint62"; "varuint62")]
-    fn supported_numeric_underlying_types_succeed(valid_type: &str) {
-        // Arrange
-        let slice = &format!(
-            "
-                module Test
-
-                unchecked enum E : {valid_type} {{}}
-            "
-        );
-
-        // Act/Assert
-        assert_parses(slice);
-    }
-
+    /// Verifies that associated fields are disallowed in Slice1 mode.
     #[test]
-    fn underlying_type_is_required() {
+    fn associated_fields_fail() {
         // Arrange
         let slice = "
+            mode = Slice1
             module Test
-            enum E {
-                A
+
+            unchecked enum E {
+                A(b: bool)
             }
         ";
 
@@ -75,10 +71,15 @@ mod slice2 {
         let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
-        let expected = Diagnostic::new(Error::EnumUnderlyingTypeNotSupported {
-            enum_identifier: "E".to_owned(),
-            kind: None,
-        });
+        let expected = Diagnostic::new(Error::NotSupportedInCompilationMode {
+            kind: "enum".to_owned(),
+            identifier: "E".to_owned(),
+            mode: CompilationMode::Slice1,
+        })
+        .add_note(
+            "enumerators declared in Slice1 mode cannot have associated fields",
+            None,
+        );
         check_diagnostics(diagnostics, [expected]);
     }
 }

--- a/tests/enums/mode_compatibility.rs
+++ b/tests/enums/mode_compatibility.rs
@@ -82,4 +82,33 @@ mod slice1 {
         );
         check_diagnostics(diagnostics, [expected]);
     }
+
+    /// Verifies that even empty associated field lists are disallowed in Slice1 mode.
+    #[test]
+    fn empty_associated_fields_fail() {
+        // Arrange
+        let slice = "
+            mode = Slice1
+            module Test
+
+            unchecked enum E {
+                A()
+            }
+        ";
+
+        // Act
+        let diagnostics = parse_for_diagnostics(slice);
+
+        // Assert
+        let expected = Diagnostic::new(Error::NotSupportedInCompilationMode {
+            kind: "enum".to_owned(),
+            identifier: "E".to_owned(),
+            mode: CompilationMode::Slice1,
+        })
+        .add_note(
+            "enumerators declared in Slice1 mode cannot have associated fields",
+            None,
+        );
+        check_diagnostics(diagnostics, [expected]);
+    }
 }


### PR DESCRIPTION
This PR adds support for enumerators with associated fields.

This feature is only available in `Slice2` mode, and only for enums that don't specify an underlying type.
```
enum E {
    A
    B(b: bool)
    C(s: Sequence<int32?>, tag(12) s: string)
}
```
The syntax of associated fields is equivalent to... fields (go figure). Anything supported by fields is supported by these.

Note that I am aware of the TODO in the cycle checking logic. I'm just splitting it off into it's own PR.

### Summary of enums

In `Slice1`, enums cannot specify an underlying type, and enumerators cannot declare associated fields.
Enumerators can declare values that are within the range of `0` and `int32::MAX`.
If a 'Slice1' enum is used in a `Slice2` file, it is treated as-if it has the underlying type `int32`.

In `Slice2`, enums can specify an underlying type.
Enums with underlying types _cannot_ use associated fields, but _can_ assign values to it's enumerators.
Enums without underlying types _can_ use associated fields, but _cannot_ assign values to it's enumerators.

----

See #30