### PR TITLE
Separate the Spans of Messages and Tags in Doc Comments

### DIFF
--- a/src/grammar/comments.rs
+++ b/src/grammar/comments.rs
@@ -5,17 +5,11 @@ use crate::slice_file::Span;
 
 #[derive(Debug)]
 pub struct DocComment {
-    pub overview: Option<Overview>,
+    pub overview: Option<Message>,
     pub params: Vec<ParamTag>,
     pub returns: Vec<ReturnsTag>,
     pub throws: Vec<ThrowsTag>,
     pub see: Vec<SeeTag>,
-    pub span: Span,
-}
-
-#[derive(Debug)]
-pub struct Overview {
-    pub message: Message,
     pub span: Span,
 }
 
@@ -85,12 +79,14 @@ pub enum MessageComponent {
     Link(LinkTag),
 }
 
-pub type Message = Vec<MessageComponent>;
+#[derive(Debug)]
+pub struct Message {
+    pub value: Vec<MessageComponent>,
+    pub span: Span,
+}
 
 implement_Element_for!(DocComment, "doc comment");
 implement_Symbol_for!(DocComment);
-implement_Element_for!(Overview, "overview");
-implement_Symbol_for!(Overview);
 implement_Element_for!(ParamTag, "param tag");
 implement_Symbol_for!(ParamTag);
 implement_Element_for!(ReturnsTag, "returns tag");
@@ -101,3 +97,5 @@ implement_Element_for!(SeeTag, "see tag");
 implement_Symbol_for!(SeeTag);
 implement_Element_for!(LinkTag, "link tag");
 implement_Symbol_for!(LinkTag);
+implement_Element_for!(Message, "doc message");
+implement_Symbol_for!(Message);

--- a/src/parsers/comments/grammar.lalrpop
+++ b/src/parsers/comments/grammar.lalrpop
@@ -40,7 +40,7 @@ extern {
 // Grammar Rules
 
 pub DocComment: DocComment = {
-    <l: @L> <overview: Overview?> => create_doc_comment(overview, l, comment_parser.file_name),
+    <l: @L> <overview: MessageLines?> => create_doc_comment(overview, l, comment_parser.file_name),
     <mut comment: DocComment> <param_block: ParamBlock> => {
         append_tag_to_comment!(comment, params, param_block)
     },
@@ -55,29 +55,22 @@ pub DocComment: DocComment = {
     },
 }
 
-Overview: Overview = {
-    <l: @L> <message: MessageLines> <r: @R> => {
-        let span = Span::new(l, r, comment_parser.file_name);
-        Overview { message, span }
-    },
-}
-
 ParamBlock: ParamTag = {
-    <l: @L> param_keyword <identifier: Identifier> <message: Section> <r: @R> => {
+    <l: @L> param_keyword <identifier: Identifier> <r: @R> <message: Section> => {
         let span = Span::new(l, r, comment_parser.file_name);
         ParamTag { identifier, message, span }
     },
 }
 
 ReturnsBlock: ReturnsTag = {
-    <l: @L> returns_keyword <identifier: Identifier?> <message: Section> <r: @R> => {
+    <l: @L> returns_keyword <identifier: Identifier?> <r: @R> <message: Section> => {
         let span = Span::new(l, r, comment_parser.file_name);
         ReturnsTag { identifier, message, span }
     },
 }
 
 ThrowsBlock: ThrowsTag = {
-    <l: @L> throws_keyword <identifier: ScopedIdentifier> <message: Section> <r: @R> => {
+    <l: @L> throws_keyword <identifier: ScopedIdentifier> <r: @R> <message: Section> => {
         let span = Span::new(l, r, comment_parser.file_name);
         let thrown_type = TypeRefDefinition::Unpatched(identifier);
         ThrowsTag { thrown_type, message, span }
@@ -99,13 +92,17 @@ InlineLink: LinkTag = {
 }
 
 Section: Message = {
-    <inline_message: (":" <Message?>)?> newline <message_lines: MessageLines?> => {
-        construct_section_message(inline_message.flatten(), message_lines)
+    <l: @L> <inline_message: (":" <Message?>)?> newline <message_lines: MessageLines?> <r: @R> => {
+        let span = Span::new(l, r, comment_parser.file_name);
+        construct_section_message(inline_message.flatten(), message_lines, span)
     },
 }
 
 MessageLines: Message = {
-    (<Message?> newline)+ => sanitize_message_lines(<>),
+    <l: @L> <m: (<Message?> newline)+> <r: @R> => {
+        let span = Span::new(l, r, comment_parser.file_name);
+        sanitize_message_lines(m, span)
+    }
 }
 
 Message = MessageComponent+;

--- a/src/patchers/comment_link_patcher.rs
+++ b/src/patchers/comment_link_patcher.rs
@@ -75,7 +75,7 @@ impl CommentLinkPatcher<'_> {
     fn compute_patches_for(&mut self, commentable: &impl Commentable, ast: &Ast) {
         if let Some(comment) = commentable.comment() {
             if let Some(overview) = &comment.overview {
-                self.resolve_links_in(&overview.message, commentable, ast);
+                self.resolve_links_in(overview, commentable, ast);
             }
             for param_tag in &comment.params {
                 self.resolve_links_in(&param_tag.message, commentable, ast);
@@ -94,7 +94,7 @@ impl CommentLinkPatcher<'_> {
     }
 
     fn resolve_links_in(&mut self, message: &Message, commentable: &impl Commentable, ast: &Ast) {
-        for component in message {
+        for component in &message.value {
             if let MessageComponent::Link(link_tag) = component {
                 self.resolve_link(&link_tag.link, commentable, ast);
             }
@@ -146,7 +146,7 @@ impl CommentLinkPatcher<'_> {
     fn apply_patches(&mut self, scope: &str, comment: &mut Option<DocComment>) {
         if let Some(comment) = comment {
             if let Some(overview) = &mut comment.overview {
-                self.patch_links_in(&mut overview.message);
+                self.patch_links_in(overview);
             }
             for param_tag in &mut comment.params {
                 self.patch_links_in(&mut param_tag.message);
@@ -165,7 +165,7 @@ impl CommentLinkPatcher<'_> {
     }
 
     fn patch_links_in(&mut self, message: &mut Message) {
-        for component in message {
+        for component in &mut message.value {
             if let MessageComponent::Link(link_tag) = component {
                 patch_link!(self, link_tag);
             }

--- a/src/slice_file.rs
+++ b/src/slice_file.rs
@@ -4,7 +4,7 @@ use crate::grammar::*;
 use crate::utils::ptr_util::WeakPtr;
 use console::style;
 use serde::Serialize;
-use std::cmp::Ordering;
+use std::cmp::{max, min, Ordering};
 use std::fmt::{Display, Write};
 
 const EXPANDED_TAB: &str = "    ";
@@ -51,6 +51,18 @@ impl Span {
     pub fn new(start: Location, end: Location, file: &str) -> Self {
         let file = file.to_owned();
         Span { start, end, file }
+    }
+}
+
+impl std::ops::Add for &Span {
+    type Output = Span;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Span {
+            start: min(self.start, rhs.start),
+            end: max(self.end, rhs.end),
+            file: self.file.clone(),
+        }
     }
 }
 

--- a/src/validators/operations.rs
+++ b/src/validators/operations.rs
@@ -70,7 +70,7 @@ fn validate_returns_tags_for_operation_with_no_return_type(
                 operation.identifier(),
             ),
         })
-        .set_span(returns_tag.span())
+        .set_span(&(returns_tag.span() + returns_tag.message.span()))
         .set_scope(operation.parser_scoped_identifier())
         .push_into(diagnostics);
     }
@@ -152,7 +152,7 @@ fn validate_throws_tags_for_operation_with_no_throws_clause(
                 operation.identifier(),
             ),
         })
-        .set_span(throws_tag.span())
+        .set_span(&(throws_tag.span() + throws_tag.message.span()))
         .set_scope(operation.parser_scoped_identifier())
         .push_into(diagnostics);
     }

--- a/tests/comment_tests.rs
+++ b/tests/comment_tests.rs
@@ -33,7 +33,7 @@ mod comments {
         assert_eq!(overview.span.start, (4, 16).into());
         assert_eq!(overview.span.end, (4, 51).into());
 
-        let message = &overview.message;
+        let message = &overview.value;
         assert_eq!(message.len(), 2);
         let MessageComponent::Text(text) = &message[0] else { panic!() };
         assert_eq!(text, "This is a single line doc comment.");
@@ -66,7 +66,7 @@ mod comments {
         assert_eq!(overview.span.start, (4, 16).into());
         assert_eq!(overview.span.end, (5, 39).into());
 
-        let message = &overview.message;
+        let message = &overview.value;
         assert_eq!(message.len(), 4);
         let MessageComponent::Text(text) = &message[0] else { panic!() };
         assert_eq!(text, "This is a");
@@ -101,7 +101,7 @@ mod comments {
 
         let param_tag = &param_tags[0];
         assert_eq!(param_tag.span.start, (5, 21).into());
-        assert_eq!(param_tag.span.end, (5, 52).into());
+        assert_eq!(param_tag.span.end, (5, 37).into());
 
         let identifier = &param_tag.identifier;
         assert_eq!(identifier.value, "testParam");
@@ -109,8 +109,12 @@ mod comments {
         assert_eq!(identifier.span.end, (5, 37).into());
 
         let message = &param_tag.message;
-        assert_eq!(message.len(), 2);
-        let MessageComponent::Text(text) = &message[0] else { panic!() };
+        assert_eq!(message.span.start, (5, 37).into());
+        assert_eq!(message.span.end, (5, 52).into());
+
+        let components = &message.value;
+        assert_eq!(components.len(), 2);
+        let MessageComponent::Text(text) = &components[0] else { panic!() };
         assert_eq!(text, "My test param");
     }
 
@@ -145,7 +149,9 @@ mod comments {
         assert_eq!(identifier.span.end, (5, 34).into());
 
         let message = &returns_tag.message;
-        assert!(message.is_empty());
+        assert!(message.value.is_empty());
+        assert_eq!(message.span.start, (5, 34).into());
+        assert_eq!(message.span.end, (5, 34).into());
     }
 
     #[test]
@@ -249,14 +255,18 @@ mod comments {
 
         let throws_tag = &throws_tags[0];
         assert_eq!(throws_tag.span.start, (8, 21).into());
-        assert_eq!(throws_tag.span.end, (8, 72).into());
+        assert_eq!(throws_tag.span.end, (8, 40).into());
 
         let thrown_type = throws_tag.thrown_type().unwrap();
         assert_eq!(thrown_type.parser_scoped_identifier(), "tests::MyException");
 
         let message = &throws_tag.message;
-        assert_eq!(message.len(), 2);
-        let MessageComponent::Text(text) = &message[0] else { panic!() };
+        assert_eq!(message.span.start, (8, 40).into());
+        assert_eq!(message.span.end, (8, 72).into());
+
+        let components = &message.value;
+        assert_eq!(components.len(), 2);
+        let MessageComponent::Text(text) = &components[0] else { panic!() };
         assert_eq!(text, "Message about my thrown thing.");
     }
 
@@ -351,7 +361,7 @@ mod comments {
         // Assert
         let struct_def = ast.find_element::<Struct>("tests::TestStruct").unwrap();
         let overview = &struct_def.comment().unwrap().overview;
-        let message = &overview.as_ref().unwrap().message;
+        let message = &overview.as_ref().unwrap().value;
 
         assert_eq!(message.len(), 3);
         let MessageComponent::Text(text) = &message[0] else { panic!() };

--- a/tests/diagnostic_output_tests.rs
+++ b/tests/diagnostic_output_tests.rs
@@ -38,7 +38,7 @@ mod output {
 
         // Assert
         let expected = concat!(
-            r#"{"message":"comment has a 'param' tag for 'x', but operation 'op' has no parameter with that name","severity":"warning","span":{"start":{"row":5,"col":17},"end":{"row":5,"col":39},"file":"string-0"},"notes":[],"error_code":"IncorrectDocComment"}"#,
+            r#"{"message":"comment has a 'param' tag for 'x', but operation 'op' has no parameter with that name","severity":"warning","span":{"start":{"row":5,"col":17},"end":{"row":5,"col":25},"file":"string-0"},"notes":[],"error_code":"IncorrectDocComment"}"#,
             "\n",
             r#"{"message":"invalid enum 'E': enums must contain at least one enumerator","severity":"error","span":{"start":{"row":9,"col":9},"end":{"row":9,"col":15},"file":"string-0"},"notes":[],"error_code":"E010"}"#,
             "\n",
@@ -86,7 +86,7 @@ warning [IncorrectDocComment]: comment has a 'param' tag for 'x', but operation 
  --> string-0:5:17
   |
 5 |             /// @param x: this is an x
-  |                 ----------------------
+  |                 --------
   |
 error [E019]: invalid tag on member 'x': tagged members must be optional
  --> string-0:8:17
@@ -172,7 +172,7 @@ error [E010]: invalid enum 'E': enums must contain at least one enumerator
 
         // Assert: Only one of the two lints should be allowed.
         let expected = concat!(
-            r#"{"message":"comment has a 'param' tag for 'x', but operation 'op' has no parameter with that name","severity":"warning","span":{"start":{"row":6,"col":21},"end":{"row":6,"col":43},"file":"string-0"},"notes":[],"error_code":"IncorrectDocComment"}"#,
+            r#"{"message":"comment has a 'param' tag for 'x', but operation 'op' has no parameter with that name","severity":"warning","span":{"start":{"row":6,"col":21},"end":{"row":6,"col":29},"file":"string-0"},"notes":[],"error_code":"IncorrectDocComment"}"#,
             "\n",
         );
         assert_eq!(expected, String::from_utf8(output).unwrap());


### PR DESCRIPTION
Currently, the location tracking for doc comments isn't granular. We store a `Span` for the entire comment, and one for each tag (`@param ...`, `@returns ...`, etc). The spans we store for a tag includes the tag itself _and_ the message that comes after it.

```
@param foo: This text is also part of the span!
```

This PR augments the location tracking for tags; now we track the tag `@param foo` and the message `This text is also part of the span` separately. This is more consistent with the locations we store for other Slice constructs (struct.span() doesn't include all the fields inside of it) and is more useful for the language server, which needs to differentiate between these two to tell what a user clicked on.

----

This also lets us remove the `Overview` struct. It only holds a `Message` and a `Span`. But now that `Message` has it's own span, `Overview` is kind of redundant. So I deleted it, and now wherever we held an `Overview` we just directly hold a `Message`.

----

This PR also adds support for adding spans together. This way we can recover the span for an entire doc comment by adding together the tag span and the message span.