### PR TITLE
Minor Simplification to 'all_attributes' Function

### DIFF
--- a/slicec/src/diagnostics/diagnostic.rs
+++ b/slicec/src/diagnostics/diagnostic.rs
@@ -165,7 +165,7 @@ impl Diagnostics {
 
         // Helper function that checks whether a lint is allowed by attributes on the provided entity.
         fn is_lint_allowed_by_attributes(attributable: &(impl Attributable + ?Sized), lint: &Lint) -> bool {
-            let attributes = attributable.all_attributes().concat().into_iter();
+            let attributes = attributable.all_attributes().into_iter();
             let mut allowed = attributes.filter_map(|a| a.downcast::<attributes::Allow>());
             allowed.any(|allow| is_lint_allowed_by(allow.allowed_lints.iter(), lint))
         }

--- a/slicec/src/grammar/traits.rs
+++ b/slicec/src/grammar/traits.rs
@@ -34,7 +34,7 @@ pub trait Attributable {
     fn attributes(&self) -> Vec<&Attribute>;
 
     /// Returns all the attributes of the element and its parents.
-    fn all_attributes(&self) -> Vec<Vec<&Attribute>>;
+    fn all_attributes(&self) -> Vec<&Attribute>;
 }
 
 // These functions are declared in a separate trait because they have type parameters, making them not 'object-safe'.
@@ -167,8 +167,8 @@ macro_rules! implement_Attributable_for {
                 self.attributes.iter().map(WeakPtr::borrow).collect()
             }
 
-            fn all_attributes(&self) -> Vec<Vec<&Attribute>> {
-                vec![self.attributes()]
+            fn all_attributes(&self) -> Vec<&Attribute> {
+                self.attributes()
             }
         }
     };
@@ -178,8 +178,8 @@ macro_rules! implement_Attributable_for {
                 self.attributes.iter().map(WeakPtr::borrow).collect()
             }
 
-            fn all_attributes(&self) -> Vec<Vec<&Attribute>> {
-                let mut attributes_list = vec![self.attributes()];
+            fn all_attributes(&self) -> Vec<&Attribute> {
+                let mut attributes_list = self.attributes();
                 attributes_list.extend(self.parent().all_attributes());
                 attributes_list
             }

--- a/slicec/tests/attribute_tests.rs
+++ b/slicec/tests/attribute_tests.rs
@@ -708,7 +708,6 @@ mod attributes {
             let parameter = ast.find_element::<Parameter>("A::I::op::s").unwrap();
             let parent_attributes = parameter
                 .all_attributes()
-                .concat()
                 .into_iter()
                 .map(|a| a.downcast::<Unparsed>().unwrap())
                 .collect::<Vec<_>>();


### PR DESCRIPTION
Right now it returns a nested `Vec<Vec<...>>`. We can just have it return a flat `Vec<_>` instead.
The first thing each caller do is flatten it with `concat` anyways.