### PR TITLE
Interfaces can no longer be used as types.

### DIFF
--- a/src/ast/node.rs
+++ b/src/ast/node.rs
@@ -97,7 +97,6 @@ impl<'a> TryFrom<&'a Node> for WeakPtr<dyn Type> {
         match node {
             Node::Struct(struct_ptr) => Ok(downgrade_as!(struct_ptr, dyn Type)),
             Node::Class(class_ptr) => Ok(downgrade_as!(class_ptr, dyn Type)),
-            Node::Interface(interface_ptr) => Ok(downgrade_as!(interface_ptr, dyn Type)),
             Node::Enum(enum_ptr) => Ok(downgrade_as!(enum_ptr, dyn Type)),
             Node::CustomType(custom_type_ptr) => Ok(downgrade_as!(custom_type_ptr, dyn Type)),
             Node::TypeAlias(type_alias_ptr) => Ok(downgrade_as!(type_alias_ptr, dyn Type)),
@@ -124,7 +123,6 @@ impl<'a> TryFrom<&'a Node> for &'a dyn Type {
         match node {
             Node::Struct(struct_ptr) => Ok(struct_ptr.borrow()),
             Node::Class(class_ptr) => Ok(class_ptr.borrow()),
-            Node::Interface(interface_ptr) => Ok(interface_ptr.borrow()),
             Node::Enum(enum_ptr) => Ok(enum_ptr.borrow()),
             Node::CustomType(custom_type_ptr) => Ok(custom_type_ptr.borrow()),
             Node::TypeAlias(type_alias_ptr) => Ok(type_alias_ptr.borrow()),

--- a/src/grammar/elements/exception.rs
+++ b/src/grammar/elements/exception.rs
@@ -39,6 +39,11 @@ impl Exception {
     pub fn base_exception(&self) -> Option<&Exception> {
         self.base.as_ref().map(TypeRef::definition)
     }
+
+    // This intentionally shadows the trait method of the same name on `Type`.
+    pub fn supported_encodings(&self) -> SupportedEncodings {
+        self.supported_encodings.clone().unwrap()
+    }
 }
 
 implement_Element_for!(Exception, "exception");

--- a/src/grammar/elements/interface.rs
+++ b/src/grammar/elements/interface.rs
@@ -2,7 +2,6 @@
 
 use super::super::*;
 use crate::slice_file::Span;
-use crate::supported_encodings::SupportedEncodings;
 use crate::utils::ptr_util::WeakPtr;
 
 #[derive(Debug)]
@@ -14,7 +13,6 @@ pub struct Interface {
     pub attributes: Vec<WeakPtr<Attribute>>,
     pub comment: Option<DocComment>,
     pub span: Span,
-    pub(crate) supported_encodings: Option<SupportedEncodings>,
 }
 
 impl Interface {
@@ -60,28 +58,6 @@ impl Interface {
         all_bases.retain(|base| seen_identifiers.insert(base.parser_scoped_identifier()));
 
         all_bases
-    }
-}
-
-impl Type for Interface {
-    fn type_string(&self) -> String {
-        self.identifier().to_owned()
-    }
-
-    fn fixed_wire_size(&self) -> Option<u32> {
-        None
-    }
-
-    fn is_class_type(&self) -> bool {
-        false
-    }
-
-    fn tag_format(&self) -> Option<TagFormat> {
-        Some(TagFormat::FSize)
-    }
-
-    fn supported_encodings(&self) -> SupportedEncodings {
-        self.supported_encodings.clone().unwrap()
     }
 }
 

--- a/src/grammar/elements/interface.rs
+++ b/src/grammar/elements/interface.rs
@@ -2,6 +2,7 @@
 
 use super::super::*;
 use crate::slice_file::Span;
+use crate::supported_encodings::SupportedEncodings;
 use crate::utils::ptr_util::WeakPtr;
 
 #[derive(Debug)]
@@ -13,6 +14,7 @@ pub struct Interface {
     pub attributes: Vec<WeakPtr<Attribute>>,
     pub comment: Option<DocComment>,
     pub span: Span,
+    pub(crate) supported_encodings: Option<SupportedEncodings>,
 }
 
 impl Interface {
@@ -58,6 +60,11 @@ impl Interface {
         all_bases.retain(|base| seen_identifiers.insert(base.parser_scoped_identifier()));
 
         all_bases
+    }
+
+    // This intentionally shadows the trait method of the same name on `Type`.
+    pub fn supported_encodings(&self) -> SupportedEncodings {
+        self.supported_encodings.clone().unwrap()
     }
 }
 

--- a/src/grammar/wrappers.rs
+++ b/src/grammar/wrappers.rs
@@ -112,4 +112,4 @@ pub trait AsTypes {
     fn concrete_type(&self) -> Types;
 }
 
-generate_types_wrapper!(Struct, Class, Interface, Enum, CustomType, Sequence, Dictionary, Primitive);
+generate_types_wrapper!(Struct, Class, Enum, CustomType, Sequence, Dictionary, Primitive);

--- a/src/parsers/slice/grammar.rs
+++ b/src/parsers/slice/grammar.rs
@@ -242,6 +242,7 @@ fn construct_interface(
         attributes,
         comment,
         span,
+        supported_encodings: None, // Patched by the encoding patcher.
     });
 
     // Add all the operations to the interface.

--- a/src/parsers/slice/grammar.rs
+++ b/src/parsers/slice/grammar.rs
@@ -242,7 +242,6 @@ fn construct_interface(
         attributes,
         comment,
         span,
-        supported_encodings: None, // Patched by the encoding patcher.
     });
 
     // Add all the operations to the interface.

--- a/src/patchers/encoding_patcher.rs
+++ b/src/patchers/encoding_patcher.rs
@@ -36,8 +36,11 @@ pub unsafe fn patch_ast(compilation_state: &mut CompilationState) {
                 exception_ptr.borrow_mut().supported_encodings = Some(encodings);
             }
             Node::Interface(interface_ptr) => {
-                let encodings = patcher.get_supported_encodings_for(interface_ptr.borrow());
-                interface_ptr.borrow_mut().supported_encodings = Some(encodings);
+                // We still compute which encodings an interface can be used with, so we can validate that the interface
+                // is supported by whatever compilation mode it has been declared in.
+                // But since interfaces aren't a type, we don't need to store the result of this computation, since
+                // nothing can reference this interface except other interfaces.
+                patcher.get_supported_encodings_for(interface_ptr.borrow());
             }
             Node::Enum(enum_ptr) => {
                 let encodings = patcher.get_supported_encodings_for(enum_ptr.borrow());
@@ -135,10 +138,6 @@ impl EncodingPatcher<'_> {
             Types::Class(class_def) => {
                 allow_nullable_with_slice_1 = true;
                 self.get_supported_encodings_for(class_def)
-            }
-            Types::Interface(interface_def) => {
-                allow_nullable_with_slice_1 = true;
-                self.get_supported_encodings_for(interface_def)
             }
             Types::Enum(enum_def) => self.get_supported_encodings_for(enum_def),
             Types::CustomType(custom_type) => {

--- a/src/patchers/encoding_patcher.rs
+++ b/src/patchers/encoding_patcher.rs
@@ -36,11 +36,8 @@ pub unsafe fn patch_ast(compilation_state: &mut CompilationState) {
                 exception_ptr.borrow_mut().supported_encodings = Some(encodings);
             }
             Node::Interface(interface_ptr) => {
-                // We still compute which encodings an interface can be used with, so we can validate that the interface
-                // is supported by whatever compilation mode it has been declared in.
-                // But since interfaces aren't a type, we don't need to store the result of this computation, since
-                // nothing can reference this interface except other interfaces.
-                patcher.get_supported_encodings_for(interface_ptr.borrow());
+                let encodings = patcher.get_supported_encodings_for(interface_ptr.borrow());
+                interface_ptr.borrow_mut().supported_encodings = Some(encodings);
             }
             Node::Enum(enum_ptr) => {
                 let encodings = patcher.get_supported_encodings_for(enum_ptr.borrow());

--- a/src/validators/dictionary.rs
+++ b/src/validators/dictionary.rs
@@ -49,7 +49,6 @@ fn check_dictionary_key_type(type_ref: &TypeRef) -> Option<Diagnostic> {
             true
         }
         Types::Class(_) => false,
-        Types::Interface(_) => false,
         Types::Enum(_) => true,
         Types::CustomType(_) => true,
         Types::Sequence(_) => false,
@@ -71,9 +70,9 @@ fn check_dictionary_key_type(type_ref: &TypeRef) -> Option<Diagnostic> {
 }
 
 fn formatted_kind(definition: &dyn Type) -> String {
-    match definition.concrete_type() {
-        Types::Class(c) => format!("{} '{}'", c.kind(), c.identifier()),
-        Types::Interface(i) => format!("{} '{}'", i.kind(), i.identifier()),
-        _ => definition.kind().to_owned(),
+    if let Types::Class(class_def) = definition.concrete_type() {
+        format!("class '{}'", class_def.identifier())
+    } else {
+        definition.kind().to_owned()
     }
 }

--- a/src/validators/members.rs
+++ b/src/validators/members.rs
@@ -57,7 +57,6 @@ fn tagged_members_cannot_use_classes(members: Vec<&impl Member>, diagnostics: &m
         match typeref.definition().concrete_type() {
             Types::Struct(struct_def) => struct_def.fields().iter().any(|m| uses_classes(&m.data_type)),
             Types::Class(_) => true,
-            Types::Interface(_) => false,
             Types::Enum(_) => false,
             Types::CustomType(_) => false,
             Types::Sequence(sequence) => uses_classes(&sequence.element_type),

--- a/tests/dictionaries/key_type.rs
+++ b/tests/dictionaries/key_type.rs
@@ -108,7 +108,6 @@ fn allowed_constructed_types(key_type: &str, key_type_def: &str) {
 }
 
 #[test_case("MyClass", "class", "Slice1"; "classes")]
-#[test_case("MyInterface", "interface", "Slice2"; "interfaces")]
 fn disallowed_constructed_types(key_type: &str, key_kind: &str, mode: &str) {
     // Arrange
     let slice = format!(

--- a/tests/interfaces/mod.rs
+++ b/tests/interfaces/mod.rs
@@ -27,21 +27,6 @@ fn can_have_no_operations() {
 }
 
 #[test]
-fn can_have_self_referencing_operations() {
-    // Arrange
-    let slice = "
-        module Test
-
-        interface I {
-            myOp() -> I
-        }
-    ";
-
-    // Act/Assert
-    assert_parses(slice);
-}
-
-#[test]
 fn can_have_one_operation() {
     // Arrange
     let slice = "

--- a/tests/mixed_encoding_tests.rs
+++ b/tests/mixed_encoding_tests.rs
@@ -21,17 +21,12 @@ fn valid_mixed_compilation_mode_succeeds() {
             A
             B
         }
-
-        interface AnInterface {
-            op() -> AnEnum
-        }
     ";
     let slice2 = "
         mode = Slice2
         module Test
         struct AStruct {
             e: AnEnum
-            i: AnInterface
             c: ACompactStruct
         }
     ";

--- a/tests/optional_tests.rs
+++ b/tests/optional_tests.rs
@@ -125,7 +125,6 @@ mod optional {
         }
 
         #[test_case("class Foo {}"; "class")]
-        #[test_case("interface Foo {}"; "interface")]
         #[test_case("custom Foo"; "custom type")]
         fn optional_user_defined_types_are_allowed(definition: &str) {
             // Arrange
@@ -447,7 +446,6 @@ mod optional {
 
         #[test_case("struct Foo {}"; "r#struct")]
         #[test_case("unchecked enum Foo: uint8 {}"; "r#enum")]
-        #[test_case("interface Foo {}"; "interface")]
         #[test_case("custom Foo"; "custom type")]
         fn optional_user_defined_types_are_allowed(definition: &str) {
             // Arrange

--- a/tests/typealias_tests.rs
+++ b/tests/typealias_tests.rs
@@ -12,7 +12,6 @@ mod typealias {
 
     #[test_case("struct S {}", "S", "Slice2"; "structs")]
     #[test_case("class C {}", "C", "Slice1"; "classes")]
-    #[test_case("interface I {}", "I", "Slice2"; "interfaces")]
     #[test_case("enum E { Foo }", "E", "Slice1"; "enums")]
     #[test_case("custom C", "C", "Slice2"; "custom types")]
     #[test_case("", "bool", "Slice2"; "primitives")]


### PR DESCRIPTION
This implements the parser side of #673.

Interfaces can no longer be used as a type in Slice; i.e. it no longer implements the `Type` trait.

On a more conceptual level. Defining an interface no longer implicitly defines a corresponding proxy type.