### PR TITLE
Switch 'Options' to a Sequence instead of a Dictionary

### DIFF
--- a/slice/Compiler/CodeGenerator.slice
+++ b/slice/Compiler/CodeGenerator.slice
@@ -8,7 +8,12 @@ interface CodeGenerator {
         (generatedFiles: Sequence<GeneratedFile>, diagnostics: Sequence<Diagnostic>)
 }
 
-typealias Options = Dictionary<string, string>
+typealias Options = Sequence<KeyValuePair>
+
+struct KeyValuePair {
+    key: string
+    value: string
+}
 
 struct SliceFile {
     path: string

--- a/slice/Compiler/CodeGenerator.slice
+++ b/slice/Compiler/CodeGenerator.slice
@@ -8,9 +8,9 @@ interface CodeGenerator {
         (generatedFiles: Sequence<GeneratedFile>, diagnostics: Sequence<Diagnostic>)
 }
 
-typealias Options = Sequence<KeyValuePair>
+typealias Options = Sequence<CodeGeneratorOption>
 
-struct KeyValuePair {
+struct CodeGeneratorOption {
     key: string
     value: string
 }

--- a/slicec/src/definition_types.rs
+++ b/slicec/src/definition_types.rs
@@ -242,8 +242,8 @@ impl EncodeInto for &MessageComponent {
     }
 }
 
-pub struct Arguments(pub Vec<(String, String)>);
-impl EncodeInto for Arguments {
+pub struct Options(pub Vec<(String, String)>);
+impl EncodeInto for Options {
     fn encode_into(self, encoder: &mut Encoder<impl OutputTarget>) -> Result<()> {
         encoder.encode_size(self.0.len())?;
         for (e1, e2) in &self.0 {

--- a/slicec/src/main.rs
+++ b/slicec/src/main.rs
@@ -68,7 +68,7 @@ fn spawn_plugin_process(plugin: &Plugin, slice_payload: &[u8]) -> std::io::Resul
     // Encode and write any plugin arguments to the subprocess's 'stdin'.
     let mut arguments_payload = Vec::new();
     let mut slice_encoder = Encoder::from(&mut arguments_payload);
-    slice_encoder.encode(definition_types::Arguments(plugin.args.clone()))?;
+    slice_encoder.encode(definition_types::Options(plugin.args.clone()))?;
     stdin.write_all(&arguments_payload)?;
 
     // Return a handle to the subprocess so we can wait on it to complete.


### PR DESCRIPTION
This PR switches the `Options` type we send along with `generateCode` requests from a `Dictionary` to a `Sequence`.
The motivation is to remove the restriction of having unique keys.
But this also has the benefit of communicating that `slicec` preserves the order of your arguments.

----

This requires no changes from `slicec`. We were already storing the parsed arguments as a `Vec<(String, String)>`,
and I was mistaken, it seems like we decided not to implement duplicate-key detection in `slicec`, looking at the original PR.