### PR TITLE
Improve Error Message about Self-Referential Types

### DIFF
--- a/slicec/src/diagnostics/errors.rs
+++ b/slicec/src/diagnostics/errors.rs
@@ -523,7 +523,7 @@ implement_diagnostic_functions!(
     (
         "E047",
         InfiniteSizeCycle,
-        format!("disallowed type cycle; type {type_id} references itself: {cycle}"),
+        format!("type {type_id} illegally references itself: {cycle}"),
         type_id, cycle
     ),
     (


### PR DESCRIPTION
We talked about this last week and agreed that "X has infinite size" is not a meaningfully helpful message.