### PR TITLE
Remove `get_module` and `get_raw_scope` Functions and Cleanup

### DIFF
--- a/slicec/src/grammar/traits.rs
+++ b/slicec/src/grammar/traits.rs
@@ -3,7 +3,6 @@
 use super::attributes::AttributeKind;
 use super::comments::DocComment;
 use super::elements::{Attribute, Identifier, Integer, TypeRef};
-use super::util::Scope;
 use super::wrappers::{AsEntities, AsTypes};
 use crate::slice_file::Span;
 
@@ -18,7 +17,6 @@ pub trait Symbol: Element {
 pub trait ScopedSymbol: Symbol {
     fn parser_scope(&self) -> &str;
     fn module_scope(&self) -> &str;
-    fn get_raw_scope(&self) -> &Scope;
 }
 
 pub trait NamedSymbol: Symbol + Attributable {
@@ -121,10 +119,6 @@ macro_rules! implement_Scoped_Symbol_for {
 
             fn module_scope(&self) -> &str {
                 &self.scope.module_scope
-            }
-
-            fn get_raw_scope(&self) -> &Scope {
-                &self.scope
             }
         }
     };

--- a/slicec/src/grammar/traits.rs
+++ b/slicec/src/grammar/traits.rs
@@ -2,7 +2,7 @@
 
 use super::attributes::AttributeKind;
 use super::comments::DocComment;
-use super::elements::{Attribute, Identifier, Integer, Module, TypeRef};
+use super::elements::{Attribute, Identifier, Integer, TypeRef};
 use super::util::Scope;
 use super::wrappers::{AsEntities, AsTypes};
 use crate::slice_file::Span;
@@ -18,7 +18,6 @@ pub trait Symbol: Element {
 pub trait ScopedSymbol: Symbol {
     fn parser_scope(&self) -> &str;
     fn module_scope(&self) -> &str;
-    fn get_module(&self) -> &Module;
     fn get_raw_scope(&self) -> &Scope;
 }
 
@@ -121,14 +120,7 @@ macro_rules! implement_Scoped_Symbol_for {
             }
 
             fn module_scope(&self) -> &str {
-                match &self.scope.module {
-                    Some(module_ptr) => module_ptr.borrow().nested_module_identifier(),
-                    None => "",
-                }
-            }
-
-            fn get_module(&self) -> &Module {
-                self.scope.module.as_ref().unwrap().borrow()
+                &self.scope.module_scope
             }
 
             fn get_raw_scope(&self) -> &Scope {

--- a/slicec/src/grammar/util.rs
+++ b/slicec/src/grammar/util.rs
@@ -1,12 +1,9 @@
 // Copyright (c) ZeroC, Inc.
 
-use super::Module;
-use crate::utils::ptr_util::WeakPtr;
-
 #[derive(Clone, Debug, Default)]
 pub struct Scope {
     pub parser_scope: String,
-    pub module: Option<WeakPtr<Module>>,
+    pub module_scope: String,
 }
 
 impl Scope {
@@ -21,16 +18,12 @@ impl Scope {
         if let Some(last_scope_index) = self.parser_scope.rfind("::") {
             // Remove any characters after the last '::' in the string.
             // We ensure that we're only removing additional parser scopes, and not any scopes that came from a module.
-            #[cfg(debug_assertions)]
-            {
-                let module_scope = self.module.as_ref().map(|m| m.borrow().nested_module_identifier());
-                debug_assert!(self.parser_scope.len() > module_scope.map_or(0, str::len))
-            }
+            debug_assert!(self.parser_scope.len() > self.module_scope.len());
             self.parser_scope.truncate(last_scope_index);
         } else {
             // If the string doesn't contain '::', there's only a single scope. We pop it off by clearing the string.
-            // This is only possible if we're not in a module, otherwise we'd always have at least 1 module scope.
-            debug_assert!(self.module.is_none());
+            // This means the user forgot to write a module, which is an error. But we have to handle this gracefully.
+            debug_assert!(self.module_scope.is_empty());
             self.parser_scope.clear();
         }
     }

--- a/slicec/src/parsers/slice/grammar.rs
+++ b/slicec/src/parsers/slice/grammar.rs
@@ -71,15 +71,14 @@ fn construct_module(
         .push_into(parser.diagnostics);
     }
 
-    let module_ptr = OwnedPtr::new(Module {
+    parser.current_scope.module_scope = identifier.value.clone();
+    parser.current_scope.parser_scope = identifier.value.clone();
+
+    OwnedPtr::new(Module {
         identifier,
         attributes,
         span,
-    });
-
-    parser.current_scope.module = Some(module_ptr.downgrade());
-    parser.current_scope.parser_scope = module_ptr.borrow().nested_module_identifier().to_owned();
-    module_ptr
+    })
 }
 
 fn construct_struct(


### PR DESCRIPTION
This PR removes the `get_module` and `get_raw_scope` functions from `struct Scope`, because they're uncalled.
It was part of the public API, but even for the other places that use `slicec`, it was dead there too.

Removing these functions let's us simplify the `Scope` struct. Instead of holding a `WeakPtr<Module>`, now it just holds a `String`. This is simpler, and necessary for my intended fixes to #808.

## What's Changed

- Nothing changed except removing dead code.