### PR TITLE
Move Slice Compiler Definitions 'icerpc-csharp -> slicec'.

### DIFF
--- a/slice/Compiler/CodeGenerator.slice
+++ b/slice/Compiler/CodeGenerator.slice
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-[cs::namespace("ZeroC.Slice.Compiler")]
+[cs::namespace("ZeroC.Slice.Symbols.Compiler")]
 module Compiler
 
 interface CodeGenerator {

--- a/slice/Compiler/DocComment.slice
+++ b/slice/Compiler/DocComment.slice
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-[cs::namespace("ZeroC.Slice.Compiler")]
+[cs::namespace("ZeroC.Slice.Symbols.Compiler")]
 module Compiler
 
 struct DocComment {

--- a/slice/Compiler/SyntaxElements.slice
+++ b/slice/Compiler/SyntaxElements.slice
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-[cs::namespace("ZeroC.Slice.Compiler")]
+[cs::namespace("ZeroC.Slice.Symbols.Compiler")]
 module Compiler
 
 /// A unique identifier for a Slice entity. This is always a fully-scoped identifier.
@@ -80,7 +80,7 @@ struct Enumerator {
 
 struct Discriminant {
     absoluteValue: uint64
-    isPositive: bool
+    isNegative: bool
 }
 
 struct CustomType {


### PR DESCRIPTION
After talking it over yesterday, we changed our minds, and decided it's cleanest to have the Slice compiler definitions in the same repository as the Slice compiler, since they will likely evolve together.

If this is merged, I'll update the Slice vendoring file in `icerpc-csharp` to pull them in from here,
remove these files from `icerpc-slice`, and shuffle any related issues to the right place.