### PR TITLE
Suppress Build Summary Message for Non-Human Output Modes

### DIFF
--- a/src/compilation_state.rs
+++ b/src/compilation_state.rs
@@ -4,7 +4,7 @@ use crate::ast::Ast;
 use crate::diagnostic_emitter::{emit_totals, DiagnosticEmitter};
 use crate::diagnostics::{get_totals, Diagnostic, Diagnostics};
 use crate::slice_file::SliceFile;
-use crate::slice_options::SliceOptions;
+use crate::slice_options::{DiagnosticFormat, SliceOptions};
 
 #[derive(Debug, Default)]
 pub struct CompilationState {
@@ -54,7 +54,11 @@ impl CompilationState {
         let mut stderr = console::Term::stderr();
         let mut emitter = DiagnosticEmitter::new(&mut stderr, options, &self.files);
         DiagnosticEmitter::emit_diagnostics(&mut emitter, diagnostics).expect("failed to emit diagnostics");
-        emit_totals(total_warnings, total_errors).expect("failed to emit totals");
+
+        // Only emit the summary message if we're writing human-readable output.
+        if options.diagnostic_format == DiagnosticFormat::Human {
+            emit_totals(total_warnings, total_errors).expect("failed to emit totals");
+        }
 
         total_errors != 0
     }


### PR DESCRIPTION
This PR fixes: https://github.com/icerpc/icerpc-csharp/issues/4043.
Now, we don't emit the summary message unless `slicec` is using the `Human` `DiagnosticFormat` (the default).
Since otherwise, we expect a tool to be consuming the output, and it doesn't care about this summary.

----

I ripgrepped, and the only two places where we write to stdout or stderr were when we emit the diagnostics (which was already properly JSONified) and the summary message.