### PR TITLE
Don't visit unpatched typerefs

### DIFF
--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -269,6 +269,8 @@ impl TypeRef {
     pub fn visit_with(&self, visitor: &mut impl Visitor) {
         visitor.visit_type_ref(self);
 
+        // If this typeref isn't patched, do not attempt to visit it further.
+        // Note that sequence and dictionary types (the only types we visit further) are always patched anyways.
         if matches!(&self.definition, TypeRefDefinition::Unpatched(_)) {
             return;
         }

--- a/src/visitor.rs
+++ b/src/visitor.rs
@@ -268,6 +268,11 @@ impl TypeRef {
     /// dictionary, it recursively calls itself on their underlying element, key, and value types.
     pub fn visit_with(&self, visitor: &mut impl Visitor) {
         visitor.visit_type_ref(self);
+
+        if matches!(&self.definition, TypeRefDefinition::Unpatched(_)) {
+            return;
+        }
+
         match self.concrete_type() {
             Types::Sequence(sequence_ref) => sequence_ref.element_type.visit_with(visitor),
             Types::Dictionary(dictionary_ref) => {


### PR DESCRIPTION
Fixes #671 by not visiting unattached types in the typeref visitor.
