### PR TITLE
Reject Duplicate Dictionary Keys

### DIFF
--- a/slice-codec/src/decode_from.rs
+++ b/slice-codec/src/decode_from.rs
@@ -56,7 +56,8 @@ macro_rules! decode_dictionary_entries {
                 return Err(error.into());
             } else {
                 // `insert` should always return `None` for a new key.
-                debug_assert!($dictionary.insert(key, value).is_none());
+                let result = $dictionary.insert(key, value);
+                debug_assert!(result.is_none());
             }
         }
     };

--- a/slice-codec/src/decode_from.rs
+++ b/slice-codec/src/decode_from.rs
@@ -54,11 +54,10 @@ macro_rules! decode_dictionary_entries {
                     key: alloc::format!("{key:?}"),
                 };
                 return Err(error.into());
-            } else {
-                // `insert` should always return `None` for a new key.
-                let result = $dictionary.insert(key, value);
-                debug_assert!(result.is_none());
             }
+
+            let result = $dictionary.insert(key, value);
+            debug_assert!(result.is_none()); // `insert` should always return `None` for a new key.
         }
     };
 }

--- a/slice-codec/src/decode_from.rs
+++ b/slice-codec/src/decode_from.rs
@@ -41,16 +41,25 @@ pub use implement_decode_from_on_numeric_primitive_type; // Re-export the macro 
 #[doc(hidden)]
 #[macro_export]
 macro_rules! decode_dictionary_entries {
-    ($map:ident, $decoder:ident, $length:ident) => {
-        // Decode each entry, and insert them into the map, one by one.
+    ($dictionary:ident, $decoder:ident, $length:ident) => {
+        // Decode each entry, and insert them into the dictionary, one by one.
         for _ in 0..$length {
             let key = $decoder.decode()?;
             let value = $decoder.decode()?;
-            if let Some(_duplicate) = $map.insert(key, value) {
-                // TODO
-                // If you insert a duplicate key into the map, it will return the old key.
-                // So, if we hit this, we return  an error, because dictionary keys must be unique.
-                todo!();
+
+            // Check if the key already exists in the dictionary
+            match $dictionary.contains_key(&key) {
+                false => {
+                    // If it doesn't, insert it normally, and assert that 'insert' returned `None`.
+                    debug_assert!($dictionary.insert(key, value).is_none());
+                }
+                true => {
+                    // If it does, immediately return a duplicate key error.
+                    let error = InvalidDataErrorKind::DuplicateDictionaryKey {
+                        key: alloc::format!("{key:?}"),
+                    };
+                    return Err(error.into());
+                }
             }
         }
     };

--- a/slice-codec/src/decode_from.rs
+++ b/slice-codec/src/decode_from.rs
@@ -47,7 +47,7 @@ macro_rules! decode_dictionary_entries {
             let key = $decoder.decode()?;
             let value = $decoder.decode()?;
 
-            // Insert the key,value pair into the dictionary. If the decoded key is already present, we return an error.
+            // Insert the (key,value) pair into the dictionary. If the decoded key is already present, we return an error.
             if $dictionary.insert(key, value).is_some() {
                 return Err(InvalidDataErrorKind::DuplicateDictionaryKey.into());
             }

--- a/slice-codec/src/decode_from.rs
+++ b/slice-codec/src/decode_from.rs
@@ -47,7 +47,7 @@ macro_rules! decode_dictionary_entries {
             let key = $decoder.decode()?;
             let value = $decoder.decode()?;
 
-            // Insert the (key,value) pair into the dictionary. If the decoded key is already present, we return an error.
+            // Insert the (key,value) pair into the dictionary. If the decoded key is already present, return an error.
             if $dictionary.insert(key, value).is_some() {
                 return Err(InvalidDataErrorKind::DuplicateDictionaryKey.into());
             }

--- a/slice-codec/src/decode_from.rs
+++ b/slice-codec/src/decode_from.rs
@@ -47,19 +47,16 @@ macro_rules! decode_dictionary_entries {
             let key = $decoder.decode()?;
             let value = $decoder.decode()?;
 
-            // Check if the key already exists in the dictionary
-            match $dictionary.contains_key(&key) {
-                false => {
-                    // If it doesn't, insert it normally, and assert that 'insert' returned `None`.
-                    debug_assert!($dictionary.insert(key, value).is_none());
-                }
-                true => {
-                    // If it does, immediately return a duplicate key error.
-                    let error = InvalidDataErrorKind::DuplicateDictionaryKey {
-                        key: alloc::format!("{key:?}"),
-                    };
-                    return Err(error.into());
-                }
+            // Check if the key already exists in the dictionary. If it does, we return a duplicate-key error.
+            // Otherwise, we insert the key normally.
+            if $dictionary.contains_key(&key) {
+                let error = InvalidDataErrorKind::DuplicateDictionaryKey {
+                    key: alloc::format!("{key:?}"),
+                };
+                return Err(error.into());
+            } else {
+                // `insert` should always return `None` for a new key.
+                debug_assert!($dictionary.insert(key, value).is_none());
             }
         }
     };

--- a/slice-codec/src/decode_from.rs
+++ b/slice-codec/src/decode_from.rs
@@ -47,17 +47,10 @@ macro_rules! decode_dictionary_entries {
             let key = $decoder.decode()?;
             let value = $decoder.decode()?;
 
-            // Check if the key already exists in the dictionary. If it does, we return a duplicate-key error.
-            // Otherwise, we insert the key normally.
-            if $dictionary.contains_key(&key) {
-                let error = InvalidDataErrorKind::DuplicateDictionaryKey {
-                    key: alloc::format!("{key:?}"),
-                };
-                return Err(error.into());
+            // Insert the key,value pair into the dictionary. If the decoded key is already present, we return an error.
+            if $dictionary.insert(key, value).is_some() {
+                return Err(InvalidDataErrorKind::DuplicateDictionaryKey.into());
             }
-
-            let result = $dictionary.insert(key, value);
-            debug_assert!(result.is_none()); // `insert` should always return `None` for a new key.
         }
     };
 }

--- a/slice-codec/src/decoding.rs
+++ b/slice-codec/src/decoding.rs
@@ -12,6 +12,8 @@ use alloc::collections::BTreeMap;
 use alloc::string::String;
 #[cfg(feature = "alloc")]
 use alloc::vec::Vec;
+#[cfg(feature = "alloc")]
+use core::fmt::Debug;
 
 // We only support `HashMap` if the standard library is available through the `std` feature flag.
 #[cfg(feature = "std")]
@@ -237,14 +239,14 @@ where
 #[cfg(feature = "std")]
 impl<K, V> DecodeFrom for HashMap<K, V>
 where
-    K: DecodeFrom + Eq + Hash,
+    K: DecodeFrom + Debug + Eq + Hash,
     V: DecodeFrom,
 {
     /// TODO
     fn decode_from(decoder: &mut Decoder<impl InputSource>) -> Result<Self> {
         // Decode how many entries are in this dictionary, and attempt to allocate a map with the necessary capacity.
         let length = decoder.decode_varuint()?;
-        let mut map = HashMap::new();
+        let mut map = HashMap::<K, V>::new();
         map.try_reserve(length)?;
 
         // Decode 'length'-many entries into the map.
@@ -256,14 +258,14 @@ where
 #[cfg(feature = "alloc")]
 impl<K, V> DecodeFrom for BTreeMap<K, V>
 where
-    K: DecodeFrom + Ord,
+    K: DecodeFrom + Debug + Ord,
     V: DecodeFrom,
 {
     /// TODO
     fn decode_from(decoder: &mut Decoder<impl InputSource>) -> Result<Self> {
         // Decode how many entries are in this dictionary, and attempt to allocate a map with the necessary capacity.
         let length = decoder.decode_varuint()?;
-        let mut map = BTreeMap::new();
+        let mut map = BTreeMap::<K, V>::new();
 
         // Decode 'length'-many entries into the map.
         decode_dictionary_entries!(map, decoder, length);

--- a/slice-codec/src/decoding.rs
+++ b/slice-codec/src/decoding.rs
@@ -246,7 +246,7 @@ where
     fn decode_from(decoder: &mut Decoder<impl InputSource>) -> Result<Self> {
         // Decode how many entries are in this dictionary, and attempt to allocate a map with the necessary capacity.
         let length = decoder.decode_varuint()?;
-        let mut map = HashMap::<K, V>::new();
+        let mut map = HashMap::new();
         map.try_reserve(length)?;
 
         // Decode 'length'-many entries into the map.
@@ -265,7 +265,7 @@ where
     fn decode_from(decoder: &mut Decoder<impl InputSource>) -> Result<Self> {
         // Decode how many entries are in this dictionary, and attempt to allocate a map with the necessary capacity.
         let length = decoder.decode_varuint()?;
-        let mut map = BTreeMap::<K, V>::new();
+        let mut map = BTreeMap::new();
 
         // Decode 'length'-many entries into the map.
         decode_dictionary_entries!(map, decoder, length);

--- a/slice-codec/src/error.rs
+++ b/slice-codec/src/error.rs
@@ -200,6 +200,7 @@ impl Display for InvalidDataErrorKind {
                 )
             }
 
+            #[cfg(feature = "alloc")]
             Self::DuplicateDictionaryKey { key } => write!(f, "duplicate key: {key}"),
         }
     }

--- a/slice-codec/src/error.rs
+++ b/slice-codec/src/error.rs
@@ -13,7 +13,7 @@ use alloc::boxed::Box;
 #[cfg(feature = "alloc")]
 use alloc::collections::TryReserveError;
 #[cfg(feature = "alloc")]
-use alloc::string::FromUtf8Error;
+use alloc::string::{FromUtf8Error, String};
 
 /// A specialized [`Result`](core::result::Result) type for encoding and decoding functions which may produce errors.
 ///
@@ -170,6 +170,13 @@ pub enum InvalidDataErrorKind {
         max: i128,
         typename: &'static str,
     },
+
+    /// A key appears multiple times in a dictionary, violating the uniqueness requirement.
+    #[cfg(feature = "alloc")]
+    DuplicateDictionaryKey {
+        /// A string representation of the offending key.
+        key: String,
+    },
 }
 
 impl Display for InvalidDataErrorKind {
@@ -182,13 +189,18 @@ impl Display for InvalidDataErrorKind {
                     write!(f, "illegal value: {desc}")
                 }
             }
+
+            #[cfg(feature = "alloc")]
+            Self::InvalidString(inner) => inner.fmt(f),
+
             Self::OutOfRange { value, min, max, typename } => {
                 write!(
                     f,
                     "value '{value}' is outside the allowed range for type '{typename}'; values must be within [{min}..{max}]"
                 )
             }
-            _ => todo!(),
+
+            Self::DuplicateDictionaryKey { key } => write!(f, "duplicate key: {key}"),
         }
     }
 }

--- a/slice-codec/src/error.rs
+++ b/slice-codec/src/error.rs
@@ -13,7 +13,7 @@ use alloc::boxed::Box;
 #[cfg(feature = "alloc")]
 use alloc::collections::TryReserveError;
 #[cfg(feature = "alloc")]
-use alloc::string::{FromUtf8Error, String};
+use alloc::string::FromUtf8Error;
 
 /// A specialized [`Result`](core::result::Result) type for encoding and decoding functions which may produce errors.
 ///
@@ -173,10 +173,7 @@ pub enum InvalidDataErrorKind {
 
     /// A key appears multiple times in a dictionary, violating the uniqueness requirement.
     #[cfg(feature = "alloc")]
-    DuplicateDictionaryKey {
-        /// A string representation of the offending key.
-        key: String,
-    },
+    DuplicateDictionaryKey,
 }
 
 impl Display for InvalidDataErrorKind {
@@ -201,7 +198,7 @@ impl Display for InvalidDataErrorKind {
             }
 
             #[cfg(feature = "alloc")]
-            Self::DuplicateDictionaryKey { key } => write!(f, "duplicate key: {key}"),
+            Self::DuplicateDictionaryKey => write!(f, "duplicate dictionary key encountered"),
         }
     }
 }

--- a/slice-codec/tests/encoding_tests.rs
+++ b/slice-codec/tests/encoding_tests.rs
@@ -142,8 +142,10 @@ mod fixed_size {
 #[cfg(test)]
 mod variable_sized {
     use slice_codec::buffer::slice::{SliceInputSource, SliceOutputTarget};
+    use slice_codec::buffer::vec::VecOutputTarget;
     use slice_codec::decoder::Decoder;
     use slice_codec::encoder::Encoder;
+    use slice_codec::{ErrorKind, InvalidDataErrorKind};
 
     use core::fmt::Debug;
 
@@ -383,8 +385,36 @@ mod variable_sized {
             assert!(decoded.is_err());
             assert!(matches!(
                 decoded.err().unwrap().kind(),
-                slice_codec::ErrorKind::InvalidData(slice_codec::InvalidDataErrorKind::InvalidString(_))
+                ErrorKind::InvalidData(InvalidDataErrorKind::InvalidString(_))
             ));
+        }
+
+        #[test]
+        fn dictionary_decoding_rejects_duplicate_key() {
+            use std::collections::HashMap;
+
+            // Arrange
+            let mut buffer = Vec::new();
+            let mut encoder = Encoder::new(VecOutputTarget::from(&mut buffer));
+            encoder.encode_size(4).unwrap();
+            encoder.encode(1001_i32).unwrap(); // Key 1
+            encoder.encode("foobar").unwrap(); // Value 1
+            encoder.encode(1002_i32).unwrap(); // Key 2
+            encoder.encode("foobar").unwrap(); // Value 2
+            encoder.encode(1001_i32).unwrap(); // Key 3 (duplicate)
+            encoder.encode("foobar").unwrap(); // Value 3
+            let mut decoder = Decoder::new(SliceInputSource::from(&buffer));
+
+            // Act
+            let result = decoder.decode::<HashMap<i32, String>>();
+            println!("{result:?}");
+
+            // Assert
+            assert!(result.is_err());
+            assert!(matches!(
+                result.err().unwrap().kind(),
+                ErrorKind::InvalidData(InvalidDataErrorKind::DuplicateDictionaryKey { key }) if key == "1001",
+            ))
         }
     }
 }

--- a/slice-codec/tests/encoding_tests.rs
+++ b/slice-codec/tests/encoding_tests.rs
@@ -399,7 +399,7 @@ mod variable_sized {
             // Arrange
             let mut buffer = Vec::new();
             let mut encoder = Encoder::new(VecOutputTarget::from(&mut buffer));
-            encoder.encode_size(4).unwrap();
+            encoder.encode_size(3).unwrap();
             encoder.encode(1001_i32).unwrap(); // Key 1
             encoder.encode("foobar").unwrap(); // Value 1
             encoder.encode(1002_i32).unwrap(); // Key 2

--- a/slice-codec/tests/encoding_tests.rs
+++ b/slice-codec/tests/encoding_tests.rs
@@ -415,7 +415,7 @@ mod variable_sized {
             assert!(result.is_err());
             assert!(matches!(
                 result.err().unwrap().kind(),
-                ErrorKind::InvalidData(InvalidDataErrorKind::DuplicateDictionaryKey { key }) if key == "1001",
+                ErrorKind::InvalidData(InvalidDataErrorKind::DuplicateDictionaryKey),
             ))
         }
     }

--- a/slice-codec/tests/encoding_tests.rs
+++ b/slice-codec/tests/encoding_tests.rs
@@ -390,8 +390,9 @@ mod variable_sized {
         }
 
         #[test]
+        #[cfg(feature = "alloc")]
         fn dictionary_decoding_rejects_duplicate_key() {
-            use std::collections::HashMap;
+            use std::collections::BTreeMap;
 
             // Arrange
             let mut buffer = Vec::new();
@@ -406,7 +407,7 @@ mod variable_sized {
             let mut decoder = Decoder::new(SliceInputSource::from(&buffer));
 
             // Act
-            let result = decoder.decode::<HashMap<i32, String>>();
+            let result = decoder.decode::<BTreeMap<i32, String>>();
             println!("{result:?}");
 
             // Assert

--- a/slice-codec/tests/encoding_tests.rs
+++ b/slice-codec/tests/encoding_tests.rs
@@ -408,7 +408,6 @@ mod variable_sized {
 
             // Act
             let result = decoder.decode::<BTreeMap<i32, String>>();
-            println!("{result:?}");
 
             // Assert
             assert!(result.is_err());

--- a/slice-codec/tests/encoding_tests.rs
+++ b/slice-codec/tests/encoding_tests.rs
@@ -142,9 +142,10 @@ mod fixed_size {
 #[cfg(test)]
 mod variable_sized {
     use slice_codec::buffer::slice::{SliceInputSource, SliceOutputTarget};
-    use slice_codec::buffer::vec::VecOutputTarget;
     use slice_codec::decoder::Decoder;
     use slice_codec::encoder::Encoder;
+
+    #[cfg(feature = "alloc")]
     use slice_codec::{ErrorKind, InvalidDataErrorKind};
 
     use core::fmt::Debug;
@@ -390,9 +391,10 @@ mod variable_sized {
         }
 
         #[test]
-        #[cfg(feature = "alloc")]
+        #[cfg(feature = "std")]
         fn dictionary_decoding_rejects_duplicate_key() {
-            use std::collections::BTreeMap;
+            use slice_codec::buffer::vec::VecOutputTarget;
+            use std::collections::HashMap;
 
             // Arrange
             let mut buffer = Vec::new();
@@ -407,7 +409,7 @@ mod variable_sized {
             let mut decoder = Decoder::new(SliceInputSource::from(&buffer));
 
             // Act
-            let result = decoder.decode::<BTreeMap<i32, String>>();
+            let result = decoder.decode::<HashMap<i32, String>>();
 
             // Assert
             assert!(result.is_err());


### PR DESCRIPTION
This PR implements #720 by strongly enforcing the spec, i.e. if we encounter duplicate keys during decoding, we error.

I don't see value in mirroring this check on the encoding side. If you're using any normal dictionary type in Rust, they will already guarantee uniqueness of keys. And if you're using your own type, well, there's nothing we can do to stop you from sending duplicates anyways.