### PR TITLE
Small Cleanup of the Codec

### DIFF
--- a/slice-codec/src/buffer/mod.rs
+++ b/slice-codec/src/buffer/mod.rs
@@ -42,7 +42,7 @@ pub trait InputSource {
     /// This function reads exactly `dest.len()`-many bytes, or if it's unable to, returns an error instead.
     /// If such an error occurs, no guarantees are made about how many bytes were read from the source, except that it
     /// is less than `dest.len()`.
-    fn read_bytes_into_buffer(&mut self, dest: &mut [u8]) -> Result<()>;
+    fn read_bytes_into_exact(&mut self, dest: &mut [u8]) -> Result<()>;
 }
 
 /// A trait for types that can be written to by a [Slice encoder](crate::encoder::Encoder).
@@ -93,7 +93,7 @@ pub trait OutputTarget {
 
 /// Represents a span of bytes that have been reserved in an [`OutputTarget`].
 /// See [`OutputTarget::reserve_space`].
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 #[must_use]
 pub struct Reservation(Range<usize>);
 

--- a/slice-codec/src/buffer/slice.rs
+++ b/slice-codec/src/buffer/slice.rs
@@ -105,7 +105,7 @@ impl InputSource for SliceInputSource<'_> {
         Ok(byte_slice)
     }
 
-    fn read_bytes_into_buffer(&mut self, dst: &mut [u8]) -> Result<()> {
+    fn read_bytes_into_exact(&mut self, dst: &mut [u8]) -> Result<()> {
         let src = self.read_byte_slice_exact(dst.len())?;
 
         // SAFETY: `read_byte_slice_exact` is guaranteed to return exactly `dst.len()` bytes, so there is enough space
@@ -303,10 +303,10 @@ mod tests {
 
             // Assert
             assert!(result.is_err());
-            assert_eq!(result.unwrap_err().kind(), &ErrorKind::UnexpectedEob {
+            assert!(matches!(result.unwrap_err().kind(), ErrorKind::UnexpectedEob {
                 requested: 6,
-                remaining: 5,
-            });
+                remaining: 5
+            }));
         }
 
         /// Verifies that [`peek_byte`] returns the correct byte from the buffer without consuming it.
@@ -407,10 +407,10 @@ mod tests {
 
             // Assert
             assert!(result.is_err());
-            assert_eq!(result.unwrap_err().kind(), &ErrorKind::UnexpectedEob {
+            assert!(matches!(result.unwrap_err().kind(), ErrorKind::UnexpectedEob {
                 requested: 6,
-                remaining: 5,
-            });
+                remaining: 5
+            }));
         }
 
         /// Verifies that [`write_byte`] writes the correct byte to the buffer and advances the position.

--- a/slice-codec/src/buffer/vec.rs
+++ b/slice-codec/src/buffer/vec.rs
@@ -225,7 +225,7 @@ mod tests {
         assert!(reserve_result.is_ok());
         assert!(write_result.is_ok());
 
-        assert_eq!(reserve_result.unwrap(), Reservation(0..3));
+        assert_eq!(reserve_result.unwrap().range(), 0..3);
         assert_eq!(target.buffer.len(), 4);
         assert_eq!(target.remaining(), target.buffer.capacity() - 4);
         assert_eq!(buffer, [0, 0, 0, 99]);

--- a/slice-codec/src/error.rs
+++ b/slice-codec/src/error.rs
@@ -88,7 +88,7 @@ impl<T: Into<ErrorKind>> From<T> for Error {
 /// It is typically held by an [`Error`].
 ///
 /// This list may grow over time, so it is not recommended to exhaustively match against it.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug)]
 #[non_exhaustive]
 pub enum ErrorKind {
     /// A function attempted to read past the end of a buffer.
@@ -148,7 +148,7 @@ impl Display for ErrorKind {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug)]
 #[non_exhaustive]
 pub enum InvalidDataErrorKind {
     /// TODO

--- a/slice-codec/src/slice2/decoding.rs
+++ b/slice-codec/src/slice2/decoding.rs
@@ -186,7 +186,7 @@ impl DecodeFrom<Slice2> for String {
             debug_assert_eq!(vector.len(), 0);
             let bytes =
                 core::mem::transmute::<&mut [core::mem::MaybeUninit<u8>], &mut [u8]>(vector.spare_capacity_mut());
-            decoder.read_bytes_into_buffer(bytes)?;
+            decoder.read_bytes_into_exact(bytes)?;
             vector.set_len(length);
         }
 

--- a/slice-codec/tests/encoding_tests.rs
+++ b/slice-codec/tests/encoding_tests.rs
@@ -2,22 +2,21 @@
 
 // cspell:ignore Lorem, ipsum, dolor, sit, amet, no, explicari, repudiare, vis, an, dicant, legimus, ponderum
 
-use slice_codec::buffer::slice::{SliceInputSource, SliceOutputTarget};
-use slice_codec::buffer::{InputSource, OutputTarget};
-use slice_codec::decode_from::DecodeFrom;
-use slice_codec::decoder::Decoder;
-use slice_codec::encode_into::EncodeInto;
-use slice_codec::encoder::Encoder;
-
-use core::fmt::Debug;
-
 #[cfg(test)]
 #[cfg(feature = "slice2")]
-mod fixed_sized {
+mod fixed_size {
 
-    use super::*;
+    use slice_codec::buffer::slice::{SliceInputSource, SliceOutputTarget};
+    use slice_codec::buffer::{InputSource, OutputTarget};
+    use slice_codec::decode_from::DecodeFrom;
+    use slice_codec::decoder::Decoder;
+    use slice_codec::encode_into::EncodeInto;
+    use slice_codec::encoder::Encoder;
     use slice_codec::slice2::Slice2;
+
     use test_case::test_case;
+
+    use core::fmt::Debug;
 
     // bool
     #[test_case(false, [0]; "false_bool")]
@@ -145,7 +144,11 @@ mod fixed_sized {
 #[cfg(test)]
 #[cfg(feature = "slice2")]
 mod variable_sized {
-    use super::*;
+    use slice_codec::buffer::slice::{SliceInputSource, SliceOutputTarget};
+    use slice_codec::decoder::Decoder;
+    use slice_codec::encoder::Encoder;
+
+    use core::fmt::Debug;
 
     mod encoding_of {
 


### PR DESCRIPTION
The slice-codec needed some cleanup even before it was moved into the `slicec` repo, and now that's just even more true.
This PR undoes some changes that were made beforehand, that I want to keep separate from the soon-to-follow cleanup.