### PR TITLE
Allow Settings Explicit Discriminants for Enums with Fields

### DIFF
--- a/src/diagnostics/errors.rs
+++ b/src/diagnostics/errors.rs
@@ -74,11 +74,6 @@ pub enum Error {
         enumerator_value: i128,
     },
 
-    /// Enumerators cannot declare explicit values when their enclosing enum doesn't have an underlying type.
-    EnumeratorCannotDeclareExplicitValue {
-        enumerator_identifier: String,
-    },
-
     /// Enumerators cannot contain fields when their enclosing enum has an underlying type.
     EnumeratorCannotContainFields {
         enumerator_identifier: String,
@@ -552,12 +547,6 @@ implement_diagnostic_functions!(
         "E052",
         ExceptionSpecificationNotSupported,
         "exceptions can only be thrown by operations defined in Slice1 mode"
-    ),
-    (
-        "E053",
-        EnumeratorCannotDeclareExplicitValue,
-        format!("invalid enumerator '{enumerator_identifier}': explicit values can only be declared within enums that specify an underlying type"),
-        enumerator_identifier
     ),
     (
         "E054",

--- a/src/validators/enums.rs
+++ b/src/validators/enums.rs
@@ -66,8 +66,8 @@ fn backing_type_bounds(enum_def: &Enum, diagnostics: &mut Diagnostics) {
             }
             None => {
                 // For enumerators in Slice2, values must fit within varint32 and be positive.
-                let varint32_max = Primitive::VarInt32.numeric_bounds().unwrap().1;
-                check_bounds(enum_def, (0, varint32_max), diagnostics);
+                const VARINT32_MAX: i128 = i32::MAX as i128;
+                check_bounds(enum_def, (0, VARINT32_MAX), diagnostics);
             }
         }
     }

--- a/tests/enums/container.rs
+++ b/tests/enums/container.rs
@@ -71,25 +71,37 @@ mod associated_fields {
     }
 
     #[test]
-    fn explicit_values_are_not_allowed() {
+    fn explicit_values_are_allowed() {
         // Arrange
         let slice = "
             module Test
             enum E {
                 A
                 B = 7
-                C
+                C(a: int8)
+                D(b: bool) = 4
             }
         ";
 
         // Act
-        let diagnostics = parse_for_diagnostics(slice);
+        let ast = parse_for_ast(slice);
 
         // Assert
-        let expected = Diagnostic::new(Error::EnumeratorCannotDeclareExplicitValue {
-            enumerator_identifier: "B".to_owned(),
-        });
-        check_diagnostics(diagnostics, [expected]);
+        let enumerator_a = ast.find_element::<Enumerator>("Test::E::A").unwrap();
+        assert!(matches!(enumerator_a.value, EnumeratorValue::Implicit(0)));
+        assert_eq!(enumerator_a.value(), 0);
+
+        let enumerator_b = ast.find_element::<Enumerator>("Test::E::B").unwrap();
+        assert!(matches!(enumerator_b.value, EnumeratorValue::Explicit(_)));
+        assert_eq!(enumerator_b.value(), 7);
+
+        let enumerator_c = ast.find_element::<Enumerator>("Test::E::C").unwrap();
+        assert!(matches!(enumerator_c.value, EnumeratorValue::Implicit(8)));
+        assert_eq!(enumerator_c.value(), 8);
+
+        let enumerator_d = ast.find_element::<Enumerator>("Test::E::D").unwrap();
+        assert!(matches!(enumerator_d.value, EnumeratorValue::Explicit(_)));
+        assert_eq!(enumerator_d.value(), 4);
     }
 
     #[test]


### PR DESCRIPTION
This PR allows users to set explicit discriminants for their enumerators, even if they have fields.
It also fixes the range of these discriminants so they must fit within [0, int32::MAX].