### PR TITLE
Fix Parser Panicing when Emitting a Syntax Error Message with No Expected Tokens

### DIFF
--- a/src/parsers/preprocessor/mod.rs
+++ b/src/parsers/preprocessor/mod.rs
@@ -56,13 +56,13 @@ fn construct_error_from(parse_error: ParseError, file_name: &str) -> Diagnostic 
 
 fn generate_message(expected: &[String], found: impl std::fmt::Debug) -> String {
     let expected_message = match expected {
-        [] => "expected no tokens, ".to_owned(),
-        [first] => format!("expected one of {first}, "),
-        [first, second] => format!("expected one of {first} or {second}, "),
+        [] => "expected no tokens".to_owned(),
+        [first] => format!("expected one of {first}"),
+        [first, second] => format!("expected one of {first} or {second}"),
         many => {
             let (last, others) = many.split_last().unwrap();
-            format!("expected one of {}, or {last}, ", others.join(", "))
+            format!("expected one of {}, or {last}", others.join(", "))
         }
     };
-    format!("{expected_message} but found '{found:?}'")
+    format!("{expected_message}, but found '{found:?}'")
 }

--- a/src/parsers/preprocessor/mod.rs
+++ b/src/parsers/preprocessor/mod.rs
@@ -35,16 +35,13 @@ fn construct_error_from(parse_error: ParseError, file_name: &str) -> Diagnostic 
             token: (start, token_kind, end),
             expected,
         } => {
-            let message = format!(
-                "expected one of {}, but found '{token_kind:?}'",
-                clean_message(&expected)
-            );
+            let message = generate_message(&expected, token_kind);
             Diagnostic::new(Error::Syntax { message }).set_span(&Span::new(start, end, file_name))
         }
 
         // The parser hit EOF in the middle of a grammar rule.
         ParseError::UnrecognizedEof { location, expected } => {
-            let message = format!("expected one of {}, but found 'EOF'", clean_message(&expected));
+            let message = generate_message(&expected, "EOF");
             Diagnostic::new(Error::Syntax { message }).set_span(&Span::new(location, location, file_name))
         }
 
@@ -57,13 +54,15 @@ fn construct_error_from(parse_error: ParseError, file_name: &str) -> Diagnostic 
     }
 }
 
-fn clean_message(expected: &[String]) -> String {
-    match expected {
-        [first] => first.to_owned(),
-        [first, second] => format!("{first} or {second}"),
+fn generate_message(expected: &[String], found: impl std::fmt::Debug) -> String {
+    let expected_message = match expected {
+        [] => "expected no tokens, ".to_owned(),
+        [first] => format!("expected one of {first}, "),
+        [first, second] => format!("expected one of {first} or {second}, "),
         many => {
             let (last, others) = many.split_last().unwrap();
-            format!("{}, or {last}", others.join(", "))
+            format!("expected one of {}, or {last}, ", others.join(", "))
         }
-    }
+    };
+    format!("{expected_message} but found '{found:?}'")
 }

--- a/src/parsers/slice/mod.rs
+++ b/src/parsers/slice/mod.rs
@@ -32,13 +32,13 @@ fn construct_error_from(parse_error: ParseError, file_name: &str) -> Diagnostic 
             token: (start, token_kind, end),
             expected,
         } => {
-            let message = format!("expected one of {}, but found '{token_kind}'", clean_message(&expected));
+            let message = generate_message(&expected, token_kind);
             Diagnostic::new(Error::Syntax { message }).set_span(&Span::new(start, end, file_name))
         }
 
         // The parser hit EOF in the middle of a grammar rule.
         ParseError::UnrecognizedEof { location, expected } => {
-            let message = format!("expected one of {}, but found 'EOF'", clean_message(&expected));
+            let message = generate_message(&expected, "EOF");
             Diagnostic::new(Error::Syntax { message }).set_span(&Span::new(location, location, file_name))
         }
 
@@ -47,7 +47,7 @@ fn construct_error_from(parse_error: ParseError, file_name: &str) -> Diagnostic 
 }
 
 // TODO: simplify this or merge the match statements in this function and tokens.rs together.
-fn clean_message(expected: &[String]) -> String {
+fn generate_message(expected: &[String], found: impl std::fmt::Display) -> String {
     let keyword = expected
         .iter()
         .map(|s| match s.as_str() {
@@ -123,12 +123,14 @@ fn clean_message(expected: &[String]) -> String {
         .map(|s| format!("'{s}'"))
         .collect::<Vec<String>>();
 
-    match &keyword[..] {
-        [first] => first.to_owned(),
-        [first, second] => format!("{first} or {second}"),
+    let expected_message = match &keyword[..] {
+        [] => "expected no tokens".to_owned(),
+        [first] => format!("expected one of {first}"),
+        [first, second] => format!("expected one of {first} or {second}"),
         many => {
             let (last, others) = many.split_last().unwrap();
-            format!("{}, or {last}", others.join(", "))
+            format!("expected one of {}, or {last}", others.join(", "))
         }
-    }
+    };
+    format!("{expected_message}, but found '{found}'")
 }


### PR DESCRIPTION
Each parser has a 'clean_message' function that's responsible for taking a LALRPOP error and making it readable before passing it off to the user, but these functions do not handle the case where the parser expected no tokens.

For example:
```
#else Hello
```
It's invalid for tokens to appear after `else`.