### PR TITLE
Update Formatting for new `rustfmt` Release

### DIFF
--- a/slicec/src/grammar/traits.rs
+++ b/slicec/src/grammar/traits.rs
@@ -263,4 +263,3 @@ pub(crate) use implement_Member_for;
 pub(crate) use implement_Named_Symbol_for;
 pub(crate) use implement_Scoped_Symbol_for;
 pub(crate) use implement_Symbol_for;
-


### PR DESCRIPTION
Looks like `rustfmt` got an update, and the heuristics it uses changed.
I didn't have the latest version locally and so didn't notice.
But this PR fixes the `formatting` failure in CI.