### PR TITLE
Remove the `tag` Modifier from `DocComment`s in the Compiler Definitions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,10 +2,5 @@
   "rust-analyzer.rustfmt.extraArgs": ["+nightly"],
   "[rust]": {
     "editor.rulers": [120]
-  },
-  "slice.configurations": [
-    {
-      "paths": ["slice/"],
-    }
-  ]
+  }
 }


### PR DESCRIPTION
This PR updates `DocComment` to just be a regular optional field, instead of a tagged field.
I'm not opposed to using tags in our Slice files, but I just don't really see the point of doing so here.

And this is the initial draft of these definitions, so there's no concern around backwards compatibility or anything.

----

Doing this also means you can fully decode a request from `slicec`, without needing any tag decoding logic, which would make bootstrapping easier.