### PR TITLE
Update Changelog and Version to '0.3.2'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.3.2] - 2024-9-11
+### Added
+- Added support for computing source-hashes of Slice files, for tools to utilize ([696]).
+### Fixed
+- Fixed redefinition errors on containers triggering false-positives for their contents ([700]).
+### Changed
+- The compiler no longer emits a build summary message when using JSON formatted output ([702]).
+
 ## [0.3.1] - 2024-3-27
 ### Enhancements
 - Input files are now loaded and parsed in the order they're passed ([694]).
@@ -18,7 +26,7 @@
 ### Breaking
 - Enums with fields can no longer be used as dictionary keys ([685]).
 - `CompilationState` no longer implements `Send` (so we have greater freedom to evolve it).
-### Changes
+### Changed
 - The files `code_gen_util.rs` and `code_block.rs` were moved out of this crate (into `slicec-cs`).
 
 ## [0.2.1] - 2023-11-29
@@ -51,6 +59,9 @@
 ## [0.1.0] - 2023-9-6
 Initial public release!
 
+[702]: https://github.com/icerpc/slicec/pull/702
+[700]: https://github.com/icerpc/slicec/pull/700
+[696]: https://github.com/icerpc/slicec/pull/696
 [694]: https://github.com/icerpc/slicec/pull/694
 [689]: https://github.com/icerpc/slicec/pull/689
 [688]: https://github.com/icerpc/slicec/pull/688
@@ -67,6 +78,7 @@ Initial public release!
 [662]: https://github.com/icerpc/slicec/pull/662
 [659]: https://github.com/icerpc/slicec/pull/659
 
+[0.3.2]: https://github.com/icerpc/slicec/releases/tag/v0.3.2
 [0.3.1]: https://github.com/icerpc/slicec/releases/tag/v0.3.1
 [0.3.0]: https://github.com/icerpc/slicec/releases/tag/v0.3.0
 [0.2.1]: https://github.com/icerpc/slicec/releases/tag/v0.2.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "slicec"
-version = "0.3.1"
+version = "0.3.2"
 authors = ["ZeroC Inc."]
 description = """
 The Slice parser and other core components for Slice compilers.


### PR DESCRIPTION
This PR adds the necessary changelog entries, and updates the version of `slicec` to `0.3.2`.

I went back and forth between `0.3.2` and `0.4.0`, and settled on `0.3.2` because I think this is what semver would dictate.
There is very little difference between this release and the last. Only 2 minor bug fixes, and support for file hashing, a pretty minor feature only used by our tooling, and even then, only for it's telemetry.

We always knew that eventually the versions for `icerpc-csharp` and `slicec` would diverge.
But, if you think we should keep the versions in sync for a little longer, feel free to say so.
I'm not married to the version, it's just what I thought felt most correct.