### PR TITLE
Pre 0.4 Cleanup Pass

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -6,7 +6,7 @@
 # format_code_in_doc_comments (https://github.com/rust-lang/rustfmt/issues/3348)
 # format_macro_matchers (https://github.com/rust-lang/rustfmt/issues/3354)
 # normalize_doc_attributes (https://github.com/rust-lang/rustfmt/issues/3351)
-# overflow_delimited_expression (https://github.com/rust-lang/rustfmt/issues/3370)
+# overflow_delimited_expr (https://github.com/rust-lang/rustfmt/issues/3370)
 # wrap_comments (https://github.com/rust-lang/rustfmt/issues/3347)
 unstable_features = true
 
@@ -23,7 +23,6 @@ merge_derives = true
 imports_granularity = "Module"
 
 wrap_comments = true
-normalize_comments = true
 normalize_doc_attributes = true
 
 overflow_delimited_expr = true

--- a/slicec/src/main.rs
+++ b/slicec/src/main.rs
@@ -180,7 +180,7 @@ fn check_if_file_is_overwritten<'a>(
     if let Some(other_plugin) = written_to_paths.insert(canonical_path, generator) {
         let message = format!(
             "the path '{}' was already written to by '{}', and would be overwritten by '{}'",
-            &generated_file.path, &other_plugin.path, &generator.path,
+            generated_file.path, other_plugin.path, generator.path,
         );
         Err(slicec::diagnostics::Error::Other { message })
     } else {

--- a/slicec/src/parsers/slice/grammar.rs
+++ b/slicec/src/parsers/slice/grammar.rs
@@ -209,7 +209,7 @@ fn construct_parameter(
         })
         .set_span(&span)
         .add_note("try using an '@param' tag on the operation it belongs to instead", None)
-        .add_note(format!("Ex: @param {}: {}", &identifier.value, raw_comment[0].0), None)
+        .add_note(format!("Ex: @param {}: {}", identifier.value, raw_comment[0].0), None)
         .push_into(parser.diagnostics);
     }
 

--- a/slicec/src/parsers/slice/lexer.rs
+++ b/slicec/src/parsers/slice/lexer.rs
@@ -409,6 +409,7 @@ where
             }
 
             #[allow(clippy::question_mark)] // For clarity and better comment placement: don't condense this with a '?'
+            // We've reached the end of the current source block.
             if let Some(next_source_block) = self.source_blocks.next() {
                 // Drop the current source block and replace it with the next source block.
                 self.current_block = next_source_block;

--- a/slicec/src/parsers/slice/lexer.rs
+++ b/slicec/src/parsers/slice/lexer.rs
@@ -408,7 +408,7 @@ where
                 }
             }
 
-            // We've reached the end of the current source block.
+            #[allow(clippy::question_mark)] // For clarity and better comment placement: don't condense this with a '?'
             if let Some(next_source_block) = self.source_blocks.next() {
                 // Drop the current source block and replace it with the next source block.
                 self.current_block = next_source_block;

--- a/slicec/src/validators/members.rs
+++ b/slicec/src/validators/members.rs
@@ -25,7 +25,7 @@ fn tags_are_unique(members: Vec<&impl Member>, diagnostics: &mut Diagnostics) {
                 format!(
                     "The tag '{}' is already being used by member '{}'",
                     window[0].tag().unwrap(),
-                    &window[0].identifier(),
+                    window[0].identifier(),
                 ),
                 Some(window[0].span()),
             )

--- a/slicec/src/validators/operations.rs
+++ b/slicec/src/validators/operations.rs
@@ -71,7 +71,7 @@ fn validate_returns_tags_for_operation_with_single_return(
             Diagnostic::from_lint(Lint::IncorrectDocComment {
                 message: format!(
                     "comment has a 'returns' tag for '{}', but operation '{}' doesn't return anything with that name",
-                    &tag_identifier.value,
+                    tag_identifier.value,
                     operation.identifier(),
                 ),
             })


### PR DESCRIPTION
I ran the latest nightly clippy against the repository and fixed the issues it found.
It was mostly just extra '&' which were unneeded.