### PR TITLE
Soften Requirement on `std` Since `Error` Moved from `std` to `core`

### DIFF
--- a/slice-codec/src/buffer/vec.rs
+++ b/slice-codec/src/buffer/vec.rs
@@ -33,12 +33,7 @@ impl<'a> VecOutputTarget<'a> {
             // If an error occurred, we wrap it in our own `UnexpectedEob` error and return it.
             let remaining = self.remaining();
             let kind = ErrorKind::UnexpectedEob { requested, remaining };
-
-            // Remove this feature gate when the `Error` trait is moved; https://github.com/icerpc/slice-rust/issues/1.
-            #[cfg(feature = "std")]
-            return Error::new_with_source(kind, _err);
-            #[cfg(not(feature = "std"))]
-            return Error::new(kind);
+            Error::new_with_source(kind, _err)
         })
     }
 }

--- a/slice-codec/src/error.rs
+++ b/slice-codec/src/error.rs
@@ -6,12 +6,11 @@ use core::ops::Range;
 use core::write;
 
 #[cfg(feature = "alloc")]
+use alloc::boxed::Box;
+#[cfg(feature = "alloc")]
 use alloc::collections::TryReserveError;
 #[cfg(feature = "alloc")]
 use alloc::string::FromUtf8Error;
-
-#[cfg(feature = "std")]
-use alloc::boxed::Box;
 
 /// A specialized [`Result`](core::result::Result) type for encoding and decoding functions which may produce errors.
 ///
@@ -26,9 +25,8 @@ pub struct Error {
     kind: ErrorKind,
 
     /// The underlying cause of this error, if any exist.
-    // Until `Error` is moved from `std` into `core`, we need a feature; https://github.com/icerpc/slice-rust/issues/1.
-    #[cfg(feature = "std")]
-    source: Option<Box<dyn std::error::Error + 'static>>,
+    #[cfg(feature = "alloc")]
+    source: Option<Box<dyn core::error::Error + 'static>>,
 }
 
 impl Error {
@@ -36,15 +34,14 @@ impl Error {
     pub fn new(kind: ErrorKind) -> Self {
         Self {
             kind,
-            #[cfg(feature = "std")]
+            #[cfg(feature = "alloc")]
             source: None,
         }
     }
 
     /// Creates a new error of the specified kind, which was logically caused by the provided source.
-    // Until `Error` is moved from `std` into `core`, we need a feature; https://github.com/icerpc/slice-rust/issues/1.
-    #[cfg(feature = "std")]
-    pub fn new_with_source(kind: ErrorKind, source: impl std::error::Error + 'static) -> Self {
+    #[cfg(feature = "alloc")]
+    pub fn new_with_source(kind: ErrorKind, source: impl core::error::Error + 'static) -> Self {
         Self {
             kind,
             source: Some(Box::new(source)),
@@ -62,8 +59,7 @@ impl Display for Error {
         // Write this error's underlying `ErrorKind`.
         self.kind.fmt(f)?;
 
-        // Until `Error` is moved from `std` into `core`, we need a feature; https://github.com/icerpc/slice-rust/issues/1.
-        #[cfg(feature = "std")]
+        #[cfg(feature = "alloc")]
         // If this error was caused by another error, also write that source error.
         if let Some(source) = &self.source {
             f.write_str("\nError was caused by:\n")?;
@@ -74,10 +70,9 @@ impl Display for Error {
     }
 }
 
-// Until `Error` is moved from `std` into `core`, we need a feature; https://github.com/icerpc/slice-rust/issues/1.
-#[cfg(feature = "std")]
-impl std::error::Error for Error {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+#[cfg(feature = "alloc")]
+impl core::error::Error for Error {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         self.source.as_deref()
     }
 }


### PR DESCRIPTION
For context, Rust has 2 "levels" of standard library:
- `core`: the 'true' standard library which is always available no matter what.
- `std`: a superset which includes extra things only available on non-embedded systems

The `slice-codec` has a "feature flag" named `std` which is enabled by default, but if it's disabled, our crate supports being used without `std`: on embedded systems.

----

Rust has a general `trait Error`, which all error like types should implement.
But, for years, this trait was `std::error::Error`: only available if you were using `std`.
In Rust 1.81 (released 1.5 years ago) they moved it to `core::error::Error`, so now it's part of `core`.

This PR implements #716: we remove this feature gate where it is no longer necessary.