### PR TITLE
Properly Handle Diagnostics From Plugins

### DIFF
--- a/slice/Compiler/Diagnostics.slice
+++ b/slice/Compiler/Diagnostics.slice
@@ -9,7 +9,7 @@ module Compiler
 /// - A reference to a Slice entity, written as its fully-scoped identifier; ex: 'MyModule::MyInterface::myOp'.
 /// - A reference to a Slice file, written as that file's relative path prefixed with '#'; ex: '#dir1/dir2/file.slice'.
 ///
-/// To reference an attribute on a Slice file or entity, you can place '$attributes' after the source, followed by the
+/// To reference an attribute on a Slice entity or file, you can use '$attributes' after the source, followed by the
 /// index of the attribute to reference, and optionally, the index of an argument to that attribute. For example:
 /// 'MyMod::MyEnum::$attributes::0' references the first attribute of 'MyEnum', and '#MyFile.slice::$attributes::0::1'
 /// references the second argument of the first attribute on 'MyFile.slice'.

--- a/slice/Compiler/Diagnostics.slice
+++ b/slice/Compiler/Diagnostics.slice
@@ -13,7 +13,7 @@ module Compiler
 /// index of the attribute to reference, and optionally, the index of an argument to that attribute. For example:
 /// 'MyMod::MyEnum::$attributes::0' references the first attribute of 'MyEnum', and '#MyFile.slice::$attributes::0::1'
 /// references the second argument of the first attribute on 'MyFile.slice'.
-typealias Source = string
+typealias DiagnosticSource = string
 
 /// A message that is reported to provide information and context for errors, warnings, or other issues.
 struct Diagnostic {
@@ -21,7 +21,7 @@ struct Diagnostic {
     kind: DiagnosticKind
 
     /// The fully-scoped Slice identifier of the element that this diagnostic is in reference to (if there is one).
-    source: Source?
+    source: DiagnosticSource?
 
     /// Any additional information that should be reported alongside this diagnostic's main message.
     notes: Sequence<DiagnosticNote>
@@ -33,7 +33,7 @@ struct DiagnosticNote {
     message: string
 
     /// The fully-scoped Slice identifier of the element that this note is in reference to (if there is one).
-    source: Source?
+    source: DiagnosticSource?
 }
 
 unchecked enum DiagnosticKind {

--- a/slice/Compiler/Diagnostics.slice
+++ b/slice/Compiler/Diagnostics.slice
@@ -6,11 +6,11 @@ module Compiler
 /// Represents the source of a {@link Diagnostic}, which can be used to provide context and snippets during emission.
 ///
 /// The source of a diagnostic can be either:
-/// - A reference to a Slice entity, written as it's fully-scoped identifier; ex: 'MyModule::MyInterface::myOp'.
+/// - A reference to a Slice entity, written as its fully-scoped identifier; ex: 'MyModule::MyInterface::myOp'.
 /// - A reference to a Slice file, written as that file's relative path prefixed with '#'; ex: '#dir1/dir2/file.slice'.
 ///
-/// To reference an attribute on a Slice file or entity, you can place '$attributes' after the source, following by the
-/// the index of the attribute to reference, and optionally, the index of an argument to that attribute. For example:
+/// To reference an attribute on a Slice file or entity, you can place '$attributes' after the source, followed by the
+/// index of the attribute to reference, and optionally, the index of an argument to that attribute. For example:
 /// 'MyMod::MyEnum::$attributes::0' references the first attribute of 'MyEnum', and '#MyFile.slice::$attributes::0::1'
 /// references the second argument of the first attribute on 'MyFile.slice'.
 typealias Source = string

--- a/slice/Compiler/Diagnostics.slice
+++ b/slice/Compiler/Diagnostics.slice
@@ -3,13 +3,16 @@
 [cs::identifier("ZeroC.Slice.Symbols.Compiler")]
 module Compiler
 
+/// TODO
+typealias Source = string
+
 /// A message that is reported to provide information and context for errors, warnings, or other issues.
 struct Diagnostic {
     /// The exact kind of diagnostic.
     kind: DiagnosticKind
 
     /// The fully-scoped Slice identifier of the element that this diagnostic is in reference to (if there is one).
-    source: string?
+    source: Source?
 
     /// Any additional information that should be reported alongside this diagnostic's main message.
     notes: Sequence<DiagnosticNote>
@@ -21,7 +24,7 @@ struct DiagnosticNote {
     message: string
 
     /// The fully-scoped Slice identifier of the element that this note is in reference to (if there is one).
-    source: string?
+    source: Source?
 }
 
 unchecked enum DiagnosticKind {

--- a/slice/Compiler/Diagnostics.slice
+++ b/slice/Compiler/Diagnostics.slice
@@ -3,7 +3,16 @@
 [cs::identifier("ZeroC.Slice.Symbols.Compiler")]
 module Compiler
 
-/// TODO
+/// Represents the source of a {@link Diagnostic}, which can be used to provide context and snippets during emission.
+///
+/// The source of a diagnostic can be either:
+/// - A reference to a Slice entity, written as it's fully-scoped identifier; ex: 'MyModule::MyInterface::myOp'.
+/// - A reference to a Slice file, written as that file's relative path prefixed with '#'; ex: '#dir1/dir2/file.slice'.
+///
+/// To reference an attribute on a Slice file or entity, you can place '$attributes' after the source, following by the
+/// the index of the attribute to reference, and optionally, the index of an argument to that attribute. For example:
+/// 'MyMod::MyEnum::$attributes::0' references the first attribute of 'MyEnum', and '#MyFile.slice::$attributes::0::1'
+/// references the second argument of the first attribute on 'MyFile.slice'.
 typealias Source = string
 
 /// A message that is reported to provide information and context for errors, warnings, or other issues.

--- a/slicec/src/ast/mod.rs
+++ b/slicec/src/ast/mod.rs
@@ -366,3 +366,13 @@ pub enum LookupError {
         is_concrete: bool,
     },
 }
+
+impl From<LookupError> for crate::diagnostics::Error {
+    fn from(error: LookupError) -> Self {
+        match error {
+            LookupError::DoesNotExist { identifier } => Self::DoesNotExist { identifier },
+            LookupError::TypeMismatch { expected, actual, is_concrete }
+                => Self::TypeMismatch { expected, actual, is_concrete },
+        }
+    }
+}

--- a/slicec/src/ast/mod.rs
+++ b/slicec/src/ast/mod.rs
@@ -371,8 +371,15 @@ impl From<LookupError> for crate::diagnostics::Error {
     fn from(error: LookupError) -> Self {
         match error {
             LookupError::DoesNotExist { identifier } => Self::DoesNotExist { identifier },
-            LookupError::TypeMismatch { expected, actual, is_concrete }
-                => Self::TypeMismatch { expected, actual, is_concrete },
+            LookupError::TypeMismatch {
+                expected,
+                actual,
+                is_concrete,
+            } => Self::TypeMismatch {
+                expected,
+                actual,
+                is_concrete,
+            },
         }
     }
 }

--- a/slicec/src/ast/node.rs
+++ b/slicec/src/ast/node.rs
@@ -111,6 +111,34 @@ impl<'a> TryFrom<&'a Node> for WeakPtr<dyn Type> {
     }
 }
 
+impl<'a> TryFrom<&'a Node> for &'a dyn NamedSymbol {
+    type Error = LookupError;
+
+    /// Attempts to unwrap a node to a dynamically typed reference of a Slice [NamedSymbol].
+    ///
+    /// If the Slice element held by the node implements [NamedSymbol], this succeeds and returns a typed reference,
+    /// otherwise this fails and returns an error message.
+    fn try_from(node: &'a Node) -> Result<&'a dyn NamedSymbol, Self::Error> {
+        match node {
+            Node::Module(module_ptr) => Ok(module_ptr.borrow()),
+            Node::Struct(struct_ptr) => Ok(struct_ptr.borrow()),
+            Node::Field(field_ptr) => Ok(field_ptr.borrow()),
+            Node::Interface(interface_ptr) => Ok(interface_ptr.borrow()),
+            Node::Operation(operation_ptr) => Ok(operation_ptr.borrow()),
+            Node::Parameter(parameter_ptr) => Ok(parameter_ptr.borrow()),
+            Node::Enum(enum_ptr) => Ok(enum_ptr.borrow()),
+            Node::Enumerator(enumerator_ptr) => Ok(enumerator_ptr.borrow()),
+            Node::CustomType(custom_type_ptr) => Ok(custom_type_ptr.borrow()),
+            Node::TypeAlias(type_alias_ptr) => Ok(type_alias_ptr.borrow()),
+            _ => Err(LookupError::TypeMismatch {
+                expected: "named symbol".to_owned(),
+                actual: ccase!(lower, node.to_string()),
+                is_concrete: false,
+            }),
+        }
+    }
+}
+
 impl<'a> TryFrom<&'a Node> for &'a dyn Entity {
     type Error = LookupError;
 

--- a/slicec/src/compilation_state.rs
+++ b/slicec/src/compilation_state.rs
@@ -34,7 +34,7 @@ impl CompilationState {
     ///
     /// # Safety
     ///
-    /// The caller of this function must ensure that no (`WeakPtr`s)[crate::utils::ptr_util::WeakPtr] exist that point
+    /// The caller of this function must ensure that no [`WeakPtr`](crate::utils::ptr_util::WeakPtr)s exist that point
     /// to the contents of this `CompilationState`. Even if they're not being actively used, their existence causes UB.
     pub unsafe fn apply_unsafe(&mut self, function: unsafe fn(&mut Self)) {
         if !self.diagnostics.has_errors() {

--- a/slicec/src/compilation_state.rs
+++ b/slicec/src/compilation_state.rs
@@ -45,7 +45,7 @@ impl CompilationState {
     pub fn get_annotated_diagnostics(&self, options: &SliceOptions) -> Vec<AnnotatedDiagnostic> {
         self.diagnostics
             .iter()
-            .map(|diagnostic| crate::diagnostics::convert_diagnostic(diagnostic, options, self))
+            .map(|diagnostic| crate::diagnostics::convert_diagnostic(diagnostic, options, &self.ast, &self.files))
             .collect()
     }
 }

--- a/slicec/src/definition_types.rs
+++ b/slicec/src/definition_types.rs
@@ -405,6 +405,8 @@ pub enum DiagnosticKind {
 impl DecodeFrom for DiagnosticKind {
     fn decode_from(decoder: &mut Decoder<impl InputSource>) -> Result<Self> {
         let value: usize = decoder.decode_varint()?;
+        let payload_size = decoder.decode_size()?;
+
         let variant = match value {
             0 => Self::Info {
                 message: decoder.decode()?,
@@ -441,7 +443,6 @@ impl DecodeFrom for DiagnosticKind {
             n => {
                 // Read the unknown variant's fields payload.
                 // We don't know what they are, but we at least know the length of the payload.
-                let payload_size = decoder.decode_size()?;
                 let mut fields_payload = vec![0; payload_size];
                 decoder.read_bytes_into_exact(&mut fields_payload)?;
 

--- a/slicec/src/diagnostics/annotated_diagnostic.rs
+++ b/slicec/src/diagnostics/annotated_diagnostic.rs
@@ -1,6 +1,6 @@
 // Copyright (c) ZeroC, Inc.
 
-use crate::compilation_state::CompilationState;
+use crate::ast::Ast;
 use crate::diagnostics::{Diagnostic, DiagnosticKind, DiagnosticLevel, Lint};
 use crate::grammar::{attributes, Attributable, Entity};
 use crate::slice_file::{SliceFile, Span};
@@ -34,18 +34,19 @@ pub struct Snippet {
 pub fn convert_diagnostic(
     diagnostic: &Diagnostic,
     options: &SliceOptions,
-    compilation_state: &CompilationState,
+    ast: &Ast,
+    files: &[SliceFile],
 ) -> AnnotatedDiagnostic {
     let notes = diagnostic.notes.iter().map(|n| AnnotatedNote {
         message: n.message.clone(),
-        snippet: get_snippet(&n.span, &compilation_state.files),
+        snippet: get_snippet(&n.span, files),
     });
 
     AnnotatedDiagnostic {
         message: diagnostic.message(),
-        level: get_diagnostic_level_for(diagnostic, options, compilation_state),
+        level: get_diagnostic_level_for(diagnostic, options, ast, files),
         code: diagnostic.code().to_owned(),
-        snippet: get_snippet(&diagnostic.span, &compilation_state.files),
+        snippet: get_snippet(&diagnostic.span, files),
         notes: notes.collect(),
     }
 }
@@ -54,7 +55,8 @@ pub fn convert_diagnostic(
 fn get_diagnostic_level_for(
     diagnostic: &Diagnostic,
     options: &SliceOptions,
-    compilation_state: &CompilationState,
+    ast: &Ast,
+    files: &[SliceFile],
 ) -> DiagnosticLevel {
     // Only lints can have their diagnostic levels changed (through attributes or command-line options).
     // For other kinds of diagnostics, we can immediately return their levels.
@@ -83,7 +85,7 @@ fn get_diagnostic_level_for(
 
     // If the diagnostic has a span, check if it's affected by an `allow` attribute on its file.
     if let Some(span) = &diagnostic.span {
-        let file = compilation_state.files.iter().find(|f| f.relative_path == span.file);
+        let file = files.iter().find(|f| f.relative_path == span.file);
         if is_lint_allowed_by_attributes(file.unwrap(), lint) {
             return DiagnosticLevel::Allowed;
         }
@@ -91,7 +93,7 @@ fn get_diagnostic_level_for(
 
     // If the diagnostic has a scope, check if it's affected by an `allow` attribute in that scope.
     if let Some(scope) = &diagnostic.scope {
-        if let Ok(entity) = compilation_state.ast.find_element::<dyn Entity>(scope) {
+        if let Ok(entity) = ast.find_element::<dyn Entity>(scope) {
             if is_lint_allowed_by_attributes(entity, lint) {
                 return DiagnosticLevel::Allowed;
             }

--- a/slicec/src/diagnostics/errors.rs
+++ b/slicec/src/diagnostics/errors.rs
@@ -387,9 +387,8 @@ impl Error {
                     if expected == 0 {
                         format!("attribute '{directive}' does not take any arguments, but {args_provided}")
                     } else {
-                        let only = if expected > *actual_count { "only " } else { "" };
                         let args = if expected == 1 { "argument" } else { "arguments" };
-                        format!("attribute '{directive}' takes exactly {expected} {args}, but {only}{args_provided}")
+                        format!("attribute '{directive}' takes exactly {expected} {args}, but {args_provided}")
                     }
                 } else if expected_count.end == usize::MAX {
                     // If the range has no upper bound, then this attribute only requires a minimum number of arguments.

--- a/slicec/src/grammar/traits.rs
+++ b/slicec/src/grammar/traits.rs
@@ -22,7 +22,7 @@ pub trait ScopedSymbol: Symbol {
     fn get_raw_scope(&self) -> &Scope;
 }
 
-pub trait NamedSymbol: Symbol {
+pub trait NamedSymbol: Symbol + Attributable {
     fn identifier(&self) -> &str;
     fn raw_identifier(&self) -> &Identifier;
     fn module_scoped_identifier(&self) -> String;

--- a/slicec/src/main.rs
+++ b/slicec/src/main.rs
@@ -83,8 +83,8 @@ fn spawn_plugin_process(plugin: &Plugin, slice_payload: &[u8]) -> std::io::Resul
 /// Runs the provided subprocess to completion, handling any failures that may occur during its execution.
 ///
 /// If the subprocess completes successfully, this returns `Ok` with its response payload.
-/// Otherwise, if the subprocess failed to complete, completed with a non-zero status code, or wrote to 'stderr', this
-/// returns an `Err` describing the failure.
+/// Otherwise, if the subprocess fails to complete, completed with a non-zero status code, or wrote to 'stderr',
+/// this returns an `Err` describing the failure.
 fn collect_plugin_output(subprocess: Child) -> std::io::Result<Vec<u8>> {
     // Wait until the subprocess finishes, then retrieve its output.
     let output = subprocess.wait_with_output()?;

--- a/slicec/src/main.rs
+++ b/slicec/src/main.rs
@@ -118,7 +118,7 @@ fn collect_plugin_output(subprocess: Child) -> std::io::Result<Vec<u8>> {
 /// Decodes a response from a code-generator plugin.
 ///
 /// If the response could be successfully decoded, this returns the generated files and diagnostics contained in the
-/// response, converted to a form `slicec` can utilize. Otherwise this return an `Err` describing the failure.
+/// response, converted to a form `slicec` can utilize. Otherwise this returns an `Err` describing the failure.
 fn decode_generator_response(
     response_payload: Vec<u8>,
     ast: &Ast,

--- a/slicec/src/main.rs
+++ b/slicec/src/main.rs
@@ -81,7 +81,7 @@ fn spawn_plugin_process(plugin: &Plugin, slice_payload: &[u8]) -> std::io::Resul
 
 /// Runs the provided subprocess to completion, handling any failures that may occur during its execution.
 ///
-/// If the subprocess completes successfully, this returns `Ok` with it's response payload.
+/// If the subprocess completes successfully, this returns `Ok` with its response payload.
 /// Otherwise, if the subprocess failed to complete, completed with a non-zero status code, or write to 'stderr', this
 /// returns an `Err` describing the failure.
 fn collect_plugin_output(subprocess: Child) -> std::io::Result<Vec<u8>> {

--- a/slicec/src/main.rs
+++ b/slicec/src/main.rs
@@ -10,8 +10,11 @@ use clap::Parser;
 use slice_codec::decoder::Decoder;
 use slice_codec::encoder::Encoder;
 
+use slicec::ast::Ast;
+use slicec::compilation_state::CompilationState;
 use slicec::diagnostic_emitter::DiagnosticEmitter;
 use slicec::diagnostics::Diagnostics;
+use slicec::slice_file::SliceFile;
 use slicec::slice_options::{DiagnosticFormat, Plugin, SliceOptions};
 
 mod definition_types;
@@ -50,6 +53,7 @@ fn encode_generate_code_request(parsed_files: &[slicec::slice_file::SliceFile]) 
     Ok(encoding_buffer)
 }
 
+/// Spawns (and starts) a subprocess to run the provided plugin, and writes the provided request payload to its 'stdin'.
 fn spawn_plugin_process(plugin: &Plugin, slice_payload: &[u8]) -> std::io::Result<Child> {
     // Spawn a new subprocess and set up pipes for all of its streams.
     let mut subprocess = Command::new(&plugin.path)
@@ -75,6 +79,11 @@ fn spawn_plugin_process(plugin: &Plugin, slice_payload: &[u8]) -> std::io::Resul
     Ok(subprocess)
 }
 
+/// Runs the provided subprocess to completion, handling any failures that may occur during its execution.
+///
+/// If the subprocess completes successfully, this returns `Ok` with it's response payload.
+/// Otherwise, if the subprocess failed to complete, completed with a non-zero status code, or write to 'stderr', this
+/// returns an `Err` describing the failure.
 fn collect_plugin_output(subprocess: Child) -> std::io::Result<Vec<u8>> {
     // Wait until the subprocess finishes, then retrieve its output.
     let output = subprocess.wait_with_output()?;
@@ -105,39 +114,33 @@ fn collect_plugin_output(subprocess: Child) -> std::io::Result<Vec<u8>> {
     }
 }
 
-fn handle_generator_response(response_payload: Vec<u8>, output_dir: &Option<String>) -> std::io::Result<Diagnostics> {
+/// Decodes a response from a code-generator plugin.
+///
+/// If the response could be successfully decoded, this returns the generated files and diagnostics contained in the
+/// response, converted to the form `slicec` expected them to be in. Otherwise this return an `Err` with the failure.
+fn decode_generator_response(
+    response_payload: Vec<u8>,
+    ast: &Ast,
+    files: &[SliceFile],
+) -> std::io::Result<(Vec<definition_types::GeneratedFile>, Diagnostics)> {
     // Decode the generator's response. It consists of 2 sequences, one of generated files and one of diagnostics.
     let mut slice_decoder = Decoder::from(&response_payload);
     let generated_files: Vec<definition_types::GeneratedFile> = slice_decoder.decode()?;
     let generator_diagnostics: Vec<definition_types::Diagnostic> = slice_decoder.decode()?;
 
-    // TODO: Convert the diagnostics we decode from the generator, into diagnostics that slicec can handle.
-    //       To do this requires re-working the diagnostic API fairly substantially.
+    // Take all of the decoded diagnostics from the generator, and convert them into diagnostics that slicec can handle.
+    let mut converted_diagnostics = Diagnostics::new();
     for generator_diagnostic in generator_diagnostics {
-        println!("{generator_diagnostic:?}");
-    }
-    let mut diagnostics = Diagnostics::new();
-
-    // If no errors were reported, attempt to generate the files in the response.
-    if !diagnostics.has_errors() {
-        for generated_file in &generated_files {
-            // Try to write the generated file to disk.
-            if let Err(io_error) = write_generated_file(generated_file, output_dir) {
-                // If an error occurred during writing the file, create a diagnostic that slicec can emit.
-                let diagnostic = slicec::diagnostics::Error::IO {
-                    action: "write generated file",
-                    path: generated_file.path.to_owned(),
-                    error: io_error,
-                };
-                slicec::diagnostics::Diagnostic::from_error(diagnostic).push_into(&mut diagnostics);
-            }
-        }
+        slice_file_converter::convert_diagnostic(generator_diagnostic, ast, files, &mut converted_diagnostics);
     }
 
-    // Return any decoded diagnostics, so slicec can emit them at the end.
-    Ok(diagnostics)
+    Ok((generated_files, converted_diagnostics))
 }
 
+/// Attempts to write a generated file to disk.
+///
+/// If an output directory was specified, the generated file will be written relative to it; Otherwise, the generated
+/// file will be written relative to the current working directory.
 fn write_generated_file(
     generated_file: &definition_types::GeneratedFile,
     output_dir: &Option<String>,
@@ -164,11 +167,24 @@ fn write_generated_file(
     Ok(())
 }
 
-fn convert_generator_error_to_diagnostic(generator: &Plugin, generator_error: std::io::Error) -> Diagnostics {
+/// Converts an [`std::io::Error`] that occurred while trying to write a generated file into a
+/// [Diagnostic](`slicec::diagnostics::Diagnostic`), and pushes it into the provided [`Diagnostics`] collection.
+fn report_file_writing_error(file_path: &String, io_error: std::io::Error, diagnostics: &mut Diagnostics) {
+    let diagnostic = slicec::diagnostics::Error::IO {
+        action: "write generated file",
+        path: file_path.to_owned(),
+        error: io_error,
+    };
+    slicec::diagnostics::Diagnostic::from_error(diagnostic).push_into(diagnostics);
+}
+
+/// Converts any [`std::io::Error`]s that occurred while trying to run a plugin into
+/// [Diagnostic](`slicec::diagnostics::Diagnostic`)s which can be emitted by the compiler.
+fn convert_generator_errors_to_diagnostics(generator: &Plugin, io_error: std::io::Error) -> Diagnostics {
     let mapped_io_error = slicec::diagnostics::Error::IO {
         action: "run code-generator",
         path: generator.path.clone(),
-        error: generator_error,
+        error: io_error,
     };
 
     let mut diagnostics = Diagnostics::new();
@@ -180,14 +196,14 @@ fn main() -> ExitCode {
     // Parse the command-line input.
     let slice_options = SliceOptions::parse();
 
-    // Perform the compilation.
+    // Compile the provided Slice files.
     let mut compilation_state = slicec::compile_from_options(&slice_options);
-    let diagnostics = &mut compilation_state.diagnostics;
+    let CompilationState { ref ast, ref mut diagnostics, ref files } = compilation_state;
 
     // Only invoke the plugins if there were no errors in the Slice files.
     if !diagnostics.has_errors() {
         // Encode the request which will be sent to each of the code-generation plugins.
-        let encoded_request = match encode_generate_code_request(&compilation_state.files) {
+        let encoded_request = match encode_generate_code_request(files) {
             Ok(result) => result,
             Err(error) => {
                 eprintln!("Critical error: failed to encode request payload!\n{error:?}");
@@ -205,12 +221,26 @@ fn main() -> ExitCode {
         // we get the response payload from it, write any generated files in the payload, and store any diagnostics
         // the generator reported so we can emit them at the end along with all the others.
         for (generator, generator_process) in generator_processes {
-            let generator_diagnostics = generator_process
-                .and_then(collect_plugin_output) // Returns the response payload if the generator ran successfully.
-                .and_then(|payload| handle_generator_response(payload, &slice_options.output_dir)) // Returns any diagnostics if the payload successfully decoded.
-                .unwrap_or_else(|err| convert_generator_error_to_diagnostic(generator, err));
+            let (generated_files, mut generator_diagnostics) = generator_process
+                // 'collect_plugin_output' returns the response payload if the generator ran successfully.
+                .and_then(collect_plugin_output)
+                // 'decode_generator_response' decodes the payload into a Vec<GeneratedFile> and a Vec<Diagnostic>.
+                .and_then(|payload| decode_generator_response(payload, ast, files))
+                // Convert any unexpected errors into reportable diagnostics.
+                .unwrap_or_else(|err| (Vec::new(), convert_generator_errors_to_diagnostics(generator, err)));
 
-            diagnostics.extend(generator_diagnostics.into_inner()); // Store generator's diagnostics for later emission.
+            // If the generator didn't report any errors, write the generated files.
+            if !generator_diagnostics.has_errors() {
+                for generated_file in &generated_files {
+                    if let Err(io_error) = write_generated_file(generated_file, &slice_options.output_dir) {
+                        // If an error occurred while writing the file, report the error as a slicec diagnostic.
+                        report_file_writing_error(&generated_file.path, io_error, &mut generator_diagnostics);
+                    }
+                }
+            }
+
+            // Store generator's diagnostics for later emission.
+            diagnostics.extend(generator_diagnostics.into_inner());
         }
     }
 

--- a/slicec/src/main.rs
+++ b/slicec/src/main.rs
@@ -198,7 +198,11 @@ fn main() -> ExitCode {
 
     // Compile the provided Slice files.
     let mut compilation_state = slicec::compile_from_options(&slice_options);
-    let CompilationState { ref ast, ref mut diagnostics, ref files } = compilation_state;
+    let CompilationState {
+        ref ast,
+        ref mut diagnostics,
+        ref files,
+    } = compilation_state;
 
     // Only invoke the plugins if there were no errors in the Slice files.
     if !diagnostics.has_errors() {

--- a/slicec/src/main.rs
+++ b/slicec/src/main.rs
@@ -91,15 +91,10 @@ fn collect_plugin_output(subprocess: Child) -> std::io::Result<Vec<u8>> {
 
     // If the subprocess wrote anything to its 'stderr', we consider this a failure and don't generate any code.
     if !output.stderr.is_empty() {
-        // Obtain an exclusive handle to this process's 'stderr'.
-        let mut stderr = std::io::stderr().lock();
-
-        // Pipe the output from the subprocess's 'stderr' to this process's 'stderr', and then return.
-        let error = match stderr.write_all(&output.stderr) {
-            Ok(_) => Error::other("errors reported on 'stderr'"),
-            Err(err) => Error::new(ErrorKind::BrokenPipe, err),
-        };
-        return Err(error);
+        // TODO: switch to 'from_utf8_lossy_owned' when stabilized (https://github.com/rust-lang/rust/issues/129436).
+        let mut error_string = String::from_utf8_lossy(&output.stderr).into_owned();
+        error_string.insert_str(0, "errors reported on 'stderr':\n");
+        return Err(Error::other(error_string));
     }
 
     // Otherwise, check the subprocess's status code to determine success.

--- a/slicec/src/main.rs
+++ b/slicec/src/main.rs
@@ -53,7 +53,8 @@ fn encode_generate_code_request(parsed_files: &[slicec::slice_file::SliceFile]) 
     Ok(encoding_buffer)
 }
 
-/// Spawns (and starts) a subprocess to run the provided plugin, and writes the provided request payload to its 'stdin'.
+/// Spawns (and starts) a subprocess to run the provided plugin, and writes the provided payload to its 'stdin',
+/// followed by any plugin arguments.
 fn spawn_plugin_process(plugin: &Plugin, slice_payload: &[u8]) -> std::io::Result<Child> {
     // Spawn a new subprocess and set up pipes for all of its streams.
     let mut subprocess = Command::new(&plugin.path)
@@ -82,7 +83,7 @@ fn spawn_plugin_process(plugin: &Plugin, slice_payload: &[u8]) -> std::io::Resul
 /// Runs the provided subprocess to completion, handling any failures that may occur during its execution.
 ///
 /// If the subprocess completes successfully, this returns `Ok` with its response payload.
-/// Otherwise, if the subprocess failed to complete, completed with a non-zero status code, or write to 'stderr', this
+/// Otherwise, if the subprocess failed to complete, completed with a non-zero status code, or wrote to 'stderr', this
 /// returns an `Err` describing the failure.
 fn collect_plugin_output(subprocess: Child) -> std::io::Result<Vec<u8>> {
     // Wait until the subprocess finishes, then retrieve its output.
@@ -117,7 +118,7 @@ fn collect_plugin_output(subprocess: Child) -> std::io::Result<Vec<u8>> {
 /// Decodes a response from a code-generator plugin.
 ///
 /// If the response could be successfully decoded, this returns the generated files and diagnostics contained in the
-/// response, converted to the form `slicec` expected them to be in. Otherwise this return an `Err` with the failure.
+/// response, converted to a form `slicec` can utilize. Otherwise this return an `Err` describing the failure.
 fn decode_generator_response(
     response_payload: Vec<u8>,
     ast: &Ast,
@@ -168,7 +169,7 @@ fn write_generated_file(
 }
 
 /// Converts an [`std::io::Error`] that occurred while trying to write a generated file into a
-/// [Diagnostic](`slicec::diagnostics::Diagnostic`), and pushes it into the provided [`Diagnostics`] collection.
+/// [`Diagnostic`](slicec::diagnostics::Diagnostic), and pushes it into the provided [`Diagnostics`] collection.
 fn report_file_writing_error(file_path: &String, io_error: std::io::Error, diagnostics: &mut Diagnostics) {
     let diagnostic = slicec::diagnostics::Error::IO {
         action: "write generated file",
@@ -179,7 +180,7 @@ fn report_file_writing_error(file_path: &String, io_error: std::io::Error, diagn
 }
 
 /// Converts any [`std::io::Error`]s that occurred while trying to run a plugin into
-/// [Diagnostic](`slicec::diagnostics::Diagnostic`)s which can be emitted by the compiler.
+/// [`Diagnostic`](slicec::diagnostics::Diagnostic)s which can be emitted by the compiler.
 fn convert_generator_errors_to_diagnostics(generator: &Plugin, io_error: std::io::Error) -> Diagnostics {
     let mapped_io_error = slicec::diagnostics::Error::IO {
         action: "run code-generator",

--- a/slicec/src/patchers/type_ref_patcher.rs
+++ b/slicec/src/patchers/type_ref_patcher.rs
@@ -178,19 +178,7 @@ impl TypeRefPatcher<'_> {
         match lookup_result {
             Ok(definition) => Some(definition),
             Err(err) => {
-                let mapped_error = match err {
-                    LookupError::DoesNotExist { identifier } => Error::DoesNotExist { identifier },
-                    LookupError::TypeMismatch {
-                        expected,
-                        actual,
-                        is_concrete,
-                    } => Error::TypeMismatch {
-                        expected,
-                        actual,
-                        is_concrete,
-                    },
-                };
-                Diagnostic::from_error(mapped_error)
+                Diagnostic::from_error(err.into())
                     .set_span(identifier.span())
                     .push_into(self.diagnostics);
                 None

--- a/slicec/src/slice_file_converter.rs
+++ b/slicec/src/slice_file_converter.rs
@@ -119,7 +119,7 @@ fn convert_source(source: Option<&str>, ast: &Ast, files: &[GrammarSliceFile], o
         return (None, None);
     };
 
-    // Otherwise, split the provided source into 'the scoped id of an symbol' and an 'optional extension'.
+    // Otherwise, split the provided source into 'the scoped id of a symbol' and an 'optional extension'.
     // This optional extension always begins with a '$' and can be used to refer to meta-elements attached to the symbol
     // like attributes or doc-comments. For example: `"MyModule::MyClass::$attributes::1"` for attribute 1 on "MyClass".
     let (symbol_id, extension) = if let Some((symbol_id, extension)) = source.split_once("::$") {
@@ -146,21 +146,16 @@ fn convert_source(source: Option<&str>, ast: &Ast, files: &[GrammarSliceFile], o
         // The 'scope' is always `None`, since files do not logically have a Slice scope like symbols do.
         let scope = None;
         let span = match extension {
+            // If there was no extension, this diagnostic is referencing the file itself.
+            // We return an empty span that just points to the start of the file in this case.
+            None => Some(Span::new((1, 1).into(), (1, 1).into(), &slice_file.relative_path)),
+
             // If the extension starts with 'attributes::', then this diagnostic is referencing the file's attributes.
             Some(ext) if ext.starts_with("attributes::") => get_attribute_span(slice_file, ext, output),
 
             Some(unknown) => {
                 let message = format!("the diagnostic source '{source}' has an unrecognized extension '{unknown}'");
                 let error = SlicecDiagnostic::from_error(SlicecError::Other { message });
-                output.push(error);
-                None // There is no meaningful span to return.
-            }
-
-            None => {
-                let message = format!("the diagnostic source '{source}' is missing a required source extension");
-                let error = SlicecDiagnostic::from_error(SlicecError::Other { message })
-                    .add_note(CRITICAL_FLAW_STRING, None)
-                    .add_note("file-sources must have an extension", None);
                 output.push(error);
                 None // There is no meaningful span to return.
             }

--- a/slicec/src/slice_file_converter.rs
+++ b/slicec/src/slice_file_converter.rs
@@ -121,14 +121,14 @@ fn convert_source(source: Option<&str>, ast: &Ast, files: &[GrammarSliceFile], o
     // Otherwise, split the provided source into 'the scoped id of an symbol' and an 'optional extension'.
     // This optional extension always begins with a '$' and can be used to refer to meta-elements attached to the symbol
     // like attributes or doc-comments. For example: `"MyModule::MyClass::$attributes::1"` for attribute 1 on "MyClass".
-    let (entity_id, extension) = if let Some((entity_id, extension)) = source.split_once("::$") {
-        (entity_id, Some(extension))
+    let (symbol_id, extension) = if let Some((symbol_id, extension)) = source.split_once("::$") {
+        (symbol_id, Some(extension))
     } else {
         (source, None)
     };
 
     // If the source starts with a '#', then it is referencing a file. Otherwise it is referencing a named symbol.
-    if let Some(diagnostic_file_path) = source.strip_prefix('#') {
+    if let Some(diagnostic_file_path) = symbol_id.strip_prefix('#') {
         // Lookup the file in the list of slice files and if it doesn't exist, emit a diagnostic and return immediately.
         let slice_file = match files.iter().find(|file| file.relative_path == diagnostic_file_path) {
             Some(file) => file,
@@ -145,8 +145,8 @@ fn convert_source(source: Option<&str>, ast: &Ast, files: &[GrammarSliceFile], o
         // The 'scope' is always `None`, since files do not logically have a Slice scope like symbols do.
         let scope = None;
         let span = match extension {
-            // If the extension starts with 'attributes::', then this diagnostic is referencing the symbol's attributes.
-            Some("attributes::") => get_attribute_span(slice_file, extension.unwrap(), output),
+            // If the extension starts with 'attributes::', then this diagnostic is referencing the file's attributes.
+            Some(ext) if ext.starts_with("attributes::") => get_attribute_span(slice_file, ext, output),
 
             Some(unknown) => {
                 let message = format!("the diagnostic source '{source}' has an unrecognized extension '{unknown}'");
@@ -167,7 +167,7 @@ fn convert_source(source: Option<&str>, ast: &Ast, files: &[GrammarSliceFile], o
         (span, scope)
     } else {
         // Lookup the named symbol in the AST and if it doesn't exist, emit a diagnostic and return immediately.
-        let named_symbol = match ast.find_element::<dyn NamedSymbol>(entity_id) {
+        let named_symbol = match ast.find_element::<dyn NamedSymbol>(symbol_id) {
             Ok(named_symbol) => named_symbol,
             Err(err) => {
                 SlicecDiagnostic::from_error(err.into())
@@ -185,7 +185,7 @@ fn convert_source(source: Option<&str>, ast: &Ast, files: &[GrammarSliceFile], o
             None => Some(named_symbol.span().clone()),
 
             // If the extension starts with 'attributes::', then this diagnostic is referencing the symbol's attributes.
-            Some("attributes::") => get_attribute_span(named_symbol, extension.unwrap(), output),
+            Some(ext) if ext.starts_with("attributes::") => get_attribute_span(named_symbol, ext, output),
 
             Some(unknown) => {
                 let message = format!("the diagnostic source '{source}' has an unrecognized extension '{unknown}'");

--- a/slicec/src/slice_file_converter.rs
+++ b/slicec/src/slice_file_converter.rs
@@ -53,7 +53,7 @@ const CRITICAL_FLAW_STRING: &str = "this indicates a critical flaw in the plugin
 /// 
 /// Instead of directly returning the converted `Diagnostic`, this function pushes it into a provided `Diagnostics`
 /// container. This is because a single plugin-diagnostic may actually produce multiple compiler-diagnostics, for
-/// example, if a plugin emits a malformed diagnostic that references a non-existent source span.
+/// example, if a plugin emits a malformed or unknown diagnostic.
 pub fn convert_diagnostic(diagnostic: Diagnostic, ast: &Ast, files: &[GrammarSliceFile], output: &mut Diagnostics) {
     // Perform the actual conversion between `DiagnosticKind` types.
     let kind = match diagnostic.kind {
@@ -112,6 +112,7 @@ pub fn convert_diagnostic(diagnostic: Diagnostic, ast: &Ast, files: &[GrammarSli
     output.push(converted_diagnostic);
 }
 
+/// Parses a diagnostic 'source' string, and returns the corresponding 'span' and 'scope' for the referenced element.
 fn convert_source(source: Option<&str>, ast: &Ast, files: &[GrammarSliceFile], output: &mut Diagnostics) -> (Option<Span>, Option<String>) {
     // If no source was provided, we can immediately return `(None, None)` since there's nothing to convert.
     let Some(source) = source else {
@@ -156,7 +157,7 @@ fn convert_source(source: Option<&str>, ast: &Ast, files: &[GrammarSliceFile], o
             }
 
             None => {
-                let message = format!("the diagnostic source '{source}' is missing a required extension");
+                let message = format!("the diagnostic source '{source}' is missing a required source extension");
                 let error = SlicecDiagnostic::from_error(SlicecError::Other { message })
                     .add_note(CRITICAL_FLAW_STRING, None)
                     .add_note("file-sources must have an extension", None);

--- a/slicec/src/slice_file_converter.rs
+++ b/slicec/src/slice_file_converter.rs
@@ -97,7 +97,7 @@ fn convert_diagnostic_kind(kind: DiagnosticKind) -> SlicecDiagnosticKind {
             => SlicecDiagnosticKind::Error(SlicecError::InvalidAttributeArgument { directive, argument }),
 
         DiagnosticKind::IncorrectAttributeArgumentCount { directive, min_expected, max_expected, actual_count } => {
-            let min_expected = if min_expected == u8::MAX { usize::MAX } else { min_expected as usize };
+            let min_expected = min_expected as usize;
             let max_expected = if max_expected == u8::MAX { usize::MAX - 1 } else { max_expected as usize };
             SlicecDiagnosticKind::Error(SlicecError::IncorrectAttributeArgumentCount {
                 directive,

--- a/slicec/src/slice_file_converter.rs
+++ b/slicec/src/slice_file_converter.rs
@@ -98,7 +98,7 @@ fn convert_diagnostic_kind(kind: DiagnosticKind) -> SlicecDiagnosticKind {
 
         DiagnosticKind::IncorrectAttributeArgumentCount { directive, min_expected, max_expected, actual_count } => {
             let min_expected = if min_expected == u8::MAX { usize::MAX } else { min_expected as usize };
-            let max_expected = if max_expected == u8::MAX { usize::MAX } else { max_expected as usize };
+            let max_expected = if max_expected == u8::MAX { usize::MAX - 1 } else { max_expected as usize };
             SlicecDiagnosticKind::Error(SlicecError::IncorrectAttributeArgumentCount {
                 directive,
                 expected_count: min_expected..(max_expected + 1),

--- a/slicec/src/slice_file_converter.rs
+++ b/slicec/src/slice_file_converter.rs
@@ -55,8 +55,26 @@ const CRITICAL_FLAW_STRING: &str = "this indicates a critical flaw in the plugin
 /// container. This is because a single plugin-diagnostic may actually produce multiple compiler-diagnostics, for
 /// example, if a plugin emits a malformed or unknown diagnostic.
 pub fn convert_diagnostic(diagnostic: Diagnostic, ast: &Ast, files: &[GrammarSliceFile], output: &mut Diagnostics) {
-    // Perform the actual conversion between `DiagnosticKind` types.
-    let kind = match diagnostic.kind {
+    // Convert between `DiagnosticKind` types.
+    let kind = convert_diagnostic_kind(diagnostic.kind);
+
+    // Convert any provided notes.
+    let notes = diagnostic.notes.into_iter().map(|note| {
+        let DiagnosticNote {message, source} = note;
+        let (span, _) = convert_source(source.as_deref(), ast, files, output);
+        slicec::diagnostics::Note { message, span }
+    }).collect();
+
+    // If a 'source' was provided, convert it to a corresponding 'span' and 'scope'.
+    let (span, scope) = convert_source(diagnostic.source.as_deref(), ast, files, output);
+
+    // Construct and push the converted 'slicec' `Diagnostic`.
+    let converted_diagnostic = slicec::diagnostics::Diagnostic { kind, span, scope, notes };
+    output.push(converted_diagnostic);
+}
+
+fn convert_diagnostic_kind(kind: DiagnosticKind) -> SlicecDiagnosticKind {
+    match kind {
         DiagnosticKind::Info { message } => SlicecDiagnosticKind::Info(message),
 
         DiagnosticKind::Warning { message } => SlicecDiagnosticKind::Lint(SlicecLint::Other { message }),
@@ -95,21 +113,7 @@ pub fn convert_diagnostic(diagnostic: Diagnostic, ast: &Ast, files: &[GrammarSli
             }
             SlicecDiagnosticKind::Error(SlicecError::Other { message})
         }
-    };
-
-    // Convert any provided notes.
-    let notes = diagnostic.notes.into_iter().map(|note| {
-        let DiagnosticNote {message, source} = note;
-        let (span, _) = convert_source(source.as_deref(), ast, files, output);
-        slicec::diagnostics::Note { message, span }
-    }).collect();
-
-    // If a 'source' was provided, convert it to a corresponding 'span' and 'scope'.
-    let (span, scope) = convert_source(diagnostic.source.as_deref(), ast, files, output);
-
-    // Construct and push the converted 'slicec' `Diagnostic`.
-    let converted_diagnostic = slicec::diagnostics::Diagnostic { kind, span, scope, notes };
-    output.push(converted_diagnostic);
+    }
 }
 
 /// Parses a diagnostic 'source' string, and returns the corresponding 'span' and 'scope' for the referenced element.
@@ -118,6 +122,10 @@ fn convert_source(source: Option<&str>, ast: &Ast, files: &[GrammarSliceFile], o
     let Some(source) = source else {
         return (None, None);
     };
+
+    let attributable: &dyn Attributable;
+    let scope: Option<String>;
+    let default_span: Option<Span>;
 
     // Otherwise, split the provided source into 'the scoped id of a symbol' and an 'optional extension'.
     // This optional extension always begins with a '$' and can be used to refer to meta-elements attached to the symbol
@@ -142,25 +150,11 @@ fn convert_source(source: Option<&str>, ast: &Ast, files: &[GrammarSliceFile], o
             }
         };
 
-        // Determine which 'span' to return based off the optional extension.
+        attributable = slice_file;
         // The 'scope' is always `None`, since files do not logically have a Slice scope like symbols do.
-        let scope = None;
-        let span = match extension {
-            // If there was no extension, this diagnostic is referencing the file itself.
-            // We return an empty span that just points to the start of the file in this case.
-            None => Some(Span::new((1, 1).into(), (1, 1).into(), &slice_file.relative_path)),
-
-            // If the extension starts with 'attributes::', then this diagnostic is referencing the file's attributes.
-            Some(ext) if ext.starts_with("attributes::") => get_attribute_span(slice_file, ext, output),
-
-            Some(unknown) => {
-                let message = format!("the diagnostic source '{source}' has an unrecognized extension '{unknown}'");
-                let error = SlicecDiagnostic::from_error(SlicecError::Other { message });
-                output.push(error);
-                None // There is no meaningful span to return.
-            }
-        };
-        (span, scope)
+        scope = None;
+        // If the diagnostic source is the file itself, we use an empty span that points to the start of the file.
+        default_span = Some(Span::new((1, 1).into(), (1, 1).into(), &slice_file.relative_path));
     } else {
         // Lookup the named symbol in the AST and if it doesn't exist, emit a diagnostic and return immediately.
         let named_symbol = match ast.find_element::<dyn NamedSymbol>(symbol_id) {
@@ -173,25 +167,31 @@ fn convert_source(source: Option<&str>, ast: &Ast, files: &[GrammarSliceFile], o
             }
         };
 
-        // Determine which 'span' to return based off the optional extension.
-        // The 'scope' is always the fully-scoped identifier of the symbol, since meta-elements don't have Slice scopes.
-        let scope = Some(named_symbol.parser_scoped_identifier());
-        let span = match extension {
-            // If there was no extension, this diagnostic is referencing the named symbol itself.
-            None => Some(named_symbol.span().clone()),
-
-            // If the extension starts with 'attributes::', then this diagnostic is referencing the symbol's attributes.
-            Some(ext) if ext.starts_with("attributes::") => get_attribute_span(named_symbol, ext, output),
-
-            Some(unknown) => {
-                let message = format!("the diagnostic source '{source}' has an unrecognized extension '{unknown}'");
-                let error = SlicecDiagnostic::from_error(SlicecError::Other { message });
-                output.push(error);
-                Some(named_symbol.span().clone()) // Fallback to using the symbol's span.
-            }
-        };
-        (span, scope)
+        attributable = named_symbol;
+        // The 'scope' is always the fully-scoped identifier of the symbol.
+        scope = Some(named_symbol.parser_scoped_identifier());
+        // If the diagnostic source is a Slice symbol, we just use the symbol's span.
+        default_span = Some(named_symbol.span().clone());
     }
+
+    // Handle any optional extensions on the source, to see if we need to drill into the spans of any meta-elements.
+    let span = match extension {
+        // If there was no extension, we just use the default span we already computed.
+        None => default_span,
+
+        // If the extension starts with 'attributes::', then this diagnostic is referencing the symbol's attributes.
+        Some(ext) if ext.starts_with("attributes::") => get_attribute_span(attributable, ext, output),
+
+        // Otherwise this is an unknown extensions and we can't handle it. Report a diagnostic and use the default span.
+        Some(unknown) => {
+            let message = format!("the diagnostic source '{source}' has an unrecognized extension '{unknown}'");
+            let error = SlicecDiagnostic::from_error(SlicecError::Other { message });
+            output.push(error);
+            default_span
+        }
+    };
+
+    (span, scope)
 }
 
 fn get_attribute_span<T: Attributable + ?Sized>(symbol: &T, extension: &str, output: &mut Diagnostics) -> Option<Span> {

--- a/slicec/src/slice_file_converter.rs
+++ b/slicec/src/slice_file_converter.rs
@@ -182,7 +182,7 @@ fn convert_source(source: Option<&str>, ast: &Ast, files: &[GrammarSliceFile], o
         // If the extension starts with 'attributes::', then this diagnostic is referencing the symbol's attributes.
         Some(ext) if ext.starts_with("attributes::") => get_attribute_span(attributable, ext, output),
 
-        // Otherwise this is an unknown extensions and we can't handle it. Report a diagnostic and use the default span.
+        // Otherwise this is an unknown extension and we can't handle it. Report a diagnostic and use the default span.
         Some(unknown) => {
             let message = format!("the diagnostic source '{source}' has an unrecognized extension '{unknown}'");
             let error = SlicecDiagnostic::from_error(SlicecError::Other { message });
@@ -199,7 +199,7 @@ fn get_attribute_span<T: Attributable + ?Sized>(symbol: &T, extension: &str, out
     let indices = extension.split("::").collect::<Vec<_>>();
     assert!(indices.len() > 1 && indices[0] == "attributes");
 
-    // Make sure we either 1 or 2 indices after 'attributes'.
+    // Make sure we have either 1 or 2 indices after 'attributes'.
     let (attribute_index_str, argument_index_str) = match &indices[1..] {
         [i] => (i.parse::<usize>(), None),
         [i, j] => (i.parse::<usize>(), Some(j.parse::<usize>())),

--- a/slicec/src/slice_file_converter.rs
+++ b/slicec/src/slice_file_converter.rs
@@ -29,8 +29,240 @@ use slicec::grammar::{Attributable, Commentable, Contained, Entity, Member, Name
 // Pull in the attribute types without aliases, since they're not ambiguous.
 use slicec::grammar::attributes::{Allow, Compress, Deprecated, Oneway, SlicedFormat, Unparsed};
 
+use slicec::diagnostics::Diagnostic as SlicecDiagnostic;
+use slicec::diagnostics::DiagnosticKind as SlicecDiagnosticKind;
+use slicec::diagnostics::Error as SlicecError;
+use slicec::diagnostics::Lint as SlicecLint;
+
+use slicec::ast::Ast;
+use slicec::diagnostics::Diagnostics;
+use slicec::slice_file::Span;
+
 // Pull in all the mapped Slice-compiler definition types.
 use crate::definition_types::*;
+
+use std::fmt::Write;
+
+// =============================== //
+// Diagnostic conversion functions //
+// =============================== //
+
+const CRITICAL_FLAW_STRING: &str = "this indicates a critical flaw in the plugin that generated this diagnostic";
+
+/// Converts a `Diagnostic` emitted from a plugin, to a `Diagnostic` that can be used by the Slice compiler.
+/// 
+/// Instead of directly returning the converted `Diagnostic`, this function pushes it into a provided `Diagnostics`
+/// container. This is because a single plugin-diagnostic may actually produce multiple compiler-diagnostics, for
+/// example, if a plugin emits a malformed diagnostic that references a non-existent source span.
+pub fn convert_diagnostic(diagnostic: Diagnostic, ast: &Ast, files: &[GrammarSliceFile], output: &mut Diagnostics) {
+    // Perform the actual conversion between `DiagnosticKind` types.
+    let kind = match diagnostic.kind {
+        DiagnosticKind::Info { message } => SlicecDiagnosticKind::Info(message),
+
+        DiagnosticKind::Warning { message } => SlicecDiagnosticKind::Lint(SlicecLint::Other { message }),
+
+        DiagnosticKind::Error { message } => SlicecDiagnosticKind::Error(SlicecError::Other { message }),
+
+        DiagnosticKind::InvalidAttribute { directive }
+            => SlicecDiagnosticKind::Error(SlicecError::InvalidAttribute { directive }),
+
+        DiagnosticKind::UnknownAttribute { directive }
+            => SlicecDiagnosticKind::Error(SlicecError::UnknownAttribute { directive }),
+
+        DiagnosticKind::MissingRequiredAttribute { expected_attribute }
+            => SlicecDiagnosticKind::Error(SlicecError::MissingRequiredAttribute { expected_attribute }),
+
+        DiagnosticKind::AttributeIsNotRepeatable { directive }
+            => SlicecDiagnosticKind::Error(SlicecError::AttributeIsNotRepeatable { directive }),
+
+        DiagnosticKind::InvalidAttributeArgument { directive, argument }
+            => SlicecDiagnosticKind::Error(SlicecError::InvalidAttributeArgument { directive, argument }),
+
+        DiagnosticKind::IncorrectAttributeArgumentCount { directive, min_expected, max_expected, actual_count } => {
+            let min_expected = if min_expected == u8::MAX { usize::MAX } else { min_expected as usize };
+            let max_expected = if max_expected == u8::MAX { usize::MAX } else { max_expected as usize };
+            SlicecDiagnosticKind::Error(SlicecError::IncorrectAttributeArgumentCount {
+                directive,
+                expected_count: min_expected..(max_expected + 1),
+                actual_count: actual_count as usize,
+            })
+        }
+
+        DiagnosticKind::Unknown { discriminant, fields_payload } => {
+            let mut message = format!("received an unknown diagnostic with a code of '{discriminant}'");
+            if !fields_payload.is_empty() {
+                write!(message, " and field-payload of:\n{fields_payload:?}").unwrap();
+            }
+            SlicecDiagnosticKind::Error(SlicecError::Other { message})
+        }
+    };
+
+    // Convert any provided notes.
+    let notes = diagnostic.notes.into_iter().map(|note| {
+        let DiagnosticNote {message, source} = note;
+        let (span, _) = convert_source(source.as_deref(), ast, files, output);
+        slicec::diagnostics::Note { message, span }
+    }).collect();
+
+    // If a 'source' was provided, convert it to a corresponding 'span' and 'scope'.
+    let (span, scope) = convert_source(diagnostic.source.as_deref(), ast, files, output);
+
+    // Construct and push the converted 'slicec' `Diagnostic`.
+    let converted_diagnostic = slicec::diagnostics::Diagnostic { kind, span, scope, notes };
+    output.push(converted_diagnostic);
+}
+
+fn convert_source(source: Option<&str>, ast: &Ast, files: &[GrammarSliceFile], output: &mut Diagnostics) -> (Option<Span>, Option<String>) {
+    // If no source was provided, we can immediately return `(None, None)` since there's nothing to convert.
+    let Some(source) = source else {
+        return (None, None);
+    };
+
+    // Otherwise, split the provided source into 'the scoped id of an symbol' and an 'optional extension'.
+    // This optional extension always begins with a '$' and can be used to refer to meta-elements attached to the symbol
+    // like attributes or doc-comments. For example: `"MyModule::MyClass::$attributes::1"` for attribute 1 on "MyClass".
+    let (entity_id, extension) = if let Some((entity_id, extension)) = source.split_once("::$") {
+        (entity_id, Some(extension))
+    } else {
+        (source, None)
+    };
+
+    // If the source starts with a '#', then it is referencing a file. Otherwise it is referencing a named symbol.
+    if let Some(diagnostic_file_path) = source.strip_prefix('#') {
+        // Lookup the file in the list of slice files and if it doesn't exist, emit a diagnostic and return immediately.
+        let slice_file = match files.iter().find(|file| file.relative_path == diagnostic_file_path) {
+            Some(file) => file,
+            None => {
+                let message = format!("no file with the relative path '{diagnostic_file_path}' was parsed by 'slicec'");
+                SlicecDiagnostic::from_error(SlicecError::Other { message })
+                    .add_note(CRITICAL_FLAW_STRING, None)
+                    .push_into(output);
+                return (None, None);
+            }
+        };
+
+        // Determine which 'span' to return based off the optional extension.
+        // The 'scope' is always `None`, since files do not logically have a Slice scope like symbols do.
+        let scope = None;
+        let span = match extension {
+            // If the extension starts with 'attributes::', then this diagnostic is referencing the symbol's attributes.
+            Some("attributes::") => get_attribute_span(slice_file, extension.unwrap(), output),
+
+            Some(unknown) => {
+                let message = format!("the diagnostic source '{source}' has an unrecognized extension '{unknown}'");
+                let error = SlicecDiagnostic::from_error(SlicecError::Other { message });
+                output.push(error);
+                None // There is no meaningful span to return.
+            }
+
+            None => {
+                let message = format!("the diagnostic source '{source}' is missing a required extension");
+                let error = SlicecDiagnostic::from_error(SlicecError::Other { message })
+                    .add_note(CRITICAL_FLAW_STRING, None)
+                    .add_note("file-sources must have an extension", None);
+                output.push(error);
+                None // There is no meaningful span to return.
+            }
+        };
+        (span, scope)
+    } else {
+        // Lookup the named symbol in the AST and if it doesn't exist, emit a diagnostic and return immediately.
+        let named_symbol = match ast.find_element::<dyn NamedSymbol>(entity_id) {
+            Ok(named_symbol) => named_symbol,
+            Err(err) => {
+                SlicecDiagnostic::from_error(err.into())
+                    .add_note(CRITICAL_FLAW_STRING, None)
+                    .push_into(output);
+                return (None, None);
+            }
+        };
+
+        // Determine which 'span' to return based off the optional extension.
+        // The 'scope' is always the fully-scoped identifier of the symbol, since meta-elements don't have Slice scopes.
+        let scope = Some(named_symbol.parser_scoped_identifier());
+        let span = match extension {
+            // If there was no extension, this diagnostic is referencing the named symbol itself.
+            None => Some(named_symbol.span().clone()),
+
+            // If the extension starts with 'attributes::', then this diagnostic is referencing the symbol's attributes.
+            Some("attributes::") => get_attribute_span(named_symbol, extension.unwrap(), output),
+
+            Some(unknown) => {
+                let message = format!("the diagnostic source '{source}' has an unrecognized extension '{unknown}'");
+                let error = SlicecDiagnostic::from_error(SlicecError::Other { message });
+                output.push(error);
+                Some(named_symbol.span().clone()) // Fallback to using the symbol's span.
+            }
+        };
+        (span, scope)
+    }
+}
+
+fn get_attribute_span<T: Attributable + ?Sized>(symbol: &T, extension: &str, output: &mut Diagnostics) -> Option<Span> {
+    // Split the extension string by '::' and ensure it starts with 'attributes' and has at least 2 parts.
+    let indices = extension.split("::").collect::<Vec<_>>();
+    assert!(indices.len() > 1 && indices[0] == "attributes");
+
+    // Make sure we either 1 or 2 indices after 'attributes'.
+    let (attribute_index_str, argument_index_str) = match &indices[1..] {
+        [i] => (i.parse::<usize>(), None),
+        [i, j] => (i.parse::<usize>(), Some(j.parse::<usize>())),
+
+        [] => unreachable!("'get_attribute_span' had 0 indices despite asserting that there was at least 1!"),
+        _ => {
+            let message = format!("{} indices were supplied to the '$attributes' diagnostic source", indices.len() - 1);
+            let error = SlicecDiagnostic::from_error(SlicecError::Other { message })
+                .add_note(CRITICAL_FLAW_STRING, None);
+            output.push(error);
+            return None;
+        }
+    };
+
+    // Retrieve the attribute being referenced based on the first index after "attributes::".
+    let Ok(attribute_index) = attribute_index_str else {
+        let message = format!("{} is not a valid integer", indices[1]);
+        let error = SlicecDiagnostic::from_error(SlicecError::Other { message })
+            .add_note(CRITICAL_FLAW_STRING, None);
+        output.push(error);
+        return None;
+    };
+    let Some(&attribute) = symbol.attributes().get(attribute_index) else {
+        let message = format!("attribute index '{attribute_index}' is out of bounds");
+        let error = SlicecDiagnostic::from_error(SlicecError::Other { message })
+            .add_note(CRITICAL_FLAW_STRING, None);
+        output.push(error);
+        return None;
+    };
+    // If there was no 2nd index, then we want to return the span of the entire attribute itself.
+    if argument_index_str.is_none() {
+        return Some(attribute.span.clone());
+    }
+
+    //// Otherwise, we know there was a 2nd index; retrieve the argument being referenced based on this 2nd index.
+    //let Ok(argument_index) = argument_index_str.unwrap() else {
+    //    let message = format!("{} is not a valid integer", indices[2]);
+    //    let error = SlicecDiagnostic::from_error(SlicecError::Other { message })
+    //        .add_note(CRITICAL_FLAW_STRING, None);
+    //    output.push(error);
+    //    return None;
+    //};
+    //let Some(argument) = attribute.arguments().get(argument_index) else {
+    //    let message = format!("argument index '{argument_index}' is out of bounds");
+    //    let error = SlicecDiagnostic::from_error(SlicecError::Other { message })
+    //        .add_note(CRITICAL_FLAW_STRING, None);
+    //    output.push(error);
+    //    return None;
+    //};
+    //// Return the span of the argument.
+    //Some(argument.span().clone())
+
+    // TODO: we need to refactor the 'Attributes' API to expose arguments and their spans before we can implement this.
+    Some(attribute.span.clone())
+}
+
+// =================================== //
+// Grammar conversion helper functions //
+// =================================== //
 
 /// Returns an [EntityInfo] describing the provided element.
 fn get_entity_info_for(element: &impl Commentable) -> EntityInfo {

--- a/slicec/src/slice_file_converter.rs
+++ b/slicec/src/slice_file_converter.rs
@@ -128,8 +128,8 @@ fn convert_source(source: Option<&str>, ast: &Ast, files: &[GrammarSliceFile], o
     let default_span: Option<Span>;
 
     // Otherwise, split the provided source into 'the scoped id of a symbol' and an 'optional extension'.
-    // This optional extension always begins with a '$' and can be used to refer to meta-elements attached to the symbol
-    // like attributes or doc-comments. For example: `"MyModule::MyClass::$attributes::1"` for attribute 1 on "MyClass".
+    // The optional extension always begins with a '$' and can be used to refer to meta-elements attached to the symbol.
+    // For example: `"MyModule::MyClass::$attributes::1"` refers to the 2nd attribute on "MyClass".
     let (symbol_id, extension) = if let Some((symbol_id, extension)) = source.split_once("::$") {
         (symbol_id, Some(extension))
     } else {


### PR DESCRIPTION
This PR is the Rust counterpart to https://github.com/icerpc/icerpc-csharp/pull/4615.
It fixes #771.

It adds the logic to convert from a slice-generated `Compiler::Diagnostic` to a native `slicec` `Diagnostic`,
and updates the `main` function to properly decode, convert, process, and emit diagnostics reported by code-generators.

----

Running `slicec` by hand on the CLI shows it's working good. But of course the real test will be once this is merged, and can be used by `icerpc-csharp` directly. This at least shows that the decoding/conversion is all correct.
```
error [E023]: invalid attribute 'cs::encodedReturn'
 --> .\icerpc-csharp\Test.slice:2:3
  |
2 | [[cs::encodedReturn]]
  |   -----------------
  |
error [E024]: unknown attribute 'cs::whatever'
 --> .\icerpc-csharp\Test.slice:6:2
  |
6 | [cs::whatever]
  |  ------------
  |
error [E028]: attribute 'cs::identifier' takes exactly 1 argument, but 2 arguments were provided
 --> .\icerpc-csharp\Test.slice:8:6
  |
8 |     [cs::identifier("Foo", "Bar")]
  |      ----------------------------
  |
error [E025]: missing required attribute 'cs::type(TYPE_STRING)'
 --> .\icerpc-csharp\Test.slice:12:1
   |
12 | custom MyType
   | -------------
   |
Failed: Compilation failed with 4 error(s)
```