### PR TITLE
Removed Stubbed-out Code for Slice1 Encoding in Rust

### DIFF
--- a/slice-codec/Cargo.toml
+++ b/slice-codec/Cargo.toml
@@ -33,9 +33,6 @@ default = ["slice2", "std"]
 # Provides support for the Slice2 encoding.
 slice2 = []
 
-# Provides support for the Slice1 encoding.
-slice1 = []
-
 # Provides implementations for encoding and decoding common standard library types like `String`, `Vec`, `HashMap`, etc.
 # Introduces a dependency on the Rust standard library. This flag should be disabled for 'no-std' projects.
 std = ["alloc"]

--- a/slice-codec/src/lib.rs
+++ b/slice-codec/src/lib.rs
@@ -18,10 +18,6 @@ extern crate std;
 #[cfg(feature = "slice2")]
 pub mod slice2;
 
-// Only include the `slice1` module if the corresponding feature is set.
-#[cfg(feature = "slice1")]
-pub mod slice1;
-
 pub mod buffer;
 pub mod decode_from;
 pub mod decoder;

--- a/slice-codec/src/slice1/mod.rs
+++ b/slice-codec/src/slice1/mod.rs
@@ -1,1 +1,0 @@
-// Copyright (c) ZeroC, Inc.


### PR DESCRIPTION
This PR removes all mentions of the `Slice1` encoding from the Rust `slice-codec`.
We never actually implemented this encoding, so there isn't alot to remove.

This implements #724.