### PR TITLE
Pre-0.4 Dependency Bumps

### DIFF
--- a/slice-codec/Cargo.toml
+++ b/slice-codec/Cargo.toml
@@ -8,7 +8,7 @@ documentation = "https://docs.rs/slice-codec"
 repository = "https://github.com/icerpc/slicec/slice-codec"
 readme = "README.md"
 keywords = ["slice", "ice", "icerpc"]
-rust-version = "1.73"
+rust-version = "1.74"
 
 # Get these crate fields from the top-level workspace 'Cargo.toml'.
 version.workspace = true
@@ -21,8 +21,8 @@ name = "slice_codec"
 path = "src/lib.rs"
 
 [dependencies]
-tokio = { version = "1.37.0", optional = true }
-bytes = { version = "1.6.0", optional = true }
+tokio = { version = "1.52.3", optional = true }
+bytes = { version = "1.11.1", optional = true }
 
 [dev-dependencies]
 test-case = "3.3.1"

--- a/slicec/Cargo.toml
+++ b/slicec/Cargo.toml
@@ -24,7 +24,7 @@ console = "0.16.3"
 convert_case = "0.11.0"
 in_definite = "1.1.2"
 # The default features enable a built-in lexer. We supply our own lexer so we don't need these.
-lalrpop-util = { version = "0.23.1", default-features = false }
+lalrpop-util = { version = "0.23.1", default-features = false, features = ["std", "unicode"] }
 # derive feature allows structs to derive Serialize automatically
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.150"

--- a/slicec/Cargo.toml
+++ b/slicec/Cargo.toml
@@ -8,7 +8,7 @@ documentation = "https://docs.rs/slicec"
 repository = "https://github.com/icerpc/slicec/slicec"
 readme = "README.md"
 keywords = ["slice", "ice", "icerpc"]
-rust-version = "1.82"
+rust-version = "1.87"
 
 # Get these crate fields from the top-level workspace 'Cargo.toml'.
 version.workspace = true
@@ -19,18 +19,19 @@ edition.workspace = true
 [dependencies]
 slice-codec = { path = "../slice-codec", version = "0.4.0" }
 # derive feature allows structs to derive Parser automatically
-clap = { version = "4.5.53", features = ["derive"] }
-console = "0.16.1"
-convert_case = "0.10.0"
+clap = { version = "4.6.1", features = ["derive"] }
+console = "0.16.3"
+convert_case = "0.11.0"
 in_definite = "1.1.2"
-lalrpop-util = "0.22.2"
+# The default features enable a built-in lexer. We supply our own lexer so we don't need these.
+lalrpop-util = { version = "0.23.1", default-features = false }
 # derive feature allows structs to derive Serialize automatically
 serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0.145"
+serde_json = "1.0.150"
 
 [build-dependencies]
 # The default features enable a built-in lexer. We supply our own lexer so we don't need these.
-lalrpop = { version = "0.22.2", default-features = false }
+lalrpop = { version = "0.23.1", default-features = false }
 
 [dev-dependencies]
 test-case = "3.3.1"

--- a/slicec/src/parsers/slice/grammar.lalrpop
+++ b/slicec/src/parsers/slice/grammar.lalrpop
@@ -322,9 +322,9 @@ UndelimitedList<T>: Vec<T> = {
 }
 
 ContainerIdentifier: Identifier = {
-    Identifier => {
-        parser.current_scope.push_scope(&<>.value);
-        <>
+    <identifier: Identifier> => {
+        parser.current_scope.push_scope(&identifier.value);
+        identifier
     },
 }
 


### PR DESCRIPTION
This PR pulls in the latest version of all our dependencies, and updates our MSRV (Minimum Supported Rust Version)s:
- `slicec` now requires Rust 1.87 to build
- `slice-codec` now requires Rust 1.74 to build

The latest version of Rust right now is 1.96

----

I reviewed all the changelog entries for all our dependencies, the only actionable things were from LALRPOP:
- They added `lexer` as a default feature of the `lalrpop-util` crate (to align with the fact that they already do this for the `lalrpop` crate). We use a custom lexer, so we need to opt-out of the default features and manually specify what we were using before. (See https://github.com/lalrpop/lalrpop/pull/1094)
- They changed how multiple `<>` tokens work in the grammar (this is a way to reference an input token without needing to give it a name). Before, `<>` always just referred to the input tokens, but now they support using `<>` multiple times, once per each token. (See https://github.com/lalrpop/lalrpop/pull/1067)