### PR TITLE
Slight Tweaks to Slice Compiler Definitions

### DIFF
--- a/slice/Compiler/CodeGenerator.slice
+++ b/slice/Compiler/CodeGenerator.slice
@@ -4,11 +4,11 @@
 module Compiler
 
 interface CodeGenerator {
-    generateCode(sourceFiles: Sequence<SliceFile>, referenceFiles: Sequence<SliceFile>, args: Arguments) ->
+    generateCode(sourceFiles: Sequence<SliceFile>, referenceFiles: Sequence<SliceFile>, options: Options) ->
         (generatedFiles: Sequence<GeneratedFile>, diagnostics: Sequence<Diagnostic>)
 }
 
-typealias Arguments = Dictionary<string, string>
+typealias Options = Dictionary<string, string>
 
 struct SliceFile {
     path: string
@@ -28,9 +28,9 @@ enum Symbol {
     VariantEnum(v: VariantEnum)
     Struct(v: Struct)
     CustomType(v: CustomType)
+    ResultType(v: ResultType)
     SequenceType(v: SequenceType)
     DictionaryType(v: DictionaryType)
-    ResultType(v: ResultType)
     TypeAlias(v: TypeAlias)
 }
 

--- a/slice/Compiler/SyntaxElements.slice
+++ b/slice/Compiler/SyntaxElements.slice
@@ -11,7 +11,7 @@ typealias EntityId = string
 ///
 /// For user-defined types, this is the type's fully-scoped identifier. For example: 'OuterModule::InnerModule::Foo'.
 /// For built-in primitive types, this is just the primitive's keyword; for example: 'int32' or 'string'.
-/// For anonymous types (sequences, dictionaries, and results), this is a numeric ID corresponding to the type's index
+/// For anonymous types (results, sequences, and dictionaries), this is a numeric ID corresponding to the type's index
 /// in {@link SliceFile::contents} (indices start from '0'). These IDs are scoped to the file they're defined in.
 typealias TypeId = string
 
@@ -99,6 +99,11 @@ struct TypeAlias {
     underlyingType: TypeRef // Can never be optional.
 }
 
+struct ResultType {
+    successType: TypeRef
+    failureType: TypeRef
+}
+
 struct SequenceType {
     elementType: TypeRef
 }
@@ -106,9 +111,4 @@ struct SequenceType {
 struct DictionaryType {
     keyType: TypeRef // Can never be optional.
     valueType: TypeRef
-}
-
-struct ResultType {
-    successType: TypeRef
-    failureType: TypeRef
 }

--- a/slicec/src/definition_types.rs
+++ b/slicec/src/definition_types.rs
@@ -189,6 +189,13 @@ pub struct TypeAlias {
 implement_encode_into_for_struct!(TypeAlias, entity_info, underlying_type);
 
 #[derive(Clone, Debug)]
+pub struct ResultType {
+    pub success_type: TypeRef,
+    pub failure_type: TypeRef,
+}
+implement_encode_into_for_struct!(ResultType, success_type, failure_type);
+
+#[derive(Clone, Debug)]
 pub struct SequenceType {
     pub element_type: TypeRef,
 }
@@ -200,13 +207,6 @@ pub struct DictionaryType {
     pub value_type: TypeRef,
 }
 implement_encode_into_for_struct!(DictionaryType, key_type, value_type);
-
-#[derive(Clone, Debug)]
-pub struct ResultType {
-    pub success_type: TypeRef,
-    pub failure_type: TypeRef,
-}
-implement_encode_into_for_struct!(ResultType, success_type, failure_type);
 
 #[derive(Clone, Debug)]
 pub struct DocComment {
@@ -271,9 +271,9 @@ pub enum Symbol {
     VariantEnum(VariantEnum) = 2,
     Struct(Struct) = 3,
     CustomType(CustomType) = 4,
-    SequenceType(SequenceType) = 5,
-    DictionaryType(DictionaryType) = 6,
-    ResultType(ResultType) = 7, // TODO make result come before dictionary!
+    ResultType(ResultType) = 5,
+    SequenceType(SequenceType) = 6,
+    DictionaryType(DictionaryType) = 7,
     TypeAlias(TypeAlias) = 8,
 }
 impl EncodeInto for &Symbol {
@@ -293,9 +293,9 @@ impl EncodeInto for &Symbol {
             Symbol::VariantEnum(v) => encoder.encode(v)?,
             Symbol::Struct(v) => encoder.encode(v)?,
             Symbol::CustomType(v) => encoder.encode(v)?,
+            Symbol::ResultType(v) => encoder.encode(v)?,
             Symbol::SequenceType(v) => encoder.encode(v)?,
             Symbol::DictionaryType(v) => encoder.encode(v)?,
-            Symbol::ResultType(v) => encoder.encode(v)?,
             Symbol::TypeAlias(v) => encoder.encode(v)?,
         }
 


### PR DESCRIPTION
This PR renames 'arguments' to 'options' to match the terminology used by `icerpc-csharp`.
It also re-orders the anonymous types so that they are in the canonical order we always use:
    `Result`, `Sequence`, `Dictionary`