### PR TITLE
Add read permissions to all GitHub workflows

### DIFF
--- a/.github/workflows/build-nightly-release.yml
+++ b/.github/workflows/build-nightly-release.yml
@@ -4,6 +4,9 @@ on:
     # Run every day at 2:00 AM
     - cron: "0 2 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   build-nightly-release:
     if: github.repository == 'icerpc/slicec'

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -13,6 +13,9 @@ on:
         required: true
         default: "nightly"
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 env:
   WARNINGS_AS_ERRORS: yes
   CARGO_TERM_COLOR: always

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: ["main"]
 
+permissions:
+  contents: read
+
 jobs:
   coverage:
     runs-on: ubuntu-latest

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
   push:
 
+permissions:
+  contents: read
+
 jobs:
   spellcheck:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Set top-level `permissions: contents: read` in build-nightly-release, build-release, ci, coverage, and spellcheck workflows

See https://codeql.github.com/codeql-query-help/actions/actions-missing-workflow-permissions/
