### PR TITLE
Fix Panics from Using Anonymous Types as a Base or Underlying Type

### DIFF
--- a/slicec/src/grammar/elements/type_ref.rs
+++ b/slicec/src/grammar/elements/type_ref.rs
@@ -51,7 +51,10 @@ impl<T: Element + ?Sized> TypeRef<T> {
 impl<T: Type + ?Sized> TypeRef<T> {
     // This intentionally shadows the trait method of the same name on `Type`.
     pub fn type_string(&self) -> String {
-        let mut s = self.definition().type_string();
+        let mut s = match &self.definition {
+            TypeRefDefinition::Patched(ptr) => ptr.borrow().type_string(),
+            TypeRefDefinition::Unpatched(ident) => ident.value.clone(),
+        };
         if self.is_optional {
             s += "?";
         }

--- a/slicec/src/parsers/slice/grammar.rs
+++ b/slicec/src/parsers/slice/grammar.rs
@@ -144,7 +144,8 @@ fn construct_interface(
             if interface_ref.is_err() {
                 Diagnostic::from_error(Error::TypeMismatch {
                     expected: "interface".to_owned(),
-                    actual: base.type_string(),
+                    // 'kind' is safe to call here. `downcast` can only fail if the type is already patched.
+                    actual: base.definition().kind().to_owned(),
                     is_concrete: true,
                 })
                 .set_span(&base.span)
@@ -286,7 +287,8 @@ fn construct_enum(
         if primitive_ref.is_err() {
             Diagnostic::from_error(Error::EnumUnderlyingTypeNotSupported {
                 enum_identifier: identifier.value.clone(),
-                kind: Some(type_ref.type_string()),
+                // 'kind' is safe to call here. `downcast` can only fail if the type is already patched.
+                kind: Some(type_ref.definition().kind().to_owned()),
             })
             .set_span(&type_ref.span)
             .push_into(parser.diagnostics);

--- a/slicec/src/parsers/slice/grammar.rs
+++ b/slicec/src/parsers/slice/grammar.rs
@@ -139,8 +139,21 @@ fn construct_interface(
     let bases = bases
         .unwrap_or_default() // Create an empty vector if no bases were specified.
         .into_iter()
-        .map(|base| base.downcast::<Interface>().unwrap())
+        .filter_map(|base| {
+            let interface_ref = base.downcast::<Interface>();
+            if interface_ref.is_err() {
+                Diagnostic::from_error(Error::TypeMismatch {
+                    expected: "interface".to_owned(),
+                    actual: base.type_string(),
+                    is_concrete: true,
+                })
+                .set_span(&base.span)
+                .push_into(parser.diagnostics);
+            }
+            interface_ref.ok()
+        })
         .collect::<Vec<_>>();
+
     let comment = parse_doc_comment(parser, &identifier.value, raw_comment);
 
     let mut interface_ptr = OwnedPtr::new(Interface {
@@ -268,7 +281,19 @@ fn construct_enum(
     enumerators: Vec<OwnedPtr<Enumerator>>,
     span: Span,
 ) -> OwnedPtr<Enum> {
-    let underlying = underlying_type.map(|type_ref| type_ref.downcast::<Primitive>().unwrap());
+    let underlying = underlying_type.and_then(|type_ref| {
+        let primitive_ref = type_ref.downcast::<Primitive>();
+        if primitive_ref.is_err() {
+            Diagnostic::from_error(Error::EnumUnderlyingTypeNotSupported {
+                enum_identifier: identifier.value.clone(),
+                kind: Some(type_ref.type_string()),
+            })
+            .set_span(&type_ref.span)
+            .push_into(parser.diagnostics);
+        }
+        primitive_ref.ok()
+    });
+
     let comment = parse_doc_comment(parser, &identifier.value, raw_comment);
 
     let mut enum_ptr = OwnedPtr::new(Enum {

--- a/slicec/src/validators/enums.rs
+++ b/slicec/src/validators/enums.rs
@@ -61,7 +61,7 @@ fn allowed_underlying_types(enum_def: &Enum, diagnostics: &mut Diagnostics) {
                 enum_identifier: enum_def.identifier().to_owned(),
                 kind: Some(underlying_type.definition().kind().to_owned()),
             })
-            .set_span(enum_def.span())
+            .set_span(underlying_type.span())
             .push_into(diagnostics);
         }
     }

--- a/slicec/tests/enums/mod.rs
+++ b/slicec/tests/enums/mod.rs
@@ -33,13 +33,13 @@ fn supported_numeric_underlying_types_succeed(valid_type: &str) {
     assert_parses(slice);
 }
 
-#[test_case("string"; "string")]
-#[test_case("float32"; "float32")]
-#[test_case("float64"; "float64")]
-#[test_case("Sequence<bool>"; "sequence")]
-#[test_case("Dictionary<string, Sequence<int8>>?"; "dictionary")]
-#[test_case("Result<uint8, varuint32>?"; "result")]
-fn invalid_underlying_type(underlying_type: &str) {
+#[test_case("string", "string"; "string")]
+#[test_case("float32", "float32"; "float32")]
+#[test_case("float64", "float64"; "float64")]
+#[test_case("Sequence<bool>", "sequence"; "sequence")]
+#[test_case("Dictionary<string, Sequence<int8>>?", "dictionary"; "dictionary")]
+#[test_case("Result<uint8, varuint32>?", "result"; "result")]
+fn invalid_underlying_type(underlying_type: &str, expected_kind: &str) {
     // Arrange
     let slice = format!(
         "
@@ -56,7 +56,7 @@ fn invalid_underlying_type(underlying_type: &str) {
     // Assert
     let expected = Diagnostic::from_error(Error::EnumUnderlyingTypeNotSupported {
         enum_identifier: "E".to_owned(),
-        kind: Some(underlying_type.to_owned()),
+        kind: Some(expected_kind.to_owned()),
     });
     check_diagnostics(diagnostics, [expected]);
 }

--- a/slicec/tests/enums/mod.rs
+++ b/slicec/tests/enums/mod.rs
@@ -36,6 +36,9 @@ fn supported_numeric_underlying_types_succeed(valid_type: &str) {
 #[test_case("string"; "string")]
 #[test_case("float32"; "float32")]
 #[test_case("float64"; "float64")]
+#[test_case("Sequence<bool>"; "sequence")]
+#[test_case("Dictionary<string, Sequence<int8>>?"; "dictionary")]
+#[test_case("Result<uint8, varuint32>?"; "result")]
 fn invalid_underlying_type(underlying_type: &str) {
     // Arrange
     let slice = format!(
@@ -58,16 +61,48 @@ fn invalid_underlying_type(underlying_type: &str) {
     check_diagnostics(diagnostics, [expected]);
 }
 
-#[test]
-fn optional_underlying_types_fail() {
+#[test_case("string"; "string")]
+#[test_case("float32"; "float32")]
+fn invalid_optional_underlying_types_fail(underlying_type: &str) {
     // Arrange
-    let slice = "
+    let slice = format!(
+        "
+            module Test
+            enum E : {underlying_type}? {{
+                A
+            }}
+        "
+    );
+
+    // Act
+    let diagnostics = parse_for_diagnostics(slice);
+
+    // Assert
+    let expected = [
+        Diagnostic::from_error(Error::EnumUnderlyingTypeNotSupported {
+            enum_identifier: "E".to_owned(),
+            kind: Some(underlying_type.to_owned()),
+        }),
+        Diagnostic::from_error(Error::CannotUseOptionalUnderlyingType {
+            enum_identifier: "E".to_owned(),
+        }),
+    ];
+    check_diagnostics(diagnostics, expected);
+}
+
+#[test_case("int32"; "int32")]
+#[test_case("varuint32"; "varuint32")]
+fn optional_underlying_types_fail(underlying_type: &str) {
+    // Arrange
+    let slice = format!(
+        "
         module Test
 
-        enum E : int32? {
+        enum E : {underlying_type}? {{
             A = 1
-        }
-    ";
+        }}
+        "
+    );
 
     // Act
     let diagnostics = parse_for_diagnostics(slice);

--- a/slicec/tests/interfaces/inheritance.rs
+++ b/slicec/tests/interfaces/inheritance.rs
@@ -3,6 +3,7 @@
 use crate::test_helpers::*;
 use slicec::diagnostics::{Diagnostic, Error};
 use slicec::grammar::*;
+use test_case::test_case;
 
 #[test]
 fn supports_single_inheritance() {
@@ -66,16 +67,21 @@ fn supports_multiple_inheritance() {
     );
 }
 
-#[test]
-fn must_inherit_from_interface() {
+#[test_case("uint8", "uint8"; "primitive")]
+#[test_case("S", "struct"; "r#struct")]
+#[test_case("Sequence<bool>", "Sequence<bool>"; "sequence")]
+#[test_case("Result<int32, int32>", "Result<int32, int32>"; "result")]
+fn must_inherit_from_interface(base_type: &str, kind: &str) {
     // Arrange
-    let slice = "
+    let slice = format!(
+        "
         module Test
 
-        struct S {}
+        struct S {{}}
 
-        interface I : S {}
-    ";
+        interface I : {base_type} {{}}
+        "
+    );
 
     // Act
     let diagnostics = parse_for_diagnostics(slice);
@@ -83,7 +89,7 @@ fn must_inherit_from_interface() {
     // Assert
     let expected = Diagnostic::from_error(Error::TypeMismatch {
         expected: "interface".to_owned(),
-        actual: "struct".to_owned(),
+        actual: kind.to_owned(),
         is_concrete: true,
     });
     check_diagnostics(diagnostics, [expected]);

--- a/slicec/tests/interfaces/inheritance.rs
+++ b/slicec/tests/interfaces/inheritance.rs
@@ -69,9 +69,10 @@ fn supports_multiple_inheritance() {
 
 #[test_case("uint8", "uint8"; "primitive")]
 #[test_case("S", "struct"; "r#struct")]
-#[test_case("Sequence<bool>", "Sequence<bool>"; "sequence")]
-#[test_case("Result<int32, int32>", "Result<int32, int32>"; "result")]
-fn must_inherit_from_interface(base_type: &str, kind: &str) {
+#[test_case("Sequence<bool>", "sequence"; "sequence")]
+#[test_case("Dictionary<int8, string>?", "dictionary"; "dictionary")]
+#[test_case("Result<int32, int32>", "result"; "result")]
+fn must_inherit_from_interface(base_type: &str, expected_kind: &str) {
     // Arrange
     let slice = format!(
         "
@@ -89,7 +90,7 @@ fn must_inherit_from_interface(base_type: &str, kind: &str) {
     // Assert
     let expected = Diagnostic::from_error(Error::TypeMismatch {
         expected: "interface".to_owned(),
-        actual: kind.to_owned(),
+        actual: expected_kind.to_owned(),
         is_concrete: true,
     });
     check_diagnostics(diagnostics, [expected]);


### PR DESCRIPTION
In a Slice file, if you try to use an anonymous type (a sequence, dictionary or result type) as:
- the underlying type of an enum (`enum Foo : Sequence<int8>`), or
- the base of an interface (`interface Foo : Sequence<int8>`)

It would cause the compiler to crash, instead of correctly reporting an error.
The same would also happen when using a primitive type as the base of an interface (`interface Foo : uint8`).

These were all due to a bad assumption we made about these types being unpatched during the parsing phase.
But anonymous types and primitives _are_ patched at construction (even during parsing) since they're fully knowable.

This PR fixes both parts of #798.

----

## What's Changed entry

None — this construct was already disallowed; only the rejection changed from a panic to a proper error. And this construct has probably never been written in the wild, so this affects no users.