### PR TITLE
Sha256 hashing for SliceFile added

### DIFF
--- a/.vscode/cspell.json
+++ b/.vscode/cspell.json
@@ -13,6 +13,7 @@
     "downcasting",
     "encodable",
     "grcov",
+    "Hashable",
     "Hasher",
     "icerpc",
     "lalrpop",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ lalrpop-util = "0.20.2"
 # derive feature allows structs to derive Serialize automatically
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0.115"
+sha2 = "0.10.8"
 
 [build-dependencies]
 # The default features enable a built-in lexer. We supply our own lexer so we don't need these.

--- a/src/slice_file.rs
+++ b/src/slice_file.rs
@@ -167,18 +167,6 @@ impl SliceFile {
 
         formatted_snippet + &line_prefix
     }
-
-    /// Hash the combination of the filename and the raw text using a SHA-256 hash.
-    ///
-    /// # Returns
-    /// The SHA-256 hash as a 32-byte array.
-    pub fn compute_sha256_hash(&self) -> [u8; 32] {
-        Sha256::new()
-            .chain_update(self.filename.as_bytes())
-            .chain_update(self.raw_text.as_bytes())
-            .finalize()
-            .into()
-    }
 }
 
 pub trait SliceFileHashable {

--- a/src/slice_file.rs
+++ b/src/slice_file.rs
@@ -4,6 +4,7 @@ use crate::grammar::*;
 use crate::utils::ptr_util::WeakPtr;
 use console::style;
 use serde::Serialize;
+use sha2::{Digest, Sha256};
 use std::cmp::{max, min, Ordering};
 use std::fmt::{Display, Write};
 
@@ -165,6 +166,19 @@ impl SliceFile {
         }
 
         formatted_snippet + &line_prefix
+    }
+
+    /// Hash the combination of the filename, relative path, and raw text using a SHA-256 hash.
+    ///
+    /// # Returns
+    /// The SHA-256 hash as a vector of bytes.
+    pub fn compute_sha256_hash(&self) -> Vec<u8> {
+        Sha256::new()
+            .chain_update(self.filename.as_bytes())
+            .chain_update(self.relative_path.as_bytes())
+            .chain_update(self.raw_text.as_bytes())
+            .finalize()
+            .to_vec()
     }
 }
 

--- a/src/slice_file.rs
+++ b/src/slice_file.rs
@@ -196,7 +196,7 @@ impl SliceFileHashable for SliceFile {
     }
 }
 
-impl SliceFileHashable for &[&SliceFile] {
+impl SliceFileHashable for &[SliceFile] {
     fn compute_sha256_hash_as_bytes(&self) -> [u8; 32] {
         // Sort the slice files by their filename before hashing them.
         let mut sorted = self.iter().collect::<Vec<_>>();
@@ -212,16 +212,6 @@ impl SliceFileHashable for &[&SliceFile] {
             })
             .finalize()
             .into()
-    }
-}
-
-impl SliceFileHashable for &[SliceFile] {
-    fn compute_sha256_hash_as_bytes(&self) -> [u8; 32] {
-        // Use the `SliceFileHashable` implementation for slices of references.
-        self.iter()
-            .collect::<Vec<_>>()
-            .as_slice()
-            .compute_sha256_hash_as_bytes()
     }
 }
 

--- a/tests/files/mod.rs
+++ b/tests/files/mod.rs
@@ -8,24 +8,29 @@ use slicec::slice_options::SliceOptions;
 use slicec::utils::file_util::resolve_files_from;
 use std::path::PathBuf;
 
-/// This test is used to verify that the `hash_all` method returns a hash that is stable across releases and uses
-/// the correct ordering of files.
+/// This test is used to verify that the `compute_sha256_hash` method for slices of `SliceFile` returns a hash that is
+/// independent of the order of the files in the slice.
 #[test]
 fn fixed_slice_file_hash() {
     // Arrange
-    let fixed_hash = "df7e2e0f34d0c8d389870dad726c4d8cacc544c24f9d4516c38c88783eaac20c";
-    let mut diagnostics = Diagnostics::new();
-    let file1 = PathBuf::from("tests/files/test.slice");
-    let file2 = PathBuf::from("tests/files/a.slice");
-    let options = SliceOptions {
-        sources: vec![file1.to_str().unwrap().to_owned(), file2.to_str().unwrap().to_owned()],
+    let file1 = PathBuf::from("tests/files/test.slice").to_str().unwrap().to_owned();
+    let file2 = PathBuf::from("tests/files/a.slice").to_str().unwrap().to_owned();
+    let options1 = SliceOptions {
+        sources: vec![file1.clone(), file2.clone()],
         ..Default::default()
     };
-    let files = resolve_files_from(&options, &mut diagnostics);
+    let options2 = SliceOptions {
+        sources: vec![file2, file1],
+        ..Default::default()
+    };
+    let mut diagnostics = Diagnostics::new();
+    let slice_files1 = resolve_files_from(&options1, &mut diagnostics);
+    let slice_files2 = resolve_files_from(&options2, &mut diagnostics);
 
     // Act
-    let hash = files.as_slice().compute_sha256_hash();
+    let hash1 = slice_files1.as_slice().compute_sha256_hash();
+    let hash2 = slice_files2.as_slice().compute_sha256_hash();
 
     // Assert
-    assert_eq!(hash, fixed_hash);
+    assert_eq!(hash1, hash2);
 }

--- a/tests/files/mod.rs
+++ b/tests/files/mod.rs
@@ -1,3 +1,31 @@
 // Copyright (c) ZeroC, Inc.
 
 mod io;
+
+use slicec::diagnostics::Diagnostics;
+use slicec::slice_file::SliceFileHashable;
+use slicec::slice_options::SliceOptions;
+use slicec::utils::file_util::resolve_files_from;
+use std::path::PathBuf;
+
+/// This test is used to verify that the `hash_all` method returns a hash that is stable across releases and uses
+/// the correct ordering of files.
+#[test]
+fn fixed_slice_file_hash() {
+    // Arrange
+    let fixed_hash = "df7e2e0f34d0c8d389870dad726c4d8cacc544c24f9d4516c38c88783eaac20c";
+    let mut diagnostics = Diagnostics::new();
+    let file1 = PathBuf::from("tests/files/test.slice");
+    let file2 = PathBuf::from("tests/files/a.slice");
+    let options = SliceOptions {
+        sources: vec![file1.to_str().unwrap().to_owned(), file2.to_str().unwrap().to_owned()],
+        ..Default::default()
+    };
+    let files = resolve_files_from(&options, &mut diagnostics);
+
+    // Act
+    let hash = files.as_slice().compute_sha256_hash();
+
+    // Assert
+    assert_eq!(hash, fixed_hash);
+}


### PR DESCRIPTION
This PR adds a `compute_sha256_hash` method to `SliceFile`. This function is used to generate a hash that will be stable across releases. Given my comment below, should we re-export `sha2` from `slicec` since I want to use it in `slicec-cs`? This would guarantee the version `slicec-cs` uses will always be identical to the slicec version. 