### PR TITLE
Add Support for Compact Enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Future] - Sometime
+### Added
+- Added support for compact enums ([686]).
+### Breaking
+- Only simple enums can be used as dictionary key types ([685]).
+
 ## [0.2.1] - 2023-11-29
 ### Enhancements
 - Added default no-op implementations to `Visitor` to make it easier to implement ([678]).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Changelog
 
-## [Future] - Sometime
-### Added
-- Added support for compact enums ([686]).
-### Breaking
-- Only simple enums can be used as dictionary key types ([685]).
-
 ## [0.2.1] - 2023-11-29
 ### Enhancements
 - Added default no-op implementations to `Visitor` to make it easier to implement ([678]).

--- a/src/diagnostics/errors.rs
+++ b/src/diagnostics/errors.rs
@@ -90,6 +90,14 @@ pub enum Error {
         enum_identifier: String,
     },
 
+    /// A type was marked 'compact' when it was invalid to do so.
+    CannotBeCompact {
+        /// The kind of type that was marked compact.
+        kind: &'static str,
+        /// The identifier of the type.
+        identifier: String,
+    },
+
     /// An enumerator was found that was out of bounds of the underlying type of the parent enum.
     EnumeratorValueOutOfBounds {
         /// The identifier of the enumerator.
@@ -137,9 +145,6 @@ pub enum Error {
     /// Compact structs cannot be empty.
     CompactStructCannotBeEmpty,
 
-    /// Compact structs cannot contain tagged fields.
-    CompactStructCannotContainTaggedFields,
-
     // ----------------  Tag Errors ---------------- //
     /// A duplicate tag value was found.
     CannotHaveDuplicateTag {
@@ -166,6 +171,12 @@ pub enum Error {
     TaggedMemberMustBeOptional {
         /// The identifier of the tagged member.
         identifier: String,
+    },
+
+    /// Compact types cannot contain tagged fields.
+    CompactTypeCannotContainTaggedFields {
+        /// The kind of type that contains the fields.
+        kind: &'static str,
     },
 
     // ----------------  General Errors ---------------- //
@@ -365,8 +376,9 @@ implement_diagnostic_functions!(
     ),
     (
         "E018",
-        CompactStructCannotContainTaggedFields,
-        "tagged fields are not supported in compact structs\nconsider removing the tag, or making the struct non-compact"
+        CompactTypeCannotContainTaggedFields,
+        format!("tagged fields are not supported in compact {kind}s\nconsider removing the tag, or making the {kind} non-compact"),
+        kind
     ),
     (
         "E019",
@@ -552,6 +564,12 @@ implement_diagnostic_functions!(
         EnumeratorCannotContainFields,
         format!("invalid enumerator '{enumerator_identifier}': fields cannot be declared within enums that specify an underlying type"),
         enumerator_identifier
+    ),
+    (
+        "E055",
+        CannotBeCompact,
+        format!("'{kind}' '{identifier}' cannot be marked compact"),
+        kind, identifier
     )
 );
 

--- a/src/grammar/elements/enum.rs
+++ b/src/grammar/elements/enum.rs
@@ -10,6 +10,7 @@ pub struct Enum {
     pub identifier: Identifier,
     pub enumerators: Vec<WeakPtr<Enumerator>>,
     pub underlying: Option<TypeRef<Primitive>>,
+    pub is_compact: bool,
     pub is_unchecked: bool,
     pub scope: Scope,
     pub attributes: Vec<WeakPtr<Attribute>>,

--- a/src/parsers/slice/grammar.lalrpop
+++ b/src/parsers/slice/grammar.lalrpop
@@ -194,9 +194,9 @@ ExceptionSpecification: Vec<TypeRef> = {
 }
 
 Enum: OwnedPtr<Enum> = {
-    <p: Prelude> <l1: @L> <uk: unchecked_keyword?> <l2: @L> enum_keyword <i: ContainerIdentifier> <r: @R> <tr: (":" <TypeRef>)?> "{" <es: UndelimitedList<Enumerator>> "}" ContainerEnd => {
-        let l = if uk.is_some() { l1 } else { l2 };
-        construct_enum(parser, p, uk.is_some(), i, tr, es, Span::new(l, r, parser.file_name))
+    <p: Prelude> <l1: @L> <ck: compact_keyword?> <uk: unchecked_keyword?> <l2: @L> enum_keyword <i: ContainerIdentifier> <r: @R> <tr: (":" <TypeRef>)?> "{" <es: UndelimitedList<Enumerator>> "}" ContainerEnd => {
+        let l = if ck.is_some() || uk.is_some() { l1 } else { l2 };
+        construct_enum(parser, p, ck.is_some(), uk.is_some(), i, tr, es, Span::new(l, r, parser.file_name))
     },
 }
 

--- a/src/parsers/slice/grammar.rs
+++ b/src/parsers/slice/grammar.rs
@@ -359,9 +359,11 @@ fn check_return_tuple(parser: &mut Parser, return_tuple: &Vec<OwnedPtr<Parameter
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn construct_enum(
     parser: &mut Parser,
     (raw_comment, attributes): (RawDocComment, Vec<WeakPtr<Attribute>>),
+    is_compact: bool,
     is_unchecked: bool,
     identifier: Identifier,
     underlying_type: Option<TypeRef>,
@@ -375,6 +377,7 @@ fn construct_enum(
         identifier,
         enumerators: Vec::new(),
         underlying,
+        is_compact,
         is_unchecked,
         scope: parser.current_scope.clone(),
         attributes,

--- a/src/patchers/encoding_patcher.rs
+++ b/src/patchers/encoding_patcher.rs
@@ -415,6 +415,14 @@ impl ComputeSupportedEncodings for Enum {
             }
         }
 
+        if self.is_compact {
+            // Compact enums are not allowed in Slice1 mode.
+            supported_encodings.disable(Encoding::Slice1);
+            if compilation_mode == CompilationMode::Slice1 {
+                return Some("enums defined in Slice1 mode cannot be 'compact'");
+            }
+        }
+
         for enumerator in self.enumerators() {
             // Enums with fields are not allowed in Slice1 mode.
             if enumerator.fields.is_some() {

--- a/src/validators/structs.rs
+++ b/src/validators/structs.rs
@@ -21,13 +21,15 @@ fn compact_structs_cannot_contain_tags(struct_def: &Struct, diagnostics: &mut Di
     if struct_def.is_compact {
         for field in struct_def.fields() {
             if field.is_tagged() {
-                Diagnostic::new(Error::CompactStructCannotContainTaggedFields)
-                    .set_span(field.span())
-                    .add_note(
-                        format!("struct '{}' is declared compact here", struct_def.identifier()),
-                        Some(struct_def.span()),
-                    )
-                    .push_into(diagnostics);
+                Diagnostic::new(Error::CompactTypeCannotContainTaggedFields {
+                    kind: struct_def.kind(),
+                })
+                .set_span(field.span())
+                .add_note(
+                    format!("struct '{}' is declared compact here", struct_def.identifier()),
+                    Some(struct_def.span()),
+                )
+                .push_into(diagnostics);
             }
         }
     }

--- a/tests/dictionaries/key_type.rs
+++ b/tests/dictionaries/key_type.rs
@@ -109,6 +109,7 @@ fn allowed_constructed_types(key_type: &str, key_type_def: &str) {
 }
 
 #[test_case("MyEnum", "enum MyEnum { A }", "enum", "Slice2" ; "enums")]
+#[test_case("MyEnum", "compact enum MyEnum { A }", "enum", "Slice2" ; "compact enums")]
 #[test_case("MyEnum", "unchecked enum MyEnum {}", "enum", "Slice2" ; "unchecked enums")]
 #[test_case("MyClass", "class MyClass {}", "class", "Slice1"; "classes")]
 fn disallowed_constructed_types(key_type: &str, key_type_def: &str, key_kind: &str, mode: &str) {

--- a/tests/enums/container.rs
+++ b/tests/enums/container.rs
@@ -33,6 +33,44 @@ mod associated_fields {
     use test_case::test_case;
 
     #[test]
+    fn enumerator_fields_can_be_tagged() {
+        // Arrange
+        let slice = "
+        module Test
+        enum E {
+            A(tag(1) b: bool?),
+        }
+        ";
+
+        // Act
+        let ast = parse_for_ast(slice);
+
+        // Assert
+        let field = ast.find_element::<Field>("Test::E::A::b").unwrap();
+        assert!(field.is_tagged());
+    }
+
+    #[test]
+    fn tags_are_disallowed_in_compact_enums() {
+        // Arrange
+        let slice = "
+        module Test
+        compact enum E {
+            A(tag(1) b: bool?),
+        }
+        ";
+
+        // Act
+        let diagnostics = parse_for_diagnostics(slice);
+
+        // Assert
+        let expected = Diagnostic::new(Error::CompactTypeCannotContainTaggedFields { kind: "enum" })
+            .add_note("enum 'E' is declared compact here", None);
+
+        check_diagnostics(diagnostics, [expected]);
+    }
+
+    #[test]
     fn explicit_values_are_not_allowed() {
         // Arrange
         let slice = "

--- a/tests/enums/mod.rs
+++ b/tests/enums/mod.rs
@@ -5,6 +5,7 @@ mod mode_compatibility;
 
 use crate::test_helpers::*;
 use slicec::diagnostics::{Diagnostic, Error};
+use slicec::slice_file::Span;
 use test_case::test_case;
 
 #[test_case("int8"; "int8")]
@@ -76,5 +77,81 @@ fn optional_underlying_types_fail() {
     let expected = Diagnostic::new(Error::CannotUseOptionalUnderlyingType {
         enum_identifier: "E".to_owned(),
     });
+    check_diagnostics(diagnostics, [expected]);
+}
+
+#[test]
+fn enums_can_be_unchecked() {
+    // Arrange
+    let slice = "
+        module Test
+
+        unchecked enum E { A }
+    ";
+
+    // Act/Assert
+    assert_parses(slice);
+}
+
+#[test]
+fn enums_can_be_compact() {
+    // Arrange
+    let slice = "
+        module Test
+
+        compact enum E { A }
+    ";
+
+    // Act/Assert
+    assert_parses(slice);
+}
+
+#[test]
+fn compact_enums_cannot_have_underlying_types() {
+    // Arrange
+    let slice = "
+        module Test
+
+        compact enum E: uint8 { A }
+    ";
+
+    // Act
+    let diagnostics = parse_for_diagnostics(slice);
+
+    // Assert
+    let expected = Diagnostic::new(Error::CannotBeCompact {
+        kind: "enum",
+        identifier: "E".to_owned(),
+    })
+    .set_span(&Span::new((4, 9).into(), (4, 23).into(), "string-0"))
+    .add_note(
+        "compact enums cannot also have underlying types\ntry removing either the 'compact' modifier, or the underlying type",
+        Some(&Span::new((4, 25).into(), (4, 30).into(), "string-0")),
+    );
+    check_diagnostics(diagnostics, [expected]);
+}
+
+#[test]
+fn compact_enums_cannot_be_unchecked() {
+    // Arrange
+    let slice = "
+        module Test
+
+        compact unchecked enum E { A }
+    ";
+
+    // Act
+    let diagnostics = parse_for_diagnostics(slice);
+
+    // Assert
+    let expected = Diagnostic::new(Error::CannotBeCompact {
+        kind: "enum",
+        identifier: "E".to_owned(),
+    })
+    .set_span(&Span::new((4, 9).into(), (4, 33).into(), "string-0"))
+    .add_note(
+        "An enum cannot be both unchecked and compact - try removing the 'compact' modifier",
+        None,
+    );
     check_diagnostics(diagnostics, [expected]);
 }

--- a/tests/enums/mode_compatibility.rs
+++ b/tests/enums/mode_compatibility.rs
@@ -111,4 +111,33 @@ mod slice1 {
         );
         check_diagnostics(diagnostics, [expected]);
     }
+
+    /// Verifies that compact enums are disallowed in Slice1 mode.
+    #[test]
+    fn compact_enums_fail() {
+        // Arrange
+        let slice = "
+            mode = Slice1
+            module Test
+
+            compact enum E {
+                A
+            }
+        ";
+
+        // Act
+        let diagnostics = parse_for_diagnostics(slice);
+
+        // Assert
+        let expected = Diagnostic::new(Error::NotSupportedInCompilationMode {
+            kind: "enum".to_owned(),
+            identifier: "E".to_owned(),
+            mode: CompilationMode::Slice1,
+        })
+        .add_note(
+            "enums defined in Slice1 mode cannot be 'compact'",
+            None,
+        );
+        check_diagnostics(diagnostics, [expected]);
+    }
 }

--- a/tests/structs/tags.rs
+++ b/tests/structs/tags.rs
@@ -49,7 +49,7 @@ mod compact_structs {
         let diagnostics = parse_for_diagnostics(slice);
 
         // Assert
-        let expected = Diagnostic::new(Error::CompactStructCannotContainTaggedFields)
+        let expected = Diagnostic::new(Error::CompactTypeCannotContainTaggedFields { kind: "struct" })
             .add_note("struct 'S' is declared compact here", None);
 
         check_diagnostics(diagnostics, [expected]);


### PR DESCRIPTION
This PR implements #681 by adding support for compact enums.
Compact enums work just like compact structs: we don't encode `TagEndMarker`, and tags cannot be used within the enum.

A compact enum cannot have an underlying type (since they're already 'compact') nor can it be unchecked (since we already don't encode `TagEndMarker` then).