### PR TITLE
Fix a Panic when Reporting Errors Spanning More than 65535 Characters Long

### DIFF
--- a/slicec/src/slice_file.rs
+++ b/slicec/src/slice_file.rs
@@ -187,10 +187,9 @@ fn get_highlight(line: &str, highlight_start: usize, highlight_end: usize) -> St
             .filter(|c| *c == '\t')
             .count();
 
-        // Since tab is only 1 character, we have to account for the extra 3 characters that are displayed
-        // for each tab.
+        // Since tab is only 1 character we have to account for the extra 3 characters that are displayed for each tab.
         let highlight_length = (highlight_end - highlight_start) + (highlight_tab_count * (EXPANDED_TAB.len() - 1));
-        style(format!("{:-<1$}", "", highlight_length)).yellow().bold()
+        style("-".repeat(highlight_length)).yellow().bold()
     };
 
     " ".repeat(whitespace_count) + &highlight.to_string()


### PR DESCRIPTION
This PR fixes #799.

`slicec` generates underlining in error message snippets, pointing to the exact place in a Slice file where the error occurred.
We were generating this underlining with the built-in `format!` macro, which has an internal limit of 65535 characters.
Now we use the `str::repeat` function to make the underlining, which has no such limit.

Is this a real concern? No.
But, `str::repeat` is also just cleaner than what we were doing.

----

## What's Changed entry

None — an error span of this length doesn't occur in practice.