### PR TITLE
Minimal `codeGenerator` Definitions in Slice

### DIFF
--- a/slicec/slice/CodeGenerator.slice
+++ b/slicec/slice/CodeGenerator.slice
@@ -3,46 +3,37 @@
 module Slice::Compiler
 
 interface CodeGenerator {
-    generateCode(inputFiles: Sequence<InputFile>)
+    generateCode(sources: Sequence<InputFile>, references: Sequence<InputFile>)
         -> (outputFiles: Sequence<GeneratedCode>, diagnostics: Sequence<Diagnostic>)
 }
 
 struct InputFile {
-    relativePath: string,
-    \mode: CompilationMode,
-    moduleDeclaration: Module?,
-    attributes: Sequence<Attribute>,
-    contents: Sequence<Definition>,
-    category: FileCategory,
+    relativePath: string
+    compilationMode: uint8
+    moduleDeclaration: ElementInfo
+    attributes: Sequence<Attribute>
+    contents: Sequence<Definition>
 }
 
 struct GeneratedCode {
-    relativePath: string,
-    contents: string,
+    relativePath: string
+    contents: string
 }
 
-compact enum CompilationMode : uint8 { Slice1, Slice2 }
-
-compact enum FileCategory : uint8 { Source, Reference }
-
 unchecked enum Definition {
-    Struct(v: Struct) = 0,
-    Class(v: Class) = 1,
-    Exception(v: Exception) = 2,
-    Interface(v: Interface) = 3,
-    Enum(v: Enum) = 4,
-    CustomType(v: CustomType) = 5,
-    TypeAlias(v: TypeAlias) = 6,
+    Struct(info: FieldContainerInfo, isCompact: bool)
+    Class(info: FieldContainerInfo, compactId: uint32?)
+    Exception(info: FieldContainerInfo)
+    Interface(info: InterfaceInfo)
+    Enum(info: EnumInfo)
+    CustomType(info: ElementInfo)
+    TypeAlias(info: ElementInfo, underlying: TypeRef)
 }
 
 struct Diagnostic {
-    level: DiagnosticLevel,
-    message: string,
-    sliceId: SliceId?,
+    level: DiagnosticLevel
+    message: string
+    sliceId: SliceId?
 }
 
-unchecked enum DiagnosticLevel : uint8 {
-    Info = 0,
-    Warning = 1,
-    Error = 2,
-}
+enum DiagnosticLevel { Info, Warning, Error}

--- a/slicec/slice/DocComment.slice
+++ b/slicec/slice/DocComment.slice
@@ -3,39 +3,19 @@
 module Slice::Compiler
 
 struct DocComment {
-    overview: Message,
-    params: Sequence<ParamTag>,
-    returns: Sequence<ReturnsTag>,
-    \throws: Sequence<ThrowsTag>,
-    see: Sequence<SeeTag>,
+    overview: Sequence<MessageComponent>
+    paramTags: Sequence<NamedTag>
+    returnTags: Sequence<NamedTag>
+    throwsTags: Sequence<NamedTag>
+    seeTags: Sequence<SliceId>
 }
 
-struct ParamTag {
-    identifier: string,
-    message: Message,
-}
-
-struct ReturnsTag {
-    identifier: string?,
-    message: Message,
-}
-
-struct ThrowsTag {
-    thrownType: SliceId,
-    message: Message,
-}
-
-struct SeeTag {
-    linkTo: SliceId,
-}
-
-struct LinkTag {
-    linkTo: SliceId,
+struct NamedTag {
+    identifier: string // is a SliceId when this is a '@throws' tag.
+    message: Sequence<MessageComponent>
 }
 
 enum MessageComponent {
-    Text(v: string),
-    Link(v: LinkTag),
+    Text(v: string)
+    Link(linkTo: SliceId)
 }
-
-typealias Message = Sequence<MessageComponent>

--- a/slicec/slice/SyntaxElements.slice
+++ b/slicec/slice/SyntaxElements.slice
@@ -12,159 +12,90 @@ module Slice::Compiler
 ///   'MyModule::MyStruct::$attribute::2::1' refers to the 2nd argument of the 3rd attribute applied to 'MyStruct'.
 typealias SliceId = string
 
-struct Module {
-    identifier: string,
-    attributes: Sequence<Attribute>,
+struct ElementInfo {
+    identifier: string
+    attributes: Sequence<Attribute>
+    comment: DocComment?
 }
 
-struct Struct {
-    identifier: string,
-    fields: Sequence<Field>,
-    isCompact: bool,
-    isSlice1Only: bool,
-    attributes: Sequence<Attribute>,
-    comment: DocComment?,
+struct FieldContainerInfo {
+    info: ElementInfo
+    fields: Sequence<FieldInfo>
+    base: TypeRef?
 }
 
-struct Class {
-    identifier: string,
-    fields: Sequence<Field>,
-    compactId: uint32?,
-    base: TypeRef?,
-    attributes: Sequence<Attribute>,
-    comment: DocComment?,
+struct FieldInfo {
+    info: ElementInfo
+    dataType: TypeRef
+    \tag: uint32?
 }
 
-struct Exception {
-    identifier: string,
-    fields: Sequence<Field>,
-    base: TypeRef?,
-    attributes: Sequence<Attribute>,
-    comment: DocComment?,
+struct InterfaceInfo {
+    info: ElementInfo
+    operations: Sequence<OperationInfo>
+    bases: Sequence<TypeRef>
 }
 
-struct Field {
-    identifier: string,
-    dataType: TypeRef,
-    \tag: uint32?,
-    attributes: Sequence<Attribute>,
-    comment: DocComment?,
+struct OperationInfo {
+    info: ElementInfo
+    parameters: Sequence<FieldInfo>
+    streamedParameter: FieldInfo?
+    returnType: Sequence<FieldInfo>
+    streamedReturnType: FieldInfo?
+    exceptionSpecification: Sequence<TypeRef>
+    isIdempotent: bool
 }
 
-struct Interface {
-    identifier: string,
-    operations: Sequence<Operation>,
-    bases: Sequence<TypeRef>,
-    attributes: Sequence<Attribute>,
-    comment: DocComment?,
+struct EnumInfo {
+    info: ElementInfo
+    enumerators: Sequence<EnumeratorInfo>
+    underlying: TypeRef?
+    isCompact: bool
+    isUnchecked: bool
 }
 
-struct Operation {
-    identifier: string,
-    parameters: Sequence<Parameter>,
-    returnType: Sequence<Parameter>,
-    exceptionSpecification: Sequence<TypeRef>,
-    isIdempotent: bool,
-    attributes: Sequence<Attribute>,
-    comment: DocComment?,
+struct EnumeratorInfo {
+    info: ElementInfo
+    fields: Sequence<Field>
+    discriminantValue: uint64
+    isDiscriminantPositive: bool
 }
 
-struct Parameter {
-    identifier: string,
-    dataType: TypeRef,
-    \tag: uint32?,
-    isStreamed: bool,
-    attributes: Sequence<Attribute>,
-}
-
-struct Enum {
-    identifier: string,
-    enumerators: Sequence<Enumerator>,
-    underlying: TypeRef?,
-    isCompact: bool,
-    isUnchecked: bool,
-    attributes: Sequence<Attribute>,
-    comment: DocComment?,
-}
-
-struct Enumerator {
-    identifier: string,
-    value: Discriminant,
-    fields: Sequence<Field>?,
-    attributes: Sequence<Attribute>,
-    comment: DocComment?,
-}
-
-struct Discriminant {
-    absoluteValue: uint64
-    sign: NumberSign,
-}
-
-// I think adding an extra type to be decoded and mapped is over the top here.
-compact enum NumberSign : uint8 { Negative, Positive }
-
-struct CustomType {
-    identifier: string,
-    attributes: Sequence<Attribute>,
-    comment: DocComment?,
-}
-
-struct TypeAlias {
-    identifier: string,
-    underlying: TypeRef,
-    attributes: Sequence<Attribute>,
-    comment: DocComment?,
-}
-
-struct ResultType {
-    successType: TypeRef,
-    failureType: TypeRef,
-}
-
-struct SequenceType {
-    elementType: TypeRef,
-}
-
-struct DictionaryType {
-    keyType: TypeRef,
-    valueType: TypeRef,
-}
-
-unchecked enum Primitive : uint8 {
-    Bool,
-    Int8,
-    UInt8,
-    Int16,
-    UInt16,
-    Int32,
-    UInt32,
-    VarInt32,
-    VarUInt32,
-    Int64,
-    UInt64,
-    VarInt62,
-    VarUInt62,
-    Float32,
-    Float64,
-    String,
-    \AnyClass,
+enum Primitive : uint8 {
+    Bool
+    Int8
+    UInt8
+    Int16
+    UInt16
+    Int32
+    UInt32
+    VarInt32
+    VarUInt32
+    Int64
+    UInt64
+    VarInt62
+    VarUInt62
+    Float32
+    Float64
+    String
+    \AnyClass
 }
 
 struct TypeRef {
-    value: TypeRefDefinition,
-    isOptional: bool,
-    attributes: Sequence<Attribute>, /* TODO: We'll need to duplicate the attributes during encoding. */
+    value: TypeRefDefinition
+    isOptional: bool
+    attributes: Sequence<Attribute> /* TODO: We'll need to duplicate the attributes during encoding. */
 }
 
 enum TypeRefDefinition {
-    Definition(v: SliceId),
-    Primitive(v: Primitive),
-    SequenceType(v: SequenceType),
-    DictionaryType(v: DictionaryType),
-    ResultType(v: ResultType),
+    Definition(v: SliceId)
+    Primitive(v: Primitive)
+    SequenceType(elementType: TypeRef)
+    DictionaryType(keyType: TypeRef, valueType: TypeRef)
+    ResultType(successType: TypeRef, failureType: TypeRef)
 }
 
 struct Attribute {
-    directive: string,
-    args: Sequence<string>,
+    directive: string
+    args: Sequence<string>
 }


### PR DESCRIPTION
This PR shows the absolute smallest I think we can pack the definitions needed for `generateCode` down to.
In the end, only 19 types are necessary (and 2 of those are simple enums). As opposed to #711 which has 35 types.

Granted, sending the data modeled as a relational database actually gets us even fewer types (only 8), since much of the necessary information can be stored in dictionaries instead of needing all these break-out types with specialized fields.