### PR TITLE
Add new `Info` Diagnostic Kind and Level

### DIFF
--- a/slicec/src/compilation_state.rs
+++ b/slicec/src/compilation_state.rs
@@ -1,7 +1,7 @@
 // Copyright (c) ZeroC, Inc.
 
 use crate::ast::Ast;
-use crate::diagnostics::{Diagnostics, AnnotatedDiagnostic};
+use crate::diagnostics::{AnnotatedDiagnostic, Diagnostics};
 use crate::slice_file::SliceFile;
 use crate::slice_options::SliceOptions;
 

--- a/slicec/src/diagnostic_emitter.rs
+++ b/slicec/src/diagnostic_emitter.rs
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-use crate::diagnostics::{DiagnosticLevel, AnnotatedDiagnostic, Snippet};
+use crate::diagnostics::{AnnotatedDiagnostic, DiagnosticLevel, Snippet};
 use crate::slice_options::{DiagnosticFormat, SliceOptions};
 use serde::ser::SerializeStruct;
 use serde::Serializer;
@@ -29,7 +29,7 @@ impl<'a> DiagnosticEmitter<'a> {
             match diagnostic.level {
                 DiagnosticLevel::Error => total_errors += 1,
                 DiagnosticLevel::Warning => total_warnings += 1,
-                DiagnosticLevel::Allowed => {}
+                DiagnosticLevel::Allowed | DiagnosticLevel::Info => {}
             }
         }
 
@@ -68,6 +68,7 @@ impl<'a> DiagnosticEmitter<'a> {
             let prefix = match &diagnostic.level {
                 DiagnosticLevel::Error => console::style(format!("error [{code}]")).red().bold(),
                 DiagnosticLevel::Warning => console::style(format!("warning [{code}]")).yellow().bold(),
+                DiagnosticLevel::Info => console::style(format!("info")).blue().bold(),
                 DiagnosticLevel::Allowed => continue,
             };
 
@@ -102,6 +103,7 @@ impl<'a> DiagnosticEmitter<'a> {
             let severity = match diagnostic.level {
                 DiagnosticLevel::Error => "error",
                 DiagnosticLevel::Warning => "warning",
+                DiagnosticLevel::Info => "info",
                 DiagnosticLevel::Allowed => continue,
             };
 

--- a/slicec/src/diagnostic_emitter.rs
+++ b/slicec/src/diagnostic_emitter.rs
@@ -69,7 +69,7 @@ impl<'a> DiagnosticEmitter<'a> {
             let prefix = match &diagnostic.level {
                 DiagnosticLevel::Error => console::style(format!("error [{code}]")).red().bold(),
                 DiagnosticLevel::Warning => console::style(format!("warning [{code}]")).yellow().bold(),
-                DiagnosticLevel::Info => console::style(format!("info")).blue().bold(),
+                DiagnosticLevel::Info => console::style("info").blue().bold(),
                 DiagnosticLevel::Allowed => continue,
             };
 

--- a/slicec/src/diagnostic_emitter.rs
+++ b/slicec/src/diagnostic_emitter.rs
@@ -52,6 +52,7 @@ impl<'a> DiagnosticEmitter<'a> {
         Ok(())
     }
 
+    /// Emits the provided diagnostics to [`Self::output`].
     pub fn emit_diagnostics(&mut self, diagnostics: &[AnnotatedDiagnostic]) -> Result<()> {
         // Emit the diagnostics in whatever form the user requested.
         match self.diagnostic_format {

--- a/slicec/src/diagnostic_emitter.rs
+++ b/slicec/src/diagnostic_emitter.rs
@@ -52,7 +52,7 @@ impl<'a> DiagnosticEmitter<'a> {
         Ok(())
     }
 
-    /// Emits the provided diagnostics to [`Self::output`].
+    /// Emits the provided diagnostics to this emitter's output.
     pub fn emit_diagnostics(&mut self, diagnostics: &[AnnotatedDiagnostic]) -> Result<()> {
         // Emit the diagnostics in whatever form the user requested.
         match self.diagnostic_format {

--- a/slicec/src/diagnostic_emitter.rs
+++ b/slicec/src/diagnostic_emitter.rs
@@ -69,7 +69,7 @@ impl<'a> DiagnosticEmitter<'a> {
             let prefix = match &diagnostic.level {
                 DiagnosticLevel::Error => console::style(format!("error [{code}]")).red().bold(),
                 DiagnosticLevel::Warning => console::style(format!("warning [{code}]")).yellow().bold(),
-                DiagnosticLevel::Info => console::style("info").blue().bold(),
+                DiagnosticLevel::Info => console::style("info".to_owned()).blue().bold(),
                 DiagnosticLevel::Allowed => continue,
             };
 

--- a/slicec/src/diagnostics/annotated_diagnostic.rs
+++ b/slicec/src/diagnostics/annotated_diagnostic.rs
@@ -60,6 +60,7 @@ fn get_diagnostic_level_for(
     // For other kinds of diagnostics, we can immediately return their levels.
     let lint = match &diagnostic.kind {
         DiagnosticKind::Error(_) => return DiagnosticLevel::Error,
+        DiagnosticKind::Info(_) => return DiagnosticLevel::Info,
         DiagnosticKind::Lint(lint) => lint,
     };
 

--- a/slicec/src/diagnostics/diagnostic.rs
+++ b/slicec/src/diagnostics/diagnostic.rs
@@ -59,11 +59,13 @@ impl Diagnostic {
         }
     }
 
-    /// Returns this diagnostic's code. This is either the name of a lint or of the form `E###`.
+    /// Returns this diagnostic's code, unless it's an informational diagnostic, in which case this returns `""`.
+    /// For errors, this is of the form `E###`; for lints this is the name of the lint;
     pub fn code(&self) -> &str {
         match &self.kind {
             DiagnosticKind::Error(error) => error.error_code(),
             DiagnosticKind::Lint(lint) => lint.lint_name(),
+            DiagnosticKind::Info(_) => "",
         }
     }
 

--- a/slicec/src/diagnostics/diagnostic.rs
+++ b/slicec/src/diagnostics/diagnostic.rs
@@ -6,9 +6,17 @@ use crate::slice_file::Span;
 /// A message that is reported by the compiler to provide information and context for errors, warnings, or other issues.
 #[derive(Debug)]
 pub struct Diagnostic {
+    /// The exact kind of diagnostic.
     pub kind: DiagnosticKind,
+
+    /// The section of a Slice file that this diagnostic is about.
+    /// If present, a snippet of text from this section will be reported alongside the diagnostic.
     pub span: Option<Span>,
+
+    /// The Slice scope that this diagnostic was emitted from (used to check for 'allow' metadata).
     pub scope: Option<String>,
+
+    /// Any additional information that should be reported alongside this diagnostic's main message.
     pub notes: Vec<Note>,
 }
 
@@ -36,11 +44,18 @@ impl Diagnostic {
         Self::new(DiagnosticKind::Lint(lint))
     }
 
-    /// Returns the message of this diagnostic.
+    /// Creates a new informational `Diagnostic` from the provided [`String`].
+    /// The newly created `Diagnostic` has no `span`, `scope`, or `notes` set.
+    pub fn info(info: impl Into<String>) -> Self {
+        Self::new(DiagnosticKind::Info(info.into()))
+    }
+
+    /// Returns this diagnostic's message.
     pub fn message(&self) -> String {
         match &self.kind {
             DiagnosticKind::Error(error) => error.message(),
             DiagnosticKind::Lint(lint) => lint.message(),
+            DiagnosticKind::Info(message) => message.clone(),
         }
     }
 
@@ -52,16 +67,21 @@ impl Diagnostic {
         }
     }
 
+    /// Sets this diagnostic's span to the provided value.
     pub fn set_span(mut self, span: &Span) -> Self {
+        assert!(self.span.is_none()); // Calling this function multiple times is probably a bug on our part.
         self.span = Some(span.to_owned());
         self
     }
 
+    /// Sets this diagnostic's scope to the provided value.
     pub fn set_scope(mut self, scope: impl Into<String>) -> Self {
+        assert!(self.scope.is_none()); // Calling this function multiple times is probably a bug on our part.
         self.scope = Some(scope.into());
         self
     }
 
+    /// Adds a [`Note`] to this diagnostic.
     pub fn add_note(mut self, message: impl Into<String>, span: Option<&Span>) -> Self {
         self.notes.push(Note {
             message: message.into(),
@@ -70,6 +90,7 @@ impl Diagnostic {
         self
     }
 
+    /// Moves this diagnostic into the provided [`Diagnostics`] collection.
     pub fn push_into(self, diagnostics: &mut Diagnostics) {
         diagnostics.0.push(self);
     }

--- a/slicec/src/diagnostics/diagnostic.rs
+++ b/slicec/src/diagnostics/diagnostic.rs
@@ -44,7 +44,7 @@ impl Diagnostic {
         Self::new(DiagnosticKind::Lint(lint))
     }
 
-    /// Creates a new informational `Diagnostic` from the provided [`String`].
+    /// Creates a new informational `Diagnostic` from the provided string.
     /// The newly created `Diagnostic` has no `span`, `scope`, or `notes` set.
     pub fn info(info: impl Into<String>) -> Self {
         Self::new(DiagnosticKind::Info(info.into()))

--- a/slicec/src/diagnostics/mod.rs
+++ b/slicec/src/diagnostics/mod.rs
@@ -18,10 +18,10 @@ pub enum DiagnosticKind {
     /// An irrecoverable error; the compiler will terminate early at the end of the next phase.
     Error(Error),
 
-    /// A minor and recoverable mistake; has no effect on the compiler's execution pipe-line.
+    /// A minor and recoverable mistake; has no effect on the compiler's execution pipeline.
     Lint(Lint),
 
-    /// A purely informational comment; has no effect on the compiler's execution pipe-line.
+    /// A purely informational comment; has no effect on the compiler's execution pipeline.
     Info(String),
 }
 

--- a/slicec/src/diagnostics/mod.rs
+++ b/slicec/src/diagnostics/mod.rs
@@ -1,21 +1,28 @@
 // Copyright (c) ZeroC, Inc.
 
+mod annotated_diagnostic;
 mod diagnostic;
 mod errors;
 mod lints;
-mod annotated_diagnostic;
 
+pub use annotated_diagnostic::*;
 pub use diagnostic::{Diagnostic, Diagnostics};
 pub use errors::Error;
 pub use lints::Lint;
-pub use annotated_diagnostic::*;
 
 use crate::slice_file::Span;
 
+/// Wrapper enum for the 3 possible kinds of diagnostics.
 #[derive(Debug)]
 pub enum DiagnosticKind {
+    /// An irrecoverable error; the compiler will terminate early at the end of the next phase.
     Error(Error),
+
+    /// A minor and recoverable mistake; has no effect on the compiler's execution pipe-line.
     Lint(Lint),
+
+    /// A purely informational comment; has no effect on the compiler's execution pipe-line.
+    Info(String),
 }
 
 /// Diagnostic levels describe the severity of a diagnostic, and how the compiler should react to their emission.
@@ -30,6 +37,9 @@ pub enum DiagnosticLevel {
 
     /// Diagnostics with the `Allowed` level will be suppressed and will not emit any message.
     Allowed,
+
+    /// Diagnostics with the `Info` level will be emitted, but will not influence the exit code of the compiler.
+    Info,
 }
 
 /// Stores additional information about a diagnostic.


### PR DESCRIPTION
This PR adds a new `Info` diagnostic kind and level, corresponding to the `Info` level which is already defined in the Slice-Compiler definitions.

Right now it isn't used anywhere, but this is necessary to properly decode all diagnostics we could receive from a code-generator.