### PR TITLE
Finished Adding all the Diagnostics to the Slice-Compiler Definitions

### DIFF
--- a/slice/Compiler/CodeGenerator.slice
+++ b/slice/Compiler/CodeGenerator.slice
@@ -33,15 +33,3 @@ enum Symbol {
     DictionaryType(v: DictionaryType)
     TypeAlias(v: TypeAlias)
 }
-
-struct Diagnostic {
-    level: DiagnosticLevel
-    message: string
-    source: string?
-}
-
-unchecked enum DiagnosticLevel : uint8 {
-    Info
-    Warning
-    Error
-}

--- a/slice/Compiler/Diagnostics.slice
+++ b/slice/Compiler/Diagnostics.slice
@@ -1,0 +1,74 @@
+// Copyright (c) ZeroC, Inc.
+
+[cs::identifier("ZeroC.Slice.Symbols.Compiler")]
+module Compiler
+
+/// A message that is reported to provide information and context for errors, warnings, or other issues.
+struct Diagnostic {
+    /// The exact kind of diagnostic.
+    kind: DiagnosticKind
+
+    /// The fully-scoped Slice identifier of the element that this diagnostic is in reference to (if there is one).
+    source: string?
+
+    /// Any additional information that should be reported alongside this diagnostic's main message.
+    notes: Sequence<DiagnosticNote>
+}
+
+/// Stores additional information to report alongside a {@link Diagnostic}.
+struct DiagnosticNote {
+    /// The message to emit alongside the main diagnostic which this note is attached to.
+    message: string
+
+    /// The fully-scoped Slice identifier of the element that this note is in reference to (if there is one).
+    source: string?
+}
+
+unchecked enum DiagnosticKind {
+    /// A general purpose diagnostic which should be emitted as an error.
+    Error(message: string)
+
+    /// A general purpose diagnostic which should be emitted as a warning.
+    Warning(message: string)
+
+    /// A general purpose diagnostic which is purely informational.
+    Info(message: string)
+
+    //
+    // Attribute Diagnostics
+    //
+
+    /// An attribute was applied to a Slice element for which it's invalid.
+    /// For example: applying `[oneway]` to a struct ('oneway' is only allowed on operations).
+    /// @param directive: the directive of the invalid attribute.
+    InvalidAttribute(directive: string)
+
+    /// An unknown attribute was encountered, which uses a known prefix.
+    /// For example: if a C# code-generator encountered the following attribute: `[cs::foobar]`.
+    /// @param directive: the directive of the unknown attribute.
+    UnknownAttribute(directive: string)
+
+    /// An element requires a specific attribute to be applied to it, which is not present.
+    /// For example: custom types must have their mapped type specified with a `[xxx:type(...)]` attribute.
+    /// @param expectedAttribute: the missing attribute; should include placeholder names for expected arguments.
+    MissingRequiredAttribute(expectedAttribute: string)
+
+    /// A non-repeatable attribute was applied to the same element multiple times.
+    /// For example: `[compress(Args)] [compress(Return)] myOperation()`; 'compress' is not repeatable.
+    /// @param directive: the directive of the non-repeatable attribute.
+    AttributeIsNotRepeatable(directive: string)
+
+    /// An invalid argument was provided to an attribute which otherwise accepts arguments.
+    /// For example: `[compress(FooBar)] myOperation()`; 'compress' accepts arguments but 'FooBar' is not a valid one.
+    /// @param directive: the directive of the attribute.
+    /// @param argument: the invalid argument that was provided.
+    InvalidAttributeArgument(directive: string, argument: string)
+
+    /// Too few or too many arguments were supplied to an otherwise valid attribute.
+    /// For example: `[oneway(FooBar)]` ('oneway' takes no arguments) or `[compress]` ('compress' requires arguments).
+    /// @param directive: the directive of the attribute.
+    /// @param minExpected: the minimum number of arguments this attribute can be given.
+    /// @param maxExpected: the maximum number of arguments this attribute can be given.
+    /// @param actualCount: the number of arguments this attribute was actually given.
+    IncorrectAttributeArgumentCount(directive: string, minExpected: uint8, maxExpected: uint8, actualCount: uint8)
+}

--- a/slice/Compiler/Diagnostics.slice
+++ b/slice/Compiler/Diagnostics.slice
@@ -25,14 +25,14 @@ struct DiagnosticNote {
 }
 
 unchecked enum DiagnosticKind {
-    /// A general purpose diagnostic which should be emitted as an error.
-    Error(message: string)
+    /// A general purpose diagnostic which is purely informational.
+    Info(message: string)
 
     /// A general purpose diagnostic which should be emitted as a warning.
     Warning(message: string)
 
-    /// A general purpose diagnostic which is purely informational.
-    Info(message: string)
+    /// A general purpose diagnostic which should be emitted as an error.
+    Error(message: string)
 
     //
     // Attribute Diagnostics

--- a/slicec/src/definition_types.rs
+++ b/slicec/src/definition_types.rs
@@ -10,7 +10,7 @@ use slice_codec::decode_from::DecodeFrom;
 use slice_codec::decoder::Decoder;
 use slice_codec::encode_into::EncodeInto;
 use slice_codec::encoder::Encoder;
-use slice_codec::{InvalidDataErrorKind, Result};
+use slice_codec::Result;
 
 /// TAG_END_MARKER must be encoded at the end of every non-compact type.
 const TAG_END_MARKER: i32 = -1;
@@ -322,9 +322,9 @@ impl DecodeFrom for GeneratedFile {
 
 #[derive(Clone, Debug)]
 pub struct Diagnostic {
-    pub level: DiagnosticLevel,
-    pub message: String,
+    pub kind: DiagnosticKind,
     pub source: Option<String>,
+    pub notes: Vec<DiagnosticNote>,
 }
 impl DecodeFrom for Diagnostic {
     fn decode_from(decoder: &mut Decoder<impl InputSource>) -> Result<Self> {
@@ -332,37 +332,115 @@ impl DecodeFrom for Diagnostic {
         let has_source = decoder.decode::<bool>()?;
 
         // Decode the actual fields.
-        let level = decoder.decode()?;
+        let kind = decoder.decode()?;
+        let source = has_source.then(|| decoder.decode()).transpose()?;
+        let notes = decoder.decode()?;
+
+        decoder.skip_tagged_fields()?;
+
+        Ok(Diagnostic { kind, source, notes })
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct DiagnosticNote {
+    pub message: String,
+    pub source: Option<String>,
+}
+impl DecodeFrom for DiagnosticNote {
+    fn decode_from(decoder: &mut Decoder<impl InputSource>) -> Result<Self> {
+        // Decode the bit-sequence. With only one optional, this is just a bool.
+        let has_source = decoder.decode::<bool>()?;
+
+        // Decode the actual fields.
         let message = decoder.decode()?;
         let source = has_source.then(|| decoder.decode()).transpose()?;
 
         decoder.skip_tagged_fields()?;
 
-        Ok(Diagnostic { level, message, source })
+        Ok(DiagnosticNote { message, source })
     }
 }
 
-#[repr(u8)]
-#[derive(Clone, Copy, Debug)]
-pub enum DiagnosticLevel {
-    Info = 0,
-    Warning = 1,
-    Error = 2,
+#[repr(usize)]
+#[derive(Clone, Debug)]
+pub enum DiagnosticKind {
+    Info {
+        message: String,
+    } = 0,
+    Warning {
+        message: String,
+    } = 1,
+    Error {
+        message: String,
+    } = 2,
+    InvalidAttribute {
+        directive: String,
+    } = 3,
+    UnknownAttribute {
+        directive: String,
+    } = 4,
+    MissingRequiredAttribute {
+        expected_attribute: String,
+    } = 5,
+    AttributeIsNotRepeatable {
+        directive: String,
+    } = 6,
+    InvalidAttributeArgument {
+        directive: String,
+        argument: String,
+    } = 7,
+    IncorrectAttributeArgumentCount {
+        directive: String,
+        min_expected: u8,
+        max_expected: u8,
+        actual_count: u8,
+    } = 8,
+
+    Unknown {
+        discriminant: usize,
+    },
 }
-impl DecodeFrom for DiagnosticLevel {
+impl DecodeFrom for DiagnosticKind {
     fn decode_from(decoder: &mut Decoder<impl InputSource>) -> Result<Self> {
-        let value = decoder.decode::<u8>()?;
-        match value {
-            0 => Ok(DiagnosticLevel::Info),
-            1 => Ok(DiagnosticLevel::Warning),
-            2 => Ok(DiagnosticLevel::Error),
-            _ => {
-                let error = InvalidDataErrorKind::IllegalValue {
-                    desc: "DiagnosticLevel",
-                    value: Some(value.into()),
-                };
-                Err(error.into())
-            }
-        }
+        let value: usize = decoder.decode_varint()?;
+        let variant = match value {
+            0 => Self::Info {
+                message: decoder.decode()?,
+            },
+            1 => Self::Warning {
+                message: decoder.decode()?,
+            },
+            2 => Self::Error {
+                message: decoder.decode()?,
+            },
+            3 => Self::InvalidAttribute {
+                directive: decoder.decode()?,
+            },
+            4 => Self::UnknownAttribute {
+                directive: decoder.decode()?,
+            },
+            5 => Self::MissingRequiredAttribute {
+                expected_attribute: decoder.decode()?,
+            },
+            6 => Self::AttributeIsNotRepeatable {
+                directive: decoder.decode()?,
+            },
+            7 => Self::InvalidAttributeArgument {
+                directive: decoder.decode()?,
+                argument: decoder.decode()?,
+            },
+            8 => Self::IncorrectAttributeArgumentCount {
+                directive: decoder.decode()?,
+                min_expected: decoder.decode()?,
+                max_expected: decoder.decode()?,
+                actual_count: decoder.decode()?,
+            },
+
+            n => Self::Unknown { discriminant: n },
+        };
+
+        decoder.skip_tagged_fields()?;
+        Ok(variant)
     }
 }

--- a/slicec/src/definition_types.rs
+++ b/slicec/src/definition_types.rs
@@ -440,7 +440,7 @@ impl DecodeFrom for DiagnosticKind {
 
             n => {
                 // Read the unknown variant's fields payload.
-                // We don't what they are, but we at least know the length of the payload.
+                // We don't know what they are, but we at least know the length of the payload.
                 let payload_size = decoder.decode_size()?;
                 let mut fields_payload = vec![0; payload_size];
                 decoder.read_bytes_into_exact(&mut fields_payload)?;

--- a/slicec/src/definition_types.rs
+++ b/slicec/src/definition_types.rs
@@ -399,6 +399,7 @@ pub enum DiagnosticKind {
 
     Unknown {
         discriminant: usize,
+        fields_payload: Vec<u8>,
     },
 }
 impl DecodeFrom for DiagnosticKind {
@@ -437,7 +438,18 @@ impl DecodeFrom for DiagnosticKind {
                 actual_count: decoder.decode()?,
             },
 
-            n => Self::Unknown { discriminant: n },
+            n => {
+                // Read the unknown variant's fields payload.
+                // We don't what they are, but we at least know the length of the payload.
+                let payload_size = decoder.decode_size()?;
+                let mut fields_payload = vec![0; payload_size];
+                decoder.read_bytes_into_exact(&mut fields_payload)?;
+
+                Self::Unknown {
+                    discriminant: n,
+                    fields_payload,
+                }
+            }
         };
 
         decoder.skip_tagged_fields()?;

--- a/slicec/src/diagnostics/diagnostic.rs
+++ b/slicec/src/diagnostics/diagnostic.rs
@@ -44,10 +44,10 @@ impl Diagnostic {
         Self::new(DiagnosticKind::Lint(lint))
     }
 
-    /// Creates a new informational `Diagnostic` from the provided string.
+    /// Creates a new informational `Diagnostic` from the provided message.
     /// The newly created `Diagnostic` has no `span`, `scope`, or `notes` set.
-    pub fn info(info: impl Into<String>) -> Self {
-        Self::new(DiagnosticKind::Info(info.into()))
+    pub fn from_info(message: impl Into<String>) -> Self {
+        Self::new(DiagnosticKind::Info(message.into()))
     }
 
     /// Returns this diagnostic's message.

--- a/slicec/src/diagnostics/errors.rs
+++ b/slicec/src/diagnostics/errors.rs
@@ -7,6 +7,10 @@ use std::ops::Range;
 #[derive(Debug)]
 pub enum Error {
     // ----------------  Generic Errors ---------------- //
+    Other {
+        message: String,
+    },
+
     IO {
         action: &'static str,
         path: String,
@@ -183,7 +187,7 @@ pub enum Error {
     /// An attribute was applied to a Slice element for which it's invalid.
     /// For example: applying `[oneway]` to a struct ('oneway' is only allowed on operations).
     InvalidAttribute {
-        /// the directive of the invalid attribute.
+        /// The directive of the invalid attribute.
         directive: String,
     },
 
@@ -213,7 +217,7 @@ pub enum Error {
     InvalidAttributeArgument {
         /// The directive of the attribute.
         directive: String,
-        /// the invalid argument that was provided.
+        /// The invalid argument that was provided.
         argument: String,
     },
 
@@ -237,6 +241,7 @@ impl Error {
     /// Returns the error code corresponding to this particular [`Error`].
     pub fn error_code(&self) -> &'static str {
         match self {
+            Self::Other { .. } => "E000",
             Self::IO { .. } => "E001",
             Self::Syntax { .. } => "E002",
             Self::KeyMustBeNonOptional => "E003",
@@ -279,6 +284,8 @@ impl Error {
     /// Returns a message describing this [`Error`] in detail.
     pub fn message(&self) -> String {
         match self {
+            Self::Other { message } => message.clone(),
+
             Self::IO { action, path, error } => {
                 let message = match error.kind() {
                     std::io::ErrorKind::NotFound => "No such file or directory".to_owned(),

--- a/slicec/src/diagnostics/lints.rs
+++ b/slicec/src/diagnostics/lints.rs
@@ -4,6 +4,10 @@ use super::DiagnosticLevel;
 
 #[derive(Debug)]
 pub enum Lint {
+    Other {
+        message: String,
+    },
+
     /// An input filename was provided multiple times.
     /// Note: it's valid to specify the same path as a source and reference file (ex: `slicec foo.slice -R foo.slice`).
     /// This is only triggered by specifying it multiple times in the same context: (ex: `slicec foo.slice foo.slice`).
@@ -22,17 +26,23 @@ pub enum Lint {
     },
 
     /// A syntactical mistake in a doc-comment.
-    MalformedDocComment { message: String },
+    MalformedDocComment {
+        message: String,
+    },
 
     /// A doc comment contains an incorrect tag. Either:
     /// - The tag itself is incorrect. Ex: using `@returns` on an operation doesn't return anything.
     /// - The tag describes something incorrect. Ex: specifying `@param foo` when no parameter named "foo" exists.
-    IncorrectDocComment { message: String },
+    IncorrectDocComment {
+        message: String,
+    },
 
     /// A link in a doc-comment couldn't be resolved. Either:
     /// - The link pointed to an un-linkable element, e.g. a module, result, sequence, dictionary, or primitive.
     /// - The link pointed to a non-existent element.
-    BrokenDocLink { message: String },
+    BrokenDocLink {
+        message: String,
+    },
 }
 
 impl Lint {
@@ -40,6 +50,7 @@ impl Lint {
     /// attributes (like '[allow(...)]'), or command-line options (like '--allow').
     pub fn default_diagnostic_level(&self) -> DiagnosticLevel {
         match self {
+            Self::Other { .. } => DiagnosticLevel::Warning,
             Self::DuplicateFile { .. } => DiagnosticLevel::Warning,
             Self::Deprecated { .. } => DiagnosticLevel::Warning,
             Self::MalformedDocComment { .. } => DiagnosticLevel::Warning,
@@ -51,6 +62,7 @@ impl Lint {
     /// Returns the name of the lint which was violated.
     pub fn lint_name(&self) -> &'static str {
         match self {
+            Self::Other { .. } => "Other",
             Self::DuplicateFile { .. } => "DuplicateFile",
             Self::Deprecated { .. } => "Deprecated",
             Self::MalformedDocComment { .. } => "MalformedDocComment",
@@ -62,6 +74,8 @@ impl Lint {
     /// Returns a message describing this lint violation in detail.
     pub fn message(&self) -> String {
         match self {
+            Self::Other { message } => message.clone(),
+
             Self::DuplicateFile { path } => format!("slice file was provided more than once: '{path}'"),
 
             Self::Deprecated { identifier, reason } => {

--- a/slicec/src/main.rs
+++ b/slicec/src/main.rs
@@ -114,7 +114,7 @@ fn handle_generator_response(response_payload: Vec<u8>, output_dir: &Option<Stri
     // TODO: Convert the diagnostics we decode from the generator, into diagnostics that slicec can handle.
     //       To do this requires re-working the diagnostic API fairly substantially.
     for generator_diagnostic in generator_diagnostics {
-        println!("{}", generator_diagnostic.message);
+        println!("{generator_diagnostic:?}");
     }
     let mut diagnostics = Diagnostics::new();
 


### PR DESCRIPTION
This is the penultimate PR in the complete refactoring of `slicec`'s diagnostic system, so it plays well with the code-generators.
It reworks the Slice-Compiler Definitions for Diagnostic, most notably, by switching to a `DiagnosticKind` enum, instead of allowing `Diagnostic` to hold any arbitrary message.

This:
1) Makes error messages more standard, since they're always created by `slicec` now, instead of each plugin needing to create and format it's own strings.
2) Allows plugin issued diagnostics to work with the `allow/deny` lint configuration system (not possible when all `slicec` saw was a string)
3) Allows notes to be directly attached to a diagnostic, instead of `slicec` needing to try and infer whether a diagnostic is linked to the one that came before it now.

----

This just defines the new structure, my next (and final) PR will actually hook up `slicec` to receive and convert plug-in diagnostics into it's own native diagnostic types.