### PR TITLE
Simplify `Ast::find_element` Functions

### DIFF
--- a/slicec/README.md
+++ b/slicec/README.md
@@ -93,7 +93,7 @@ let compilation_state = compile_from_strings(&[source], None);
 // Make sure no diagnostics were reported.
 assert!(!compilation_state.diagnostics.has_errors());
 // Inspect the contents of the resulting AST.
-let color_enum = compilation_state.ast.find_element::<Enum>("Example::Color").unwrap();
+let color_enum = compilation_state.ast.find_symbol_by_id::<Enum>("Example::Color").unwrap();
 ```
 
 ## Building

--- a/slicec/src/ast/mod.rs
+++ b/slicec/src/ast/mod.rs
@@ -14,7 +14,7 @@ use std::collections::HashMap;
 ///
 /// The AST is primarily for centralizing ownership of Slice elements, but also features lookup functions for finding
 /// nodes (see [`find_node`](Ast::find_node) and [`find_node_with_scope`](Ast::find_node_with_scope)) and their
-/// elements (see [`find_element`](Ast::find_element)).
+/// elements (see [`find_symbol_by_id`](Ast::find_symbol_by_id)).
 ///
 /// In practice, there is a single instance of the AST per compilation, which is [created](Ast::create) during
 /// initialization and lives as long as the program does, making the AST effectively `'static`.
@@ -101,7 +101,8 @@ impl Ast {
     ///
     /// This is a low level method used for retrieving nodes from the AST directly.
     /// Only use this if you need access to the node, or the pointer, holding a slice element.
-    /// If you just need the Slice element itself, use [`find_element`](Ast::find_element) instead.
+    ///
+    /// If you want a reference to the Slice construct itself, use [find_symbol_by_id](Ast::find_symbol_by_id) instead.
     ///
     /// # Returns
     ///
@@ -152,7 +153,8 @@ impl Ast {
     ///
     /// This is a low level method used for retrieving nodes from the AST directly.
     /// Only use this if you need access to the node, or the pointer, holding a slice element.
-    /// If you just need the Slice element itself, use [find_element](Ast::find_element) instead.
+    ///
+    /// If you want a reference to the Slice construct itself, use [find_symbol_by_id](Ast::find_symbol_by_id) instead.
     ///
     /// # Returns
     ///
@@ -196,41 +198,17 @@ impl Ast {
         self.find_node(identifier)
     }
 
-    /// Returns a reference to a Slice element with the provided identifier and specified type, if one exists.
-    /// The identifier must be fully qualified, since this performs no scope resolution, but cannot begin with '::'.
+    /// Returns a reference to a Slice symbol (user-defined element) with the provided identifier and specified type,
+    /// if one exists. The identifier must be fully qualified, but should not begin with a leading '::'.
     ///
-    /// Anonymous types (those without identifiers) cannot be looked up. These are results, sequences, and dictionaries.
-    /// Primitive types can be looked up by their Slice keywords. Care should be taken when looking up modules (which
-    /// can be re-opened) or parameters and return members (which share an AST scope), since these may not be unique.
+    /// Care should be taken when looking up modules (which can be re-opened) or parameters and return members
+    /// (which share an AST scope), since these may not be unique.
     ///
     /// # Returns
     ///
-    /// If a Slice element of the specified type can be found with the provided identifier, this returns a reference to
-    /// it, wrapped in `Ok`. Otherwise, this returns `Err` with a string describing why the lookup failed.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use slicec::ast::Ast;
-    /// # use slicec::grammar::*;
-    /// let ast = Ast::create();
-    ///
-    /// // Look up a primitive type.
-    /// let int32_def = ast.find_element::<Primitive>("int32");
-    /// assert!(int32_def.is_ok());
-    /// assert_eq!(int32_def.unwrap().kind(), "int32");
-    ///
-    /// // TODO add more examples once parsing is easier.
-    ///
-    /// // If an element doesn't exist with the specified identifier, `Err` is returned.
-    /// let fake_element = ast.find_element::<dyn Entity>("foo::bar");
-    /// assert!(fake_element.is_err());
-    ///
-    /// // If an element exists but has the wrong type, `Err` is also returned.
-    /// let wrong_type = ast.find_element::<Struct>("bool");
-    /// assert!(wrong_type.is_err());
-    /// ```
-    pub fn find_element<'a, T: Element + ?Sized>(&'a self, identifier: &str) -> Result<&'a T, LookupError>
+    /// If a symbol with the specified identifier and type can be found in this `Ast`, this returns a reference to it,
+    /// wrapped in `Ok`. Otherwise, this returns `Err` with a string describing why the lookup failed.
+    pub fn find_symbol_by_id<'a, T: NamedSymbol + ?Sized>(&'a self, identifier: &str) -> Result<&'a T, LookupError>
     where
         &'a T: TryFrom<&'a Node, Error = LookupError>,
     {

--- a/slicec/src/ast/mod.rs
+++ b/slicec/src/ast/mod.rs
@@ -14,7 +14,7 @@ use std::collections::HashMap;
 ///
 /// The AST is primarily for centralizing ownership of Slice elements, but also features lookup functions for finding
 /// nodes (see [`find_node`](Ast::find_node) and [`find_node_with_scope`](Ast::find_node_with_scope)) and their
-/// elements (see [`find_element`](Ast::find_element) and [`find_element_with_scope`](Ast::find_element_with_scope)).
+/// elements (see [`find_element`](Ast::find_element)).
 ///
 /// In practice, there is a single instance of the AST per compilation, which is [created](Ast::create) during
 /// initialization and lives as long as the program does, making the AST effectively `'static`.
@@ -152,7 +152,7 @@ impl Ast {
     ///
     /// This is a low level method used for retrieving nodes from the AST directly.
     /// Only use this if you need access to the node, or the pointer, holding a slice element.
-    /// If you just need the Slice element itself, use [find_element_with_scope](Ast::find_element_with_scope) instead.
+    /// If you just need the Slice element itself, use [find_element](Ast::find_element) instead.
     ///
     /// # Returns
     ///
@@ -235,51 +235,6 @@ impl Ast {
         &'a T: TryFrom<&'a Node, Error = LookupError>,
     {
         self.find_node(identifier).and_then(|x| x.try_into())
-    }
-
-    /// Returns a reference to a Slice element with the provided identifier and specified type, if one exists.
-    ///
-    /// If the identifier begins with '::' it is treated as globally scoped, and this function just forwards to
-    /// [`find_element`](Ast::find_element). Otherwise the identifier is treated as being relatively scoped.
-    ///
-    /// For relative identifiers, this method first checks if the identifier is defined in the provided scope. If so, a
-    /// reference is returned to it. Otherwise each enclosing scope is checked, starting from the provided scope, and
-    /// working outwards through each of its parent scopes until reaching global scope.
-    ///
-    /// This returns the first matching Slice element it can find. If another element in a more outward scope also has
-    /// the specified identifier, it is shadowed, and will not be returned.
-    ///
-    /// Anonymous types (those without identifiers) cannot be looked up. These are results, sequences, and dictionaries.
-    /// Primitive types can be looked up by their Slice keywords. Care should be taken when looking up modules (which
-    /// can be re-opened) or parameters and return members (which share an AST scope), since these may not be unique.
-    ///
-    /// # Returns
-    ///
-    /// If a Slice element of the specified type can be found with the provided identifier, this returns a reference to
-    /// it, wrapped in `Ok`. Otherwise, this returns `Err` with a string describing why the lookup failed.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// # use slicec::ast::Ast;
-    /// # use slicec::grammar::*;
-    /// let ast = Ast::create();
-    ///
-    /// // TODO add more examples once parsing is easier.
-    ///
-    /// // If an element doesn't exist with the specified identifier, `Err` is returned.
-    /// let fake_element = ast.find_element_with_scope::<dyn Entity>("hello", "foo::bar");
-    /// assert!(fake_element.is_err());
-    /// ```
-    pub fn find_element_with_scope<'a, T: Element + ?Sized>(
-        &'a self,
-        identifier: &str,
-        scope: &str,
-    ) -> Result<&'a T, LookupError>
-    where
-        &'a T: TryFrom<&'a Node, Error = LookupError>,
-    {
-        self.find_node_with_scope(identifier, scope).and_then(|x| x.try_into())
     }
 
     /// Returns an immutable slice of all the [nodes](Node) contained in this AST.

--- a/slicec/src/diagnostics/annotated_diagnostic.rs
+++ b/slicec/src/diagnostics/annotated_diagnostic.rs
@@ -115,7 +115,7 @@ fn get_diagnostic_level_for(
 
     // If the diagnostic has a scope, check if it's affected by an `allow` attribute in that scope.
     if let Some(scope) = &diagnostic.scope {
-        if let Ok(entity) = ast.find_element::<dyn Entity>(scope) {
+        if let Ok(entity) = ast.find_symbol_by_id::<dyn Entity>(scope) {
             if is_lint_allowed_by_attributes(entity, lint) {
                 return DiagnosticLevel::Allowed;
             }

--- a/slicec/src/slice_file_converter.rs
+++ b/slicec/src/slice_file_converter.rs
@@ -157,7 +157,7 @@ fn convert_source(source: Option<&str>, ast: &Ast, files: &[GrammarSliceFile], o
         default_span = Some(Span::new((1, 1).into(), (1, 1).into(), &slice_file.relative_path));
     } else {
         // Lookup the named symbol in the AST and if it doesn't exist, emit a diagnostic and return immediately.
-        let named_symbol = match ast.find_element::<dyn NamedSymbol>(symbol_id) {
+        let named_symbol = match ast.find_symbol_by_id::<dyn NamedSymbol>(symbol_id) {
             Ok(named_symbol) => named_symbol,
             Err(err) => {
                 SlicecDiagnostic::from_error(err.into())

--- a/slicec/tests/attribute_tests.rs
+++ b/slicec/tests/attribute_tests.rs
@@ -163,7 +163,7 @@ mod attributes {
             let ast = parse_for_ast(slice);
 
             // Assert
-            let operation = ast.find_element::<Operation>("Test::I::op").unwrap();
+            let operation = ast.find_symbol_by_id::<Operation>("Test::I::op").unwrap();
             let attribute = operation.find_attribute::<SlicedFormat>().unwrap();
 
             assert!(attribute.sliced_args);
@@ -262,7 +262,7 @@ mod attributes {
             let ast = parse_for_ast(slice);
 
             // Assert
-            let operation = ast.find_element::<Operation>("Test::I::op").unwrap();
+            let operation = ast.find_symbol_by_id::<Operation>("Test::I::op").unwrap();
             assert!(operation.has_attribute::<Deprecated>());
         }
 
@@ -306,7 +306,7 @@ mod attributes {
             let ast = parse_for_ast(slice);
 
             // Assert
-            let operation = ast.find_element::<Operation>("Test::I::op").unwrap();
+            let operation = ast.find_symbol_by_id::<Operation>("Test::I::op").unwrap();
 
             let deprecated_attribute = operation.find_attribute::<Deprecated>().unwrap();
             assert_eq!(deprecated_attribute.reason.as_deref(), Some("Deprecation message here"));
@@ -424,7 +424,7 @@ mod attributes {
             let ast = parse_for_ast(slice);
 
             // Assert
-            let operation = ast.find_element::<Operation>("Test::I::op").unwrap();
+            let operation = ast.find_symbol_by_id::<Operation>("Test::I::op").unwrap();
             let attribute = operation.find_attribute::<Compress>().unwrap();
 
             assert!(attribute.compress_args);
@@ -615,7 +615,7 @@ mod attributes {
             let ast = parse_for_ast(slice);
 
             // Assert
-            let operation = ast.find_element::<Operation>("Test::I::op").unwrap();
+            let operation = ast.find_symbol_by_id::<Operation>("Test::I::op").unwrap();
 
             let unparsed_attribute = operation.find_attribute::<Unparsed>().unwrap();
             assert_eq!(unparsed_attribute.directive, "foo::bar");
@@ -638,7 +638,7 @@ mod attributes {
             let ast = parse_for_ast(slice);
 
             // Assert
-            let operation = ast.find_element::<Operation>("Test::I::op").unwrap();
+            let operation = ast.find_symbol_by_id::<Operation>("Test::I::op").unwrap();
 
             let unparsed_attribute = operation.find_attribute::<Unparsed>().unwrap();
             assert_eq!(unparsed_attribute.directive, "foo::bar");
@@ -668,7 +668,7 @@ mod attributes {
             let ast = parse_for_ast(slice);
 
             // Assert
-            let operation = ast.find_element::<Operation>("Test::I::op").unwrap();
+            let operation = ast.find_symbol_by_id::<Operation>("Test::I::op").unwrap();
 
             let unparsed_attribute = operation.find_attribute::<Unparsed>().unwrap();
             let arguments = unparsed_attribute.args.iter().map(String::as_str).collect::<Vec<_>>();
@@ -714,7 +714,7 @@ mod attributes {
             let ast = parse_for_ast(slice);
 
             // Assert
-            let parameter = ast.find_element::<Parameter>("A::I::op::s").unwrap();
+            let parameter = ast.find_symbol_by_id::<Parameter>("A::I::op::s").unwrap();
             let parent_attributes = parameter
                 .all_attributes()
                 .into_iter()
@@ -788,7 +788,7 @@ mod attributes {
             let ast = parse_for_ast(slice);
 
             // Assert
-            let module = ast.find_element::<Module>("Test").unwrap();
+            let module = ast.find_symbol_by_id::<Module>("Test").unwrap();
             assert_eq!(module.attributes.len(), 1);
 
             let attribute = module.find_attribute::<Unparsed>().unwrap();

--- a/slicec/tests/comment_tests.rs
+++ b/slicec/tests/comment_tests.rs
@@ -23,7 +23,7 @@ mod comments {
         let ast = parse_for_ast(slice);
 
         // Assert
-        let interface_def = ast.find_element::<Interface>("tests::MyInterface").unwrap();
+        let interface_def = ast.find_symbol_by_id::<Interface>("tests::MyInterface").unwrap();
 
         let interface_doc = interface_def.comment().unwrap();
         assert_eq!(interface_doc.span.start, (4, 13).into());
@@ -56,7 +56,7 @@ mod comments {
         let ast = parse_for_ast(slice);
 
         // Assert
-        let interface_def = ast.find_element::<Interface>("tests::MyInterface").unwrap();
+        let interface_def = ast.find_symbol_by_id::<Interface>("tests::MyInterface").unwrap();
 
         let interface_doc = interface_def.comment().unwrap();
         assert_eq!(interface_doc.span.start, (4, 13).into());
@@ -86,7 +86,7 @@ mod comments {
 
             interface TestInterface {
                 /// @param testParam: My test param
-                testOp(testParam: string)
+                op(testParam: string)
             }
         ";
 
@@ -94,7 +94,7 @@ mod comments {
         let ast = parse_for_ast(slice);
 
         // Assert
-        let operation = ast.find_element::<Operation>("tests::TestInterface::testOp").unwrap();
+        let operation = ast.find_symbol_by_id::<Operation>("tests::TestInterface::op").unwrap();
 
         let param_tags = &operation.comment().unwrap().params;
         assert_eq!(param_tags.len(), 1);
@@ -126,7 +126,7 @@ mod comments {
 
             interface TestInterface {
                 /// @returns bool
-                testOp(testParam: string) -> bool
+                op(testParam: string) -> bool
             }
         ";
 
@@ -134,7 +134,7 @@ mod comments {
         let ast = parse_for_ast(slice);
 
         // Assert
-        let operation = ast.find_element::<Operation>("tests::TestInterface::testOp").unwrap();
+        let operation = ast.find_symbol_by_id::<Operation>("tests::TestInterface::op").unwrap();
 
         let returns_tags = &operation.comment().unwrap().returns;
         assert_eq!(returns_tags.len(), 1);
@@ -217,7 +217,7 @@ mod comments {
             interface TestInterface {
                 /// @param testParam1: A string param
                 /// @returns: bool
-                testOp(testParam1: string) -> bool
+                op(testParam1: string) -> bool
             }
         ";
 
@@ -233,7 +233,7 @@ mod comments {
 
             interface TestInterface {
                 /// @see MySee
-                testOp(testParam: string) -> bool
+                op(testParam: string) -> bool
             }
         ";
 
@@ -241,7 +241,7 @@ mod comments {
         let ast = parse_for_ast(slice);
 
         // Assert
-        let operation = ast.find_element::<Operation>("tests::TestInterface::testOp").unwrap();
+        let operation = ast.find_symbol_by_id::<Operation>("tests::TestInterface::op").unwrap();
 
         let see_tags = &operation.comment().unwrap().see;
         assert_eq!(see_tags.len(), 1);
@@ -274,7 +274,7 @@ mod comments {
         let ast = parse_for_ast(slice);
 
         // Assert
-        let interface_def = ast.find_element::<Interface>("tests::MyInterface").unwrap();
+        let interface_def = ast.find_symbol_by_id::<Interface>("tests::MyInterface").unwrap();
         let interface_doc = interface_def.comment();
 
         assert!(interface_doc.is_none());
@@ -294,7 +294,7 @@ mod comments {
         let ast = parse_for_ast(slice);
 
         // Assert
-        let struct_def = ast.find_element::<Struct>("Test::Foo").unwrap();
+        let struct_def = ast.find_symbol_by_id::<Struct>("Test::Foo").unwrap();
         let struct_doc = struct_def.comment();
 
         assert!(struct_doc.is_none());
@@ -314,7 +314,7 @@ mod comments {
         let ast = parse_for_ast(slice);
 
         // Assert
-        let struct_def = ast.find_element::<Struct>("tests::TestStruct").unwrap();
+        let struct_def = ast.find_symbol_by_id::<Struct>("tests::TestStruct").unwrap();
         let overview = &struct_def.comment().unwrap().overview;
         let message = &overview.as_ref().unwrap().value;
 

--- a/slicec/tests/custom_tests.rs
+++ b/slicec/tests/custom_tests.rs
@@ -19,7 +19,7 @@ mod custom {
         let ast = parse_for_ast(slice);
 
         // Assert
-        let custom_type = ast.find_element::<CustomType>("Test::ACustomType").unwrap();
+        let custom_type = ast.find_symbol_by_id::<CustomType>("Test::ACustomType").unwrap();
         assert_eq!(custom_type.identifier(), "ACustomType");
     }
 }

--- a/slicec/tests/enums/container.rs
+++ b/slicec/tests/enums/container.rs
@@ -46,7 +46,7 @@ mod associated_fields {
         let ast = parse_for_ast(slice);
 
         // Assert
-        let field = ast.find_element::<Field>("Test::E::A::b").unwrap();
+        let field = ast.find_symbol_by_id::<Field>("Test::E::A::b").unwrap();
         assert!(field.is_tagged());
     }
 
@@ -87,19 +87,19 @@ mod associated_fields {
         let ast = parse_for_ast(slice);
 
         // Assert
-        let enumerator_a = ast.find_element::<Enumerator>("Test::E::A").unwrap();
+        let enumerator_a = ast.find_symbol_by_id::<Enumerator>("Test::E::A").unwrap();
         assert!(matches!(enumerator_a.value, EnumeratorValue::Implicit(0)));
         assert_eq!(enumerator_a.value(), 0);
 
-        let enumerator_b = ast.find_element::<Enumerator>("Test::E::B").unwrap();
+        let enumerator_b = ast.find_symbol_by_id::<Enumerator>("Test::E::B").unwrap();
         assert!(matches!(enumerator_b.value, EnumeratorValue::Explicit(_)));
         assert_eq!(enumerator_b.value(), 7);
 
-        let enumerator_c = ast.find_element::<Enumerator>("Test::E::C").unwrap();
+        let enumerator_c = ast.find_symbol_by_id::<Enumerator>("Test::E::C").unwrap();
         assert!(matches!(enumerator_c.value, EnumeratorValue::Implicit(8)));
         assert_eq!(enumerator_c.value(), 8);
 
-        let enumerator_d = ast.find_element::<Enumerator>("Test::E::D").unwrap();
+        let enumerator_d = ast.find_symbol_by_id::<Enumerator>("Test::E::D").unwrap();
         assert!(matches!(enumerator_d.value, EnumeratorValue::Explicit(_)));
         assert_eq!(enumerator_d.value(), 4);
     }
@@ -168,7 +168,7 @@ mod associated_fields {
         let ast = parse_for_ast(slice);
 
         // Assert
-        assert!(ast.find_element::<Field>("Test::Foo::Bar::baz").is_ok());
+        assert!(ast.find_symbol_by_id::<Field>("Test::Foo::Bar::baz").is_ok());
     }
 
     #[test]
@@ -189,19 +189,19 @@ mod associated_fields {
         let ast = parse_for_ast(slice);
 
         // Assert
-        let a = ast.find_element::<Enumerator>("Test::E::A").unwrap();
+        let a = ast.find_symbol_by_id::<Enumerator>("Test::E::A").unwrap();
         assert!(matches!(a.value, EnumeratorValue::Implicit(0)));
         assert!(a.fields.is_none());
 
-        let b = ast.find_element::<Enumerator>("Test::E::B").unwrap();
+        let b = ast.find_symbol_by_id::<Enumerator>("Test::E::B").unwrap();
         assert!(matches!(b.value, EnumeratorValue::Implicit(1)));
         assert!(b.fields.as_ref().unwrap().len() == 1);
 
-        let c = ast.find_element::<Enumerator>("Test::E::C").unwrap();
+        let c = ast.find_symbol_by_id::<Enumerator>("Test::E::C").unwrap();
         assert!(matches!(c.value, EnumeratorValue::Implicit(2)));
         assert!(c.fields.as_ref().unwrap().len() == 2);
 
-        let d = ast.find_element::<Enumerator>("Test::E::D").unwrap();
+        let d = ast.find_symbol_by_id::<Enumerator>("Test::E::D").unwrap();
         assert!(matches!(d.value, EnumeratorValue::Implicit(3)));
         assert!(d.fields.as_ref().unwrap().is_empty());
     }
@@ -224,7 +224,7 @@ mod associated_fields {
         let ast = parse_for_ast(slice);
 
         // Assert
-        let enum_def = ast.find_element::<Enum>("Test::E").unwrap();
+        let enum_def = ast.find_symbol_by_id::<Enum>("Test::E").unwrap();
         assert_eq!(enum_def.is_unchecked, expected);
     }
 
@@ -260,7 +260,7 @@ mod associated_fields {
         let ast = parse_for_ast(slice);
 
         // Assert
-        let enum_def = ast.find_element::<Enum>("Test::E").unwrap();
+        let enum_def = ast.find_symbol_by_id::<Enum>("Test::E").unwrap();
         assert_eq!(enum_def.enumerators.len(), 0);
     }
 
@@ -328,7 +328,7 @@ mod underlying_type {
         let ast = parse_for_ast(slice);
 
         // Assert
-        let enumerators = ast.find_element::<Enum>("Test::E").unwrap().enumerators();
+        let enumerators = ast.find_symbol_by_id::<Enum>("Test::E").unwrap().enumerators();
         assert_eq!(enumerators[0].value(), 0);
         assert_eq!(enumerators[1].value(), 1);
         assert_eq!(enumerators[2].value(), 2);
@@ -350,7 +350,7 @@ mod underlying_type {
         let ast = parse_for_ast(slice);
 
         // Assert
-        let enumerators = ast.find_element::<Enum>("Test::E").unwrap().enumerators();
+        let enumerators = ast.find_symbol_by_id::<Enum>("Test::E").unwrap().enumerators();
         assert_eq!(enumerators[1].value(), 3);
         assert_eq!(enumerators[2].value(), 4);
     }
@@ -488,7 +488,7 @@ mod underlying_type {
         let ast = parse_for_ast(slice);
 
         // Assert
-        let enum_def = ast.find_element::<Enum>("Test::E").unwrap();
+        let enum_def = ast.find_symbol_by_id::<Enum>("Test::E").unwrap();
         assert_eq!(enum_def.is_unchecked, expected);
     }
 
@@ -524,7 +524,7 @@ mod underlying_type {
         let ast = parse_for_ast(slice);
 
         // Assert
-        let enum_def = ast.find_element::<Enum>("Test::E").unwrap();
+        let enum_def = ast.find_symbol_by_id::<Enum>("Test::E").unwrap();
         assert_eq!(enum_def.enumerators.len(), 0);
     }
 
@@ -546,10 +546,14 @@ mod underlying_type {
         let ast = parse_for_ast(slice);
 
         // Assert
-        assert_eq!(ast.find_element::<Enumerator>("Test::E::B").unwrap().value(), 0b1001111);
-        assert_eq!(ast.find_element::<Enumerator>("Test::E::D").unwrap().value(), 128);
-        assert_eq!(ast.find_element::<Enumerator>("Test::E::H").unwrap().value(), 0xA4FD);
-        assert_eq!(ast.find_element::<Enumerator>("Test::E::N").unwrap().value(), -0xbc81);
+        let enumerator_b = ast.find_symbol_by_id::<Enumerator>("Test::E::B").unwrap();
+        assert_eq!(enumerator_b.value(), 0b1001111);
+        let enumerator_d = ast.find_symbol_by_id::<Enumerator>("Test::E::D").unwrap();
+        assert_eq!(enumerator_d.value(), 128);
+        let enumerator_h = ast.find_symbol_by_id::<Enumerator>("Test::E::H").unwrap();
+        assert_eq!(enumerator_h.value(), 0xA4FD);
+        let enumerator_n = ast.find_symbol_by_id::<Enumerator>("Test::E::N").unwrap();
+        assert_eq!(enumerator_n.value(), -0xbc81);
     }
 
     #[test]
@@ -629,7 +633,7 @@ mod underlying_type {
         let ast = parse_for_ast(slice);
 
         // Assert
-        let enum_def = ast.find_element::<Enum>("Test::E").unwrap();
+        let enum_def = ast.find_symbol_by_id::<Enum>("Test::E").unwrap();
         let enumerators = enum_def.enumerators();
 
         assert_eq!(enumerators.len(), 3);
@@ -661,7 +665,7 @@ mod underlying_type {
         let ast = parse_for_ast(slice);
 
         // Assert
-        let enum_def_a = ast.find_element::<Enum>("Test::A").unwrap();
+        let enum_def_a = ast.find_symbol_by_id::<Enum>("Test::A").unwrap();
         let enumerators_a = enum_def_a.enumerators();
 
         assert!(matches!(enumerators_a[0].value, EnumeratorValue::Explicit(..)));

--- a/slicec/tests/identifier_tests.rs
+++ b/slicec/tests/identifier_tests.rs
@@ -20,9 +20,9 @@ fn escaped_keywords() {
     let ast = parse_for_ast(slice);
 
     // Assert
-    assert!(ast.find_element::<Interface>("module::interface").is_ok());
-    assert!(ast.find_element::<Struct>("module::struct").is_ok());
-    assert!(ast.find_element::<CustomType>("module::custom").is_ok());
+    assert!(ast.find_symbol_by_id::<Interface>("module::interface").is_ok());
+    assert!(ast.find_symbol_by_id::<Struct>("module::struct").is_ok());
+    assert!(ast.find_symbol_by_id::<CustomType>("module::custom").is_ok());
 }
 
 #[test]
@@ -39,9 +39,9 @@ fn escaped_identifiers() {
     let ast = parse_for_ast(slice);
 
     // Assert
-    assert!(ast.find_element::<Interface>("MyModule::MyInterface").is_ok());
-    assert!(ast.find_element::<Struct>("MyModule::MyStruct").is_ok());
-    assert!(ast.find_element::<CustomType>("MyModule::MyCustom").is_ok());
+    assert!(ast.find_symbol_by_id::<Interface>("MyModule::MyInterface").is_ok());
+    assert!(ast.find_symbol_by_id::<Struct>("MyModule::MyStruct").is_ok());
+    assert!(ast.find_symbol_by_id::<CustomType>("MyModule::MyCustom").is_ok());
 }
 
 #[test]
@@ -76,7 +76,7 @@ fn escaped_scoped_identifiers_containing_keywords() {
     let ast = parse_for_ast(slice);
 
     // Assert
-    assert!(ast.find_element::<Struct>("Foo::module").is_ok());
+    assert!(ast.find_symbol_by_id::<Struct>("Foo::module").is_ok());
 }
 
 #[test]

--- a/slicec/tests/interfaces/inheritance.rs
+++ b/slicec/tests/interfaces/inheritance.rs
@@ -20,8 +20,8 @@ fn supports_single_inheritance() {
     let ast = parse_for_ast(slice);
 
     // Assert
-    let interface_i_def = ast.find_element::<Interface>("Test::I").unwrap();
-    let interface_j_def = ast.find_element::<Interface>("Test::J").unwrap();
+    let interface_i_def = ast.find_symbol_by_id::<Interface>("Test::I").unwrap();
+    let interface_j_def = ast.find_symbol_by_id::<Interface>("Test::J").unwrap();
     let interface_j_bases = interface_j_def.base_interfaces();
 
     assert!(interface_i_def.base_interfaces().is_empty());
@@ -49,9 +49,9 @@ fn supports_multiple_inheritance() {
     let ast = parse_for_ast(slice);
 
     // Assert
-    let interface_i_def = ast.find_element::<Interface>("Test::I").unwrap();
-    let interface_j_def = ast.find_element::<Interface>("Test::J").unwrap();
-    let interface_k_def = ast.find_element::<Interface>("Test::K").unwrap();
+    let interface_i_def = ast.find_symbol_by_id::<Interface>("Test::I").unwrap();
+    let interface_j_def = ast.find_symbol_by_id::<Interface>("Test::J").unwrap();
+    let interface_k_def = ast.find_symbol_by_id::<Interface>("Test::K").unwrap();
     let interface_k_bases = interface_k_def.base_interfaces();
 
     assert!(interface_i_def.base_interfaces().is_empty());
@@ -148,9 +148,9 @@ fn inherits_correct_operations() {
     let ast = parse_for_ast(slice);
 
     // Assert
-    let interface_a_def = ast.find_element::<Interface>("Test::A").unwrap();
-    let interface_b_def = ast.find_element::<Interface>("Test::B").unwrap();
-    let interface_d_def = ast.find_element::<Interface>("Test::D").unwrap();
+    let interface_a_def = ast.find_symbol_by_id::<Interface>("Test::A").unwrap();
+    let interface_b_def = ast.find_symbol_by_id::<Interface>("Test::B").unwrap();
+    let interface_d_def = ast.find_symbol_by_id::<Interface>("Test::D").unwrap();
 
     assert_eq!(interface_a_def.operations().len(), 1);
     assert_eq!(interface_a_def.all_inherited_operations().len(), 0);

--- a/slicec/tests/interfaces/mod.rs
+++ b/slicec/tests/interfaces/mod.rs
@@ -20,7 +20,7 @@ fn can_have_no_operations() {
     let ast = parse_for_ast(slice);
 
     // Assert
-    let interface_def = ast.find_element::<Interface>("Test::I").unwrap();
+    let interface_def = ast.find_symbol_by_id::<Interface>("Test::I").unwrap();
     assert_eq!(interface_def.identifier(), "I");
     assert_eq!(interface_def.operations().len(), 0);
 }
@@ -40,7 +40,7 @@ fn can_have_one_operation() {
     let ast = parse_for_ast(slice);
 
     // Assert
-    let interface_def = ast.find_element::<Interface>("Test::I").unwrap();
+    let interface_def = ast.find_symbol_by_id::<Interface>("Test::I").unwrap();
     assert_eq!(interface_def.operations().len(), 1);
 }
 
@@ -61,7 +61,7 @@ fn can_have_multiple_operation() {
     let ast = parse_for_ast(slice);
 
     // Assert
-    let interface_def = ast.find_element::<Interface>("Test::I").unwrap();
+    let interface_def = ast.find_symbol_by_id::<Interface>("Test::I").unwrap();
     assert_eq!(interface_def.operations().len(), 3);
 }
 

--- a/slicec/tests/interfaces/operations.rs
+++ b/slicec/tests/interfaces/operations.rs
@@ -20,7 +20,7 @@ fn can_have_no_parameters() {
     let ast = parse_for_ast(slice);
 
     // Assert
-    let operation = ast.find_element::<Operation>("Test::I::op").unwrap();
+    let operation = ast.find_symbol_by_id::<Operation>("Test::I::op").unwrap();
     assert!(operation.parameters().is_empty());
 }
 
@@ -39,7 +39,7 @@ fn can_have_no_return_type() {
     let ast = parse_for_ast(slice);
 
     // Assert
-    let operation = ast.find_element::<Operation>("Test::I::op").unwrap();
+    let operation = ast.find_symbol_by_id::<Operation>("Test::I::op").unwrap();
     assert!(operation.return_members().is_empty());
 }
 
@@ -58,7 +58,7 @@ fn can_contain_tags() {
     let ast = parse_for_ast(slice);
 
     // Assert
-    let operation = ast.find_element::<Operation>("Test::I::op").unwrap();
+    let operation = ast.find_symbol_by_id::<Operation>("Test::I::op").unwrap();
     let tag_def = operation.parameters()[0].tag();
     assert_eq!(tag_def, Some(1));
 }
@@ -78,7 +78,7 @@ fn parameter_and_return_can_have_the_same_tag() {
     let ast = parse_for_ast(slice);
 
     // Assert
-    let operation = ast.find_element::<Operation>("Test::I::op").unwrap();
+    let operation = ast.find_symbol_by_id::<Operation>("Test::I::op").unwrap();
     let parameter_tag = operation.parameters()[0].tag();
     let return_tag = operation.return_members()[0].tag();
     assert_eq!(parameter_tag, Some(1));
@@ -100,7 +100,7 @@ fn can_have_parameters() {
     let ast = parse_for_ast(slice);
 
     // Assert
-    let operation = ast.find_element::<Operation>("Test::I::op").unwrap();
+    let operation = ast.find_symbol_by_id::<Operation>("Test::I::op").unwrap();
     let parameters = operation.parameters();
 
     assert_eq!(parameters.len(), 3);
@@ -136,7 +136,7 @@ fn can_have_return_value() {
     let ast = parse_for_ast(slice);
 
     // Assert
-    let operation = ast.find_element::<Operation>("Test::I::op").unwrap();
+    let operation = ast.find_symbol_by_id::<Operation>("Test::I::op").unwrap();
     let returns = operation.return_members();
 
     assert_eq!(returns.len(), 1);
@@ -159,7 +159,7 @@ fn can_have_return_tuple() {
     let ast = parse_for_ast(slice);
 
     // Assert
-    let operation = ast.find_element::<Operation>("Test::I::op").unwrap();
+    let operation = ast.find_symbol_by_id::<Operation>("Test::I::op").unwrap();
     let returns = operation.return_members();
 
     assert_eq!(returns.len(), 2);
@@ -263,7 +263,7 @@ mod streams {
         let ast = parse_for_ast(slice);
 
         // Assert
-        let operation = ast.find_element::<Operation>("Test::I::op").unwrap();
+        let operation = ast.find_symbol_by_id::<Operation>("Test::I::op").unwrap();
         let parameters = operation.parameters();
         let returns = operation.return_members();
 

--- a/slicec/tests/module_tests.rs
+++ b/slicec/tests/module_tests.rs
@@ -16,7 +16,7 @@ mod module {
         let ast = parse_for_ast(slice);
 
         // Assert
-        assert!(ast.find_element::<Module>("Test").is_ok());
+        assert!(ast.find_symbol_by_id::<Module>("Test").is_ok());
     }
 
     #[test]
@@ -30,7 +30,7 @@ mod module {
         let ast = parse_for_ast(slice);
 
         // Assert
-        assert!(ast.find_element::<Module>("A::B::C::D").is_ok());
+        assert!(ast.find_symbol_by_id::<Module>("A::B::C::D").is_ok());
     }
 
     #[test]
@@ -68,7 +68,7 @@ mod module {
         let ast = parse_multiple_for_ast(&[slice1, slice2]);
 
         // Assert
-        assert!(ast.find_element::<Struct>("Foo::Test1").is_ok());
-        assert!(ast.find_element::<Struct>("Foo::Test2").is_ok());
+        assert!(ast.find_symbol_by_id::<Struct>("Foo::Test1").is_ok());
+        assert!(ast.find_symbol_by_id::<Struct>("Foo::Test2").is_ok());
     }
 }

--- a/slicec/tests/optional_tests.rs
+++ b/slicec/tests/optional_tests.rs
@@ -27,7 +27,7 @@ mod optional {
         let ast = parse_for_ast(slice);
 
         // Assert
-        let field = ast.find_element::<Field>("Test::S::a").unwrap();
+        let field = ast.find_symbol_by_id::<Field>("Test::S::a").unwrap();
         assert!(field.data_type.is_optional);
     }
 
@@ -49,7 +49,7 @@ mod optional {
         let ast = parse_for_ast(slice);
 
         // Assert
-        let field = ast.find_element::<Field>("Test::S::a").unwrap();
+        let field = ast.find_symbol_by_id::<Field>("Test::S::a").unwrap();
         assert_eq!(field.data_type.type_string(), type_name.to_owned() + "?");
     }
 
@@ -84,7 +84,7 @@ mod optional {
         let ast = parse_for_ast(slice);
 
         // Assert
-        let field = ast.find_element::<Field>("Test::S::a").unwrap();
+        let field = ast.find_symbol_by_id::<Field>("Test::S::a").unwrap();
         assert!(field.data_type.is_optional);
     }
 
@@ -107,7 +107,7 @@ mod optional {
         let ast = parse_for_ast(slice);
 
         // Assert
-        let field = ast.find_element::<Field>("Test::S::a").unwrap();
+        let field = ast.find_symbol_by_id::<Field>("Test::S::a").unwrap();
         assert!(field.data_type.is_optional);
     }
 
@@ -125,7 +125,7 @@ mod optional {
         let ast = parse_for_ast(slice);
 
         // Assert
-        let field = ast.find_element::<Field>("Test::S::a").unwrap();
+        let field = ast.find_symbol_by_id::<Field>("Test::S::a").unwrap();
         assert!(field.data_type.is_optional);
 
         let Types::ResultType(result_type) = field.data_type().concrete_type() else { panic!() };
@@ -147,7 +147,7 @@ mod optional {
         let ast = parse_for_ast(slice);
 
         // Assert
-        let field = ast.find_element::<Field>("Test::S::a").unwrap();
+        let field = ast.find_symbol_by_id::<Field>("Test::S::a").unwrap();
         assert!(!field.data_type.is_optional);
 
         let Types::ResultType(result_type) = field.data_type().concrete_type() else { panic!() };
@@ -169,7 +169,7 @@ mod optional {
         let ast = parse_for_ast(slice);
 
         // Assert
-        let field = ast.find_element::<Field>("Test::S::a").unwrap();
+        let field = ast.find_symbol_by_id::<Field>("Test::S::a").unwrap();
         assert!(!field.data_type.is_optional);
 
         let Types::ResultType(result_type) = field.data_type().concrete_type() else { panic!() };
@@ -191,7 +191,7 @@ mod optional {
         let ast = parse_for_ast(slice);
 
         // Assert
-        let field = ast.find_element::<Field>("Test::S::a").unwrap();
+        let field = ast.find_symbol_by_id::<Field>("Test::S::a").unwrap();
         assert!(field.data_type.is_optional);
 
         let Types::Sequence(sequence) = field.data_type().concrete_type() else { panic!() };
@@ -212,7 +212,7 @@ mod optional {
         let ast = parse_for_ast(slice);
 
         // Assert
-        let field = ast.find_element::<Field>("Test::S::a").unwrap();
+        let field = ast.find_symbol_by_id::<Field>("Test::S::a").unwrap();
         assert!(!field.data_type.is_optional);
 
         let Types::Sequence(sequence) = field.data_type().concrete_type() else { panic!() };
@@ -233,7 +233,7 @@ mod optional {
         let ast = parse_for_ast(slice);
 
         // Assert
-        let field = ast.find_element::<Field>("Test::S::a").unwrap();
+        let field = ast.find_symbol_by_id::<Field>("Test::S::a").unwrap();
         assert!(field.data_type.is_optional);
 
         let Types::Dictionary(dictionary) = field.data_type().concrete_type() else { panic!() };
@@ -256,7 +256,7 @@ mod optional {
         let ast = parse(slice, None).ast; // use `parse` to ignore errors.
 
         // Assert
-        let field = ast.find_element::<Field>("Test::S::a").unwrap();
+        let field = ast.find_symbol_by_id::<Field>("Test::S::a").unwrap();
         assert!(!field.data_type.is_optional);
 
         let Types::Dictionary(dictionary) = field.data_type().concrete_type() else { panic!() };
@@ -278,7 +278,7 @@ mod optional {
         let ast = parse_for_ast(slice);
 
         // Assert
-        let field = ast.find_element::<Field>("Test::S::a").unwrap();
+        let field = ast.find_symbol_by_id::<Field>("Test::S::a").unwrap();
         assert!(!field.data_type.is_optional);
 
         let Types::Dictionary(dictionary) = field.data_type().concrete_type() else { panic!() };
@@ -300,22 +300,22 @@ mod optional {
         let ast = parse_for_ast(slice);
 
         // Assert
-        let parameter_a = ast.find_element::<Parameter>("Test::I::op::a").unwrap();
+        let parameter_a = ast.find_symbol_by_id::<Parameter>("Test::I::op::a").unwrap();
         assert!(parameter_a.data_type().is_optional);
 
-        let parameter_b = ast.find_element::<Parameter>("Test::I::op::b").unwrap();
+        let parameter_b = ast.find_symbol_by_id::<Parameter>("Test::I::op::b").unwrap();
         assert!(!parameter_b.data_type().is_optional);
 
-        let parameter_c = ast.find_element::<Parameter>("Test::I::op::c").unwrap();
+        let parameter_c = ast.find_symbol_by_id::<Parameter>("Test::I::op::c").unwrap();
         assert!(parameter_c.data_type().is_optional);
 
-        let return_x = ast.find_element::<Parameter>("Test::I::op::x").unwrap();
+        let return_x = ast.find_symbol_by_id::<Parameter>("Test::I::op::x").unwrap();
         assert!(!return_x.data_type().is_optional);
 
-        let return_y = ast.find_element::<Parameter>("Test::I::op::y").unwrap();
+        let return_y = ast.find_symbol_by_id::<Parameter>("Test::I::op::y").unwrap();
         assert!(return_y.data_type().is_optional);
 
-        let return_z = ast.find_element::<Parameter>("Test::I::op::z").unwrap();
+        let return_z = ast.find_symbol_by_id::<Parameter>("Test::I::op::z").unwrap();
         assert!(!return_z.data_type().is_optional);
     }
 
@@ -333,7 +333,7 @@ mod optional {
         let ast = parse_for_ast(slice);
 
         // Assert
-        let return_value = ast.find_element::<Parameter>("Test::I::op::returnValue").unwrap();
+        let return_value = ast.find_symbol_by_id::<Parameter>("Test::I::op::returnValue").unwrap();
         assert!(return_value.data_type().is_optional);
     }
 
@@ -353,13 +353,13 @@ mod optional {
         let ast = parse_for_ast(slice);
 
         // Assert
-        let member_a = ast.find_element::<Field>("Test::S::a").unwrap();
+        let member_a = ast.find_symbol_by_id::<Field>("Test::S::a").unwrap();
         assert!(member_a.data_type().is_optional);
 
-        let member_b = ast.find_element::<Field>("Test::S::b").unwrap();
+        let member_b = ast.find_symbol_by_id::<Field>("Test::S::b").unwrap();
         assert!(!member_b.data_type().is_optional);
 
-        let member_c = ast.find_element::<Field>("Test::S::c").unwrap();
+        let member_c = ast.find_symbol_by_id::<Field>("Test::S::c").unwrap();
         assert!(member_c.data_type().is_optional);
     }
 }

--- a/slicec/tests/parser_tests.rs
+++ b/slicec/tests/parser_tests.rs
@@ -71,7 +71,7 @@ fn string_literals_support_character_escaping() {
     let ast = parse_for_ast(slice);
 
     // Assert
-    let struct_def = ast.find_element::<Struct>("Test::Foo").unwrap();
+    let struct_def = ast.find_symbol_by_id::<Struct>("Test::Foo").unwrap();
     let deprecated = struct_def.find_attribute::<attributes::Deprecated>().unwrap();
     assert_eq!(deprecated.reason, Some("This is a backslash\"\\\"n.".to_owned()))
 }
@@ -91,7 +91,7 @@ fn integer_literals_can_contain_underscores() {
     let ast = parse_for_ast(slice);
 
     // Assert
-    let enumerator = ast.find_element::<Enumerator>("Test::Foo::A").unwrap();
+    let enumerator = ast.find_symbol_by_id::<Enumerator>("Test::Foo::A").unwrap();
     assert_eq!(enumerator.value(), 17_000_000);
 }
 

--- a/slicec/tests/preprocessor_tests.rs
+++ b/slicec/tests/preprocessor_tests.rs
@@ -30,7 +30,8 @@ fn command_line_defined_symbols() {
     let compilation_state = parse(slice, Some(&options));
 
     // Assert
-    assert!(compilation_state.ast.find_element::<Operation>("Test::I::op").is_ok());
+    let operation = compilation_state.ast.find_symbol_by_id::<Operation>("Test::I::op");
+    assert!(operation.is_ok());
 }
 
 #[test]
@@ -47,7 +48,7 @@ fn undefined_preprocessor_directive_blocks_are_consumed() {
     let ast = parse_for_ast(slice);
 
     // Assert
-    assert!(ast.find_element::<Interface>("Test::I").is_err());
+    assert!(ast.find_symbol_by_id::<Interface>("Test::I").is_err());
 }
 
 #[test]
@@ -91,7 +92,7 @@ fn preprocessor_define_symbol() {
     let ast = parse_for_ast(slice);
 
     // Assert
-    assert!(ast.find_element::<Interface>("Test::I").is_ok());
+    assert!(ast.find_symbol_by_id::<Interface>("Test::I").is_ok());
 }
 
 #[test]
@@ -111,7 +112,7 @@ fn preprocessor_undefine_symbol() {
     let ast = parse_for_ast(slice);
 
     // Assert
-    assert!(ast.find_element::<Interface>("Test::I").is_err());
+    assert!(ast.find_symbol_by_id::<Interface>("Test::I").is_err());
 }
 
 #[test]
@@ -132,7 +133,7 @@ fn preprocessor_define_symbol_multiples_times() {
     let ast = parse_for_ast(slice);
 
     // Assert
-    assert!(ast.find_element::<Interface>("Test::I").is_ok());
+    assert!(ast.find_symbol_by_id::<Interface>("Test::I").is_ok());
 }
 #[test_case("Foo", "I" ; "Foo is defined")]
 #[test_case("Bar", "J" ; "Bar is defined")]
@@ -176,7 +177,7 @@ fn preprocessor_conditional_compilation(define: &str, interface: &str) {
 
     // Assert
     assert!(ast
-        .find_element::<Interface>(format!("Test::{interface}").as_str())
+        .find_symbol_by_id::<Interface>(format!("Test::{interface}").as_str())
         .is_ok());
 }
 
@@ -195,7 +196,7 @@ fn preprocessor_not_expressions() {
     let ast = parse_for_ast(slice);
 
     // Assert
-    assert!(ast.find_element::<Interface>("Test::I").is_err());
+    assert!(ast.find_symbol_by_id::<Interface>("Test::I").is_err());
 }
 
 #[test]
@@ -214,7 +215,7 @@ fn preprocessor_and_expressions() {
     let ast = parse_for_ast(slice);
 
     // Assert
-    assert!(ast.find_element::<Interface>("Test::I").is_ok());
+    assert!(ast.find_symbol_by_id::<Interface>("Test::I").is_ok());
 }
 
 #[test]
@@ -232,7 +233,7 @@ fn preprocessor_or_expressions() {
     let ast = parse_for_ast(slice);
 
     // Assert
-    assert!(ast.find_element::<Interface>("Test::I").is_ok());
+    assert!(ast.find_symbol_by_id::<Interface>("Test::I").is_ok());
 }
 
 #[test]
@@ -250,7 +251,7 @@ fn preprocessor_grouped_expressions() {
     let ast = parse_for_ast(slice);
 
     // Assert
-    assert!(ast.find_element::<Interface>("Test::I").is_err());
+    assert!(ast.find_symbol_by_id::<Interface>("Test::I").is_err());
 }
 
 #[test]
@@ -269,7 +270,7 @@ fn preprocessor_nested_expressions() {
     let ast = parse_for_ast(slice);
 
     // Assert
-    assert!(ast.find_element::<Interface>("Test::I").is_err());
+    assert!(ast.find_symbol_by_id::<Interface>("Test::I").is_err());
 }
 
 #[test_case(
@@ -321,9 +322,9 @@ fn preprocessor_nested_conditional_blocks() {
     let ast = parse_for_ast(slice);
 
     // Assert
-    assert!(ast.find_element::<Struct>("Test::NotFooStruct").is_ok());
-    assert!(ast.find_element::<Struct>("Test::NotBarStruct").is_ok());
-    assert!(ast.find_element::<Struct>("Test::ElseStruct").is_err());
+    assert!(ast.find_symbol_by_id::<Struct>("Test::NotFooStruct").is_ok());
+    assert!(ast.find_symbol_by_id::<Struct>("Test::NotBarStruct").is_ok());
+    assert!(ast.find_symbol_by_id::<Struct>("Test::ElseStruct").is_err());
 }
 
 #[test]
@@ -343,7 +344,7 @@ fn preprocessor_ignores_comments() {
     let ast = parse_for_ast(slice);
 
     // Assert
-    assert!(ast.find_element::<Interface>("Test::I").is_err());
+    assert!(ast.find_symbol_by_id::<Interface>("Test::I").is_err());
 }
 
 #[test]

--- a/slicec/tests/primitives/mod.rs
+++ b/slicec/tests/primitives/mod.rs
@@ -33,7 +33,7 @@ fn type_parses(slice_component: &str, expected: Primitive) {
     let ast = parse_for_ast(slice);
 
     // Assert
-    let underlying = &ast.find_element::<TypeAlias>("Test::P").unwrap().underlying;
+    let underlying = &ast.find_symbol_by_id::<TypeAlias>("Test::P").unwrap().underlying;
     if let TypeRefDefinition::Patched(ptr) = &underlying.definition {
         let primitive = ptr.clone().downcast::<Primitive>().unwrap();
         assert_eq!(

--- a/slicec/tests/result_tests.rs
+++ b/slicec/tests/result_tests.rs
@@ -24,7 +24,7 @@ mod results {
         let ast = parse_for_ast(slice);
 
         // Assert
-        let operation = ast.find_element::<Operation>("Test::I::op").unwrap();
+        let operation = ast.find_symbol_by_id::<Operation>("Test::I::op").unwrap();
         let returns = operation.return_members();
 
         assert_eq!(returns.len(), 1);
@@ -63,7 +63,7 @@ mod results {
         let ast = parse_for_ast(slice);
 
         // Assert
-        let operation = ast.find_element::<Operation>("Test::I::op").unwrap();
+        let operation = ast.find_symbol_by_id::<Operation>("Test::I::op").unwrap();
         let returns = operation.return_members();
         assert_eq!(returns.len(), 1);
         let Types::ResultType(result_type) = returns[0].data_type().concrete_type() else { panic!() };

--- a/slicec/tests/scope_resolution_tests.rs
+++ b/slicec/tests/scope_resolution_tests.rs
@@ -34,10 +34,10 @@ mod scope_resolution {
         let ast = parse_multiple_for_ast(&[slice1, slice2]);
 
         // Assert
-        let s1_type = ast.find_element::<Field>("A::C::s1").unwrap().data_type();
-        let s2_type = ast.find_element::<Field>("A::C::s2").unwrap().data_type();
-        let s3_type = ast.find_element::<Field>("A::C::s3").unwrap().data_type();
-        let s4_type = ast.find_element::<Field>("A::C::s4").unwrap().data_type();
+        let s1_type = ast.find_symbol_by_id::<Field>("A::C::s1").unwrap().data_type();
+        let s2_type = ast.find_symbol_by_id::<Field>("A::C::s2").unwrap().data_type();
+        let s3_type = ast.find_symbol_by_id::<Field>("A::C::s3").unwrap().data_type();
+        let s4_type = ast.find_symbol_by_id::<Field>("A::C::s4").unwrap().data_type();
 
         assert!(matches!(s1_type.concrete_type(), Types::Primitive(Primitive::Int32)));
         assert!(matches!(s2_type.concrete_type(), Types::Primitive(Primitive::Int32)));
@@ -70,10 +70,10 @@ mod scope_resolution {
         let ast = parse_multiple_for_ast(&[slice1, slice2]);
 
         // Assert
-        let s1_type = ast.find_element::<Field>("A::B::C::s1").unwrap().data_type();
-        let s2_type = ast.find_element::<Field>("A::B::C::s2").unwrap().data_type();
-        let s3_type = ast.find_element::<Field>("A::B::C::s3").unwrap().data_type();
-        let s4_type = ast.find_element::<Field>("A::B::C::s4").unwrap().data_type();
+        let s1_type = ast.find_symbol_by_id::<Field>("A::B::C::s1").unwrap().data_type();
+        let s2_type = ast.find_symbol_by_id::<Field>("A::B::C::s2").unwrap().data_type();
+        let s3_type = ast.find_symbol_by_id::<Field>("A::B::C::s3").unwrap().data_type();
+        let s4_type = ast.find_symbol_by_id::<Field>("A::B::C::s4").unwrap().data_type();
 
         assert!(matches!(s1_type.concrete_type(), Types::Primitive(Primitive::String)));
         assert!(matches!(s2_type.concrete_type(), Types::Primitive(Primitive::String)));
@@ -107,9 +107,9 @@ mod scope_resolution {
         let ast = parse_multiple_for_ast(&[slice1, slice2, slice3]);
 
         // Assert
-        let s1_type = ast.find_element::<Field>("A::B::B::C::s1").unwrap().data_type();
-        let s2_type = ast.find_element::<Field>("A::B::B::C::s2").unwrap().data_type();
-        let s3_type = ast.find_element::<Field>("A::B::B::C::s3").unwrap().data_type();
+        let s1_type = ast.find_symbol_by_id::<Field>("A::B::B::C::s1").unwrap().data_type();
+        let s2_type = ast.find_symbol_by_id::<Field>("A::B::B::C::s2").unwrap().data_type();
+        let s3_type = ast.find_symbol_by_id::<Field>("A::B::B::C::s3").unwrap().data_type();
 
         assert!(matches!(s1_type.concrete_type(), Types::Struct(_)));
         assert!(matches!(s2_type.concrete_type(), Types::Struct(_)));
@@ -143,10 +143,10 @@ mod scope_resolution {
         let ast = parse_multiple_for_ast(&[slice1, slice2, slice3]);
 
         // Assert
-        let nested_s1_type = ast.find_element::<Field>("A::B::A::B::C::s1").unwrap().data_type();
-        let nested_s2_type = ast.find_element::<Field>("A::B::A::B::C::s2").unwrap().data_type();
-        let s1_type = ast.find_element::<Field>("A::C::s1").unwrap().data_type();
-        let s2_type = ast.find_element::<Field>("A::C::s2").unwrap().data_type();
+        let nested_s1_type = ast.find_symbol_by_id::<Field>("A::B::A::B::C::s1").unwrap().data_type();
+        let nested_s2_type = ast.find_symbol_by_id::<Field>("A::B::A::B::C::s2").unwrap().data_type();
+        let s1_type = ast.find_symbol_by_id::<Field>("A::C::s1").unwrap().data_type();
+        let s2_type = ast.find_symbol_by_id::<Field>("A::C::s2").unwrap().data_type();
 
         assert!(matches!(
             nested_s1_type.concrete_type(),

--- a/slicec/tests/sequence_tests.rs
+++ b/slicec/tests/sequence_tests.rs
@@ -20,7 +20,7 @@ mod sequences {
         let ast = parse_for_ast(slice);
 
         // Assert
-        let seq_def = ast.find_element::<TypeAlias>("Test::Seq").unwrap();
+        let seq_def = ast.find_symbol_by_id::<TypeAlias>("Test::Seq").unwrap();
         let seq_type = seq_def.underlying.concrete_type();
 
         match seq_type {

--- a/slicec/tests/structs/container.rs
+++ b/slicec/tests/structs/container.rs
@@ -24,7 +24,7 @@ mod structs {
         let ast = parse_for_ast(slice);
 
         // Assert
-        let fields = ast.find_element::<Struct>("Test::S").unwrap().fields();
+        let fields = ast.find_symbol_by_id::<Struct>("Test::S").unwrap().fields();
 
         assert_eq!(fields.len(), 3);
         assert_eq!(fields[0].identifier(), "i");
@@ -58,7 +58,7 @@ mod structs {
         let ast = parse_for_ast(slice);
 
         // Assert
-        let fields = ast.find_element::<Struct>("Test::S").unwrap().fields();
+        let fields = ast.find_symbol_by_id::<Struct>("Test::S").unwrap().fields();
         assert_eq!(fields.len(), 0);
     }
 

--- a/slicec/tests/structs/tags.rs
+++ b/slicec/tests/structs/tags.rs
@@ -22,7 +22,7 @@ mod structs {
         let ast = parse_for_ast(slice);
 
         // Assert
-        let field = ast.find_element::<Field>("Test::S::b").unwrap();
+        let field = ast.find_symbol_by_id::<Field>("Test::S::b").unwrap();
         assert_eq!(field.tag(), Some(10));
     }
 }

--- a/slicec/tests/tag_tests.rs
+++ b/slicec/tests/tag_tests.rs
@@ -79,7 +79,7 @@ mod tags {
         let ast = parse_for_ast(slice);
 
         // Assert
-        let field = ast.find_element::<Field>("Test::S::a").unwrap();
+        let field = ast.find_symbol_by_id::<Field>("Test::S::a").unwrap();
 
         assert_eq!(field.tag(), Some(1));
         assert!(field.data_type.is_optional);

--- a/slicec/tests/typealias_tests.rs
+++ b/slicec/tests/typealias_tests.rs
@@ -32,7 +32,7 @@ mod typealias {
         let ast = parse_for_ast(slice);
 
         // Assert
-        let type_alias = ast.find_element::<TypeAlias>("Test::Alias").unwrap();
+        let type_alias = ast.find_symbol_by_id::<TypeAlias>("Test::Alias").unwrap();
         type_alias.underlying.definition(); // Panics if the type-alias hasn't been initialized correctly.
     }
 
@@ -78,7 +78,7 @@ mod typealias {
         let ast = parse_for_ast(slice);
 
         // Assert
-        let type_alias = ast.find_element::<TypeAlias>("Test::MyInt").unwrap();
+        let type_alias = ast.find_symbol_by_id::<TypeAlias>("Test::MyInt").unwrap();
 
         assert_eq!(type_alias.identifier(), "MyInt");
         assert!(matches!(
@@ -102,7 +102,7 @@ mod typealias {
         let ast = parse_for_ast(slice);
 
         // Assert
-        let field = ast.find_element::<Field>("Test::S::a").unwrap();
+        let field = ast.find_symbol_by_id::<Field>("Test::S::a").unwrap();
 
         assert_eq!(field.identifier(), "a");
         assert!(matches!(


### PR DESCRIPTION
Currently, we have 4 functions on `Ast` for looking stuff up, 2 that return raw AST-nodes, and 2 that return references to Slice elements. This PR addresses the latter 2. This is a stepping stone towards fixing #806 and #808.

These 2 functions were named `find_element` and `find_element_with_scope`; the first took a fully-scoped ID, the 2nd works could take relative IDs. I deleted `find_element_with_scope`, since it was only called by `vscode-slice`, and there, we can fix the callers to manually append the scope and use `find_element` instead. And for `find_element`, I restricted the types it could be used to lookup.

Right now, you can lookup both primitive and user-defined types. After this PR, you can only use this function to lookup user-defined types. To signal this, I changed it's name from `find_element` to `find_symbol_by_id`.

`Element` is the base-most thing in `slicec`, everything is an `Element`, `struct`, `Sequence`, `Identifier`, `Primitive`.
`Symbol` is the compiler jargon term for something a user-wrote in a Slice file, so this term does not include the primitives.

## What's Changed

- The `find_element` and `find_element_by_id` functions were simplified and merged into a single `find_symbol_by_id` function. This can no longer be used to lookup primitive types.